### PR TITLE
Add a DEFLATE fuzzing target, without zlib

### DIFF
--- a/zune-inflate/fuzz/fuzz_targets/decode_zlib.rs
+++ b/zune-inflate/fuzz/fuzz_targets/decode_zlib.rs
@@ -4,5 +4,5 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     let mut decoder = zune_inflate::DeflateDecoder::new(data);
-    let _result = decoder.decode_deflate();
+    let _result = decoder.decode_zlib();
 });


### PR DESCRIPTION
Zlib format has checksums and I'm not sure how they interact with decoding in zune-inflate. I've seen other libraries get very poor coverage because most fuzzer inputs were rejected due to invalid checksums.