### PR TITLE
Escape `Vec<u8>` in docs so that <u8> is not treated as an HTML tag

### DIFF
--- a/zune-inflate/src/decoder.rs
+++ b/zune-inflate/src/decoder.rs
@@ -151,7 +151,7 @@ impl<'a> DeflateDecoder<'a>
             options
         }
     }
-    /// Decode zlib-encoded data returning the uncompressed in a Vec<u8>
+    /// Decode zlib-encoded data returning the uncompressed in a `Vec<u8>`
     /// or an error of what went wrong.
     pub fn decode_zlib(&mut self) -> Result<Vec<u8>, DecodeErrors>
     {
@@ -233,7 +233,7 @@ impl<'a> DeflateDecoder<'a>
 
         Ok(data)
     }
-    /// Decode a deflate stream returning the data as Vec<u8> or an error
+    /// Decode a deflate stream returning the data as `Vec<u8>` or an error
     /// indicating what went wrong.
     pub fn decode_deflate(&mut self) -> Result<Vec<u8>, DecodeErrors>
     {


### PR DESCRIPTION
Fixes rustdoc warning, fixes display of this in documentation