### PR TITLE
Improve CI fuzzing

### DIFF
--- a/.github/workflows/fuzz_deflate.yml
+++ b/.github/workflows/fuzz_deflate.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Install
       run: cargo install cargo-fuzz
     - name: Fuzz deflate
-      run: cargo +nightly fuzz run --fuzz-dir zune-inflate/fuzz roundtrip -- -runs=200000
+      run: cargo +nightly fuzz run --fuzz-dir zune-inflate/fuzz roundtrip -j2 -- -timeout=10s -max_total_time=60
     - name: Fuzz zlib
-      run: cargo +nightly fuzz run --fuzz-dir zune-inflate/fuzz roundtrip_zlib -- -runs=200000
+      run: cargo +nightly fuzz run --fuzz-dir zune-inflate/fuzz roundtrip_zlib -j2 -- -timeout=10s -max_total_time=30
     - name: Normal Fuzz testing.
-      run: cargo +nightly fuzz run --fuzz-dir zune-inflate/fuzz decode_buffer  -- -runs=200000
+      run: cargo +nightly fuzz run --fuzz-dir zune-inflate/fuzz decode_buffer -j2 -- -timeout=10s -max_total_time=30

--- a/.github/workflows/fuzz_png.yml
+++ b/.github/workflows/fuzz_png.yml
@@ -32,4 +32,4 @@ jobs:
         run: cargo install cargo-fuzz
 
       - name: Normal Fuzz testing.
-        run: cargo +nightly fuzz  run  --fuzz-dir zune-png/fuzz decode_buffer  fuzz-corpus/png -- -runs=10000
+        run: cargo +nightly fuzz  run  --fuzz-dir zune-png/fuzz decode_buffer  fuzz-corpus/png -j2 -- -timeout=10s -max_total_time=120

--- a/.github/workflows/fuzz_ppm.yml
+++ b/.github/workflows/fuzz_ppm.yml
@@ -32,4 +32,4 @@ jobs:
         run: cargo install cargo-fuzz
 
       - name: Normal Fuzz testing.
-        run: cargo +nightly fuzz run --fuzz-dir zune-ppm/fuzz decode_buffer  -- -runs=100000
+        run: cargo +nightly fuzz run --fuzz-dir zune-ppm/fuzz decode_buffer -j2 -- -timeout=10s -max_total_time=60

--- a/.github/workflows/fuzz_qoi.yml
+++ b/.github/workflows/fuzz_qoi.yml
@@ -32,4 +32,4 @@ jobs:
         run: cargo install cargo-fuzz
 
       - name: QOI Fuzz testing.
-        run: cargo +nightly fuzz run --fuzz-dir zune-qoi/fuzz decode_buffer zune-qoi/test_images -- -runs=10000
+        run: cargo +nightly fuzz run --fuzz-dir zune-qoi/fuzz decode_buffer zune-qoi/test_images -j2 -- -timeout=10s -max_total_time=60

--- a/.github/workflows/test_jpg.yml
+++ b/.github/workflows/test_jpg.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Test jpeg
         run: cargo test --verbose --package=zune-jpeg
       - name: Fuzz jpeg
-        run: cargo +nightly fuzz run --fuzz-dir zune-jpeg/fuzz decode_buffer -- -runs=10000 zune-jpeg/test-images/fuzz_references
+        run: cargo +nightly fuzz run --fuzz-dir zune-jpeg/fuzz decode_buffer -j2 -- -timeout=10s -max_total_time=120 zune-jpeg/test-images/fuzz_references
 


### PR DESCRIPTION
 - Take advantage of both CPU cores available on Github Actions runners
 - Run for a fixed amount of time rather than fixed amount of iterations to guarantee no CI cost blow-up
 - Set timeouts so that a hang will not balloon CI costs