### PR TITLE
Add a fuzz target for the zlib format using zlib-ng implementation

### DIFF
--- a/zune-inflate/fuzz/Cargo.toml
+++ b/zune-inflate/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 miniz_oxide = "0.6.2"
+flate2 = { version = "1.0.17", features = ["zlib-ng"], default-features = false }
 
 [dependencies.zune-inflate]
 path = ".."
@@ -28,5 +29,11 @@ doc = false
 [[bin]]
 name = "roundtrip"
 path = "fuzz_targets/roundtrip.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "roundtrip_zlib"
+path = "fuzz_targets/roundtrip_zlib.rs"
 test = false
 doc = false

--- a/zune-inflate/fuzz/fuzz_targets/roundtrip_zlib.rs
+++ b/zune-inflate/fuzz/fuzz_targets/roundtrip_zlib.rs
@@ -1,0 +1,29 @@
+#![no_main]
+
+// This target uses zlib-ng to provide some variety in encoders.
+
+// It is a good idea to run the `roundtrip` target first,
+// which will use pure-Rust `miniz_oxide` which will
+// be visible to the fuzzer, while zlib-ng is a black box
+// because it is written in C.
+
+// Copy the contents of `corpus/roundtrip` to `corpus/roundtrip_zlib`
+// to kickstart the fuzzing with a decent corpus,
+// which would be difficult to build with zlib-ng alone.
+
+use std::io::Write;
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if data.len() > 0 {
+        let compression_level = flate2::Compression::new(data[0].into());
+        let data = &data[1..];
+        let mut e = flate2::write::ZlibEncoder::new(Vec::new(), compression_level);
+        e.write_all(data).unwrap();
+        let compressed = e.finish().unwrap();
+        let mut decoder = zune_inflate::DeflateDecoder::new(&compressed);
+        let decoded = decoder.decode_zlib().expect("Failed to decompress valid compressed data!");
+        assert!(data == decoded, "The decompressed data doesn't match the original data!");
+    }
+});


### PR DESCRIPTION
Like #13, but for zlib format and using zlib-ng library. See the code comment for usage tips.

Finds bugs in a few seconds if seeded with the corpus from the `roundtrip` target.