### PR TITLE
Add a roundtrip fuzzer for zune-inflate

### DIFF
--- a/zune-inflate/fuzz/Cargo.toml
+++ b/zune-inflate/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
+miniz_oxide = "0.6.2"
 
 [dependencies.zune-inflate]
 path = ".."
@@ -21,5 +22,11 @@ members = ["."]
 [[bin]]
 name = "decode_buffer"
 path = "fuzz_targets/decode_buffer.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "roundtrip"
+path = "fuzz_targets/roundtrip.rs"
 test = false
 doc = false

--- a/zune-inflate/fuzz/fuzz_targets/roundtrip.rs
+++ b/zune-inflate/fuzz/fuzz_targets/roundtrip.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 0 {
+        let compression_level = data[0];
+        let data = &data[1..];
+        let compressed = miniz_oxide::deflate::compress_to_vec(data, compression_level);
+        let mut decoder = zune_inflate::DeflateDecoder::new(&compressed);
+        let decoded = decoder.decode_deflate().expect("Failed to decompress valid compressed data!");
+        assert!(data == decoded, "The decompressed data doesn't match the original data!");
+    }
+});


### PR DESCRIPTION
Add a fuzzer for checking that any data compressed with miniz_oxide is decoded correctly (roundtrips losslessly)

miniz_oxide is chosen because it's a mature pure-Rust compressor, and this lets the fuzzer explore its various compression codepaths, while a C library would be a black box and nowhere nearly as effective.

Run with `cargo +nightly fuzz run roundtrip`. Right now it finds panics in a few seconds.