### PR TITLE
Less bounds checks in RLE fill with a single byte

### DIFF
--- a/zune-inflate/src/decoder.rs
+++ b/zune-inflate/src/decoder.rs
@@ -18,7 +18,7 @@ use crate::gzip_constants::{
     GZIP_CM_DEFLATE, GZIP_FCOMMENT, GZIP_FEXTRA, GZIP_FHCRC, GZIP_FNAME, GZIP_FOOTER_SIZE,
     GZIP_FRESERVED, GZIP_ID1, GZIP_ID2
 };
-use crate::utils::{copy_rep_matches, fixed_copy, fixed_copy_within, make_decode_table_entry};
+use crate::utils::{copy_rep_matches, fixed_copy_within, make_decode_table_entry};
 
 struct DeflateHeaderTables
 {

--- a/zune-inflate/src/decoder.rs
+++ b/zune-inflate/src/decoder.rs
@@ -958,8 +958,8 @@ impl<'a> DeflateDecoder<'a>
                         {
                             // RLE match, repeat the byte in batches of 8
                             const COPY_SIZE: usize = 8;
-                            let rep_num = u64::from(out_block[src_offset]) * 0x0101010101010101;
-                            let rep_byte = &rep_num.to_ne_bytes();
+                            let byte_to_repeat = out_block[src_offset];
+                            let slice_to_repeat = [byte_to_repeat; COPY_SIZE];
                             // compute much should be filled with this value
                             let fill_length = usize::saturating_sub(dest_offset, current_position);
                             // round the fill length up to increments of COPY_SIZE
@@ -968,7 +968,7 @@ impl<'a> DeflateDecoder<'a>
                             let fill_area = &mut out_block[current_position..][..sloppy_fill_length];
                             // perform the actual fill
                             fill_area.chunks_exact_mut(COPY_SIZE).for_each(|chunk| {
-                                chunk.copy_from_slice(rep_byte);
+                                chunk.copy_from_slice(&slice_to_repeat);
                             });
                         }
                         else if offset <= FASTCOPY_BYTES

--- a/zune-inflate/src/decoder.rs
+++ b/zune-inflate/src/decoder.rs
@@ -970,8 +970,6 @@ impl<'a> DeflateDecoder<'a>
                             fill_area.chunks_exact_mut(COPY_SIZE).for_each(|chunk| {
                                 chunk.copy_from_slice(rep_byte);
                             });
-                            // bump the current position now that the area is filled
-                            current_position += sloppy_fill_length;
                         }
                         else if offset <= FASTCOPY_BYTES
                             && current_position + offset < dest_offset

--- a/zune-inflate/src/utils.rs
+++ b/zune-inflate/src/utils.rs
@@ -11,28 +11,6 @@ pub(crate) fn make_decode_table_entry(decode_results: &[u32], sym: usize, len: u
     decode_results[sym] + (len << 8) + len
 }
 
-/// Copy SIZE amount of bytes from src, starting from `src_offset` into dest starting from
-/// `dest_offset`.
-pub fn fixed_copy<const SIZE: usize>(
-    src: &[u8], dest: &mut [u8], src_offset: usize, dest_offset: usize
-)
-{
-    // for debug builds, ensure we don't go out of bounds
-    debug_assert!(
-        src_offset + SIZE - 1 <= src.len(),
-        "[src]: End position {} out of range for slice of length {}",
-        src_offset + SIZE,
-        src.len()
-    );
-    debug_assert!(
-        dest_offset + SIZE <= dest.len(),
-        "[dst]: End position {} out of range for slice of length {}",
-        dest_offset + SIZE,
-        dest.len()
-    );
-    dest[dest_offset..dest_offset + SIZE].copy_from_slice(&src[src_offset..src_offset + SIZE]);
-}
-
 /// A safe version of src.copy_within that helps me because I tend to always
 /// confuse the arguments
 pub fn fixed_copy_within<const SIZE: usize>(dest: &mut [u8], src_offset: usize, dest_offset: usize)


### PR DESCRIPTION
Do a bit more math up front in exchange for not having to perform two bounds checks per loop iteration on long RLE copies, and do nothing but copies in the loop.

I imagine PNGs filled with a single color should benefit, as well as screenshots or anything with large flat fill. Other cases shouldn't regress much, but I haven't actually checked, my machine is too noisy for benchmarks.