### PR TITLE
impl Error for DecodeErrors

### DIFF
--- a/zune-jpeg/src/errors.rs
+++ b/zune-jpeg/src/errors.rs
@@ -41,6 +41,9 @@ pub enum DecodeErrors
     /// Large image dimensions(Corrupted data)?
     LargeDimensions(usize)
 }
+
+impl std::error::Error for DecodeErrors {}
+
 impl From<&'static str> for DecodeErrors
 {
     fn from(data: &'static str) -> Self

--- a/zune-jpeg/src/errors.rs
+++ b/zune-jpeg/src/errors.rs
@@ -42,6 +42,7 @@ pub enum DecodeErrors
     LargeDimensions(usize)
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for DecodeErrors {}
 
 impl From<&'static str> for DecodeErrors


### PR DESCRIPTION
Makes integration with `image` easier, among other things