### PR TITLE
Fix possible off by one error in ac refinement

### DIFF
--- a/zune-jpeg/src/bitstream.rs
+++ b/zune-jpeg/src/bitstream.rs
@@ -570,41 +570,44 @@ impl BitStream
                 // correction bits to the non-zeroes.
                 // A correction bit is 1 if the absolute value of the coefficient must be increased
 
-                'advance_nonzero: while k <= self.spec_end
+                if k <= self.spec_end
                 {
-                    let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
-
-                    if *coefficient != 0
+                    'advance_nonzero: loop
                     {
-                        if self.get_bit() == 1 && (*coefficient & bit) == 0
-                        {
-                            if *coefficient >= 0
-                            {
-                                *coefficient += bit;
-                            }
-                            else
-                            {
-                                *coefficient -= bit;
-                            }
-                        }
+                        let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
 
-                        if self.bits_left < 1
+                        if *coefficient != 0
                         {
-                            self.refill(reader)?;
-                        }
-                    }
-                    else
-                    {
-                        r -= 1;
+                            if self.get_bit() == 1 && (*coefficient & bit) == 0
+                            {
+                                if *coefficient >= 0
+                                {
+                                    *coefficient += bit;
+                                } else {
+                                    *coefficient -= bit;
+                                }
+                            }
 
-                        if r < 0
-                        {
-                            // reached target zero coefficient.
+                            if self.bits_left < 1
+                            {
+                                self.refill(reader)?;
+                            }
+                        } else {
+                            r -= 1;
+
+                            if r < 0
+                            {
+                                // reached target zero coefficient.
+                                break 'advance_nonzero;
+                            }
+                        };
+
+                        if k == self.spec_end {
                             break 'advance_nonzero;
                         }
-                    };
 
-                    k += 1;
+                        k += 1;
+                    }
                 }
 
                 if symbol != 0


### PR DESCRIPTION
This is a possible fix for the Lion Image in #12 .

In cases  where the while loop `'advance_nonzero` is taken, the variable k (Coefficient index) might be +1 off after the loop, which results in the modification of the wrong coefficient after the loop.
In most cases this only results in minor differences in the decoded image, but in case of k=64 it wraps around to 0 and changes the DC value. This should be the root cause for the strange blocks in the Lion Image.





