### PR TITLE
Remove bounds checks from bit expansion

### DIFF
--- a/zune-png/src/decoder.rs
+++ b/zune-png/src/decoder.rs
@@ -980,7 +980,6 @@ impl<'a> PngDecoder<'a>
                         expand_bits_to_byte(
                             width,
                             usize::from(info.depth),
-                            0,
                             n_components,
                             self.seen_ptle,
                             to_filter_row,
@@ -999,7 +998,6 @@ impl<'a> PngDecoder<'a>
                         expand_bits_to_byte(
                             width,
                             usize::from(info.depth),
-                            0,
                             n_components,
                             self.seen_ptle,
                             &self.previous_stride,
@@ -1089,7 +1087,6 @@ impl<'a> PngDecoder<'a>
                         expand_bits_to_byte(
                             width,
                             usize::from(info.depth),
-                            0,
                             n_components,
                             self.seen_ptle,
                             to_filter_row,
@@ -1108,7 +1105,6 @@ impl<'a> PngDecoder<'a>
                         expand_bits_to_byte(
                             width,
                             usize::from(info.depth),
-                            0,
                             n_components,
                             self.seen_ptle,
                             &self.previous_stride,

--- a/zune-png/src/utils.rs
+++ b/zune-png/src/utils.rs
@@ -158,7 +158,7 @@ pub fn expand_trns<const SIXTEEN_BITS: bool>(
 
 /// Expand bits to bytes expand images with less than 8 bpp
 pub(crate) fn expand_bits_to_byte(
-    width: usize, depth: usize, in_offset: usize, out_n: usize, plte_present: bool,
+    width: usize, depth: usize, out_n: usize, plte_present: bool,
     input: &[u8], out: &mut [u8]
 )
 {
@@ -166,7 +166,6 @@ pub(crate) fn expand_bits_to_byte(
 
     let mut scale = DEPTH_SCALE_TABLE[depth];
 
-    let input = &input[in_offset..];
     let out = &mut out[..width * out_n];
 
     // for pLTE chunks with lower bit depths

--- a/zune-png/src/utils.rs
+++ b/zune-png/src/utils.rs
@@ -158,15 +158,15 @@ pub fn expand_trns<const SIXTEEN_BITS: bool>(
 
 /// Expand bits to bytes expand images with less than 8 bpp
 pub(crate) fn expand_bits_to_byte(
-    width: usize, depth: usize, mut in_offset: usize, out_n: usize, plte_present: bool,
+    width: usize, depth: usize, in_offset: usize, out_n: usize, plte_present: bool,
     input: &[u8], out: &mut [u8]
 )
 {
     const DEPTH_SCALE_TABLE: [u8; 9] = [0, 0xff, 0x55, 0, 0x11, 0, 0, 0, 0x01];
 
-    let mut current = 0;
-
     let mut scale = DEPTH_SCALE_TABLE[depth];
+
+    let input = &input[in_offset..];
 
     // for pLTE chunks with lower bit depths
     // do not scale values just expand.

--- a/zune-png/src/utils.rs
+++ b/zune-png/src/utils.rs
@@ -167,6 +167,7 @@ pub(crate) fn expand_bits_to_byte(
     let mut scale = DEPTH_SCALE_TABLE[depth];
 
     let input = &input[in_offset..];
+    let out = &mut out[..width * out_n];
 
     // for pLTE chunks with lower bit depths
     // do not scale values just expand.
@@ -175,8 +176,6 @@ pub(crate) fn expand_bits_to_byte(
     {
         scale = 1;
     }
-
-    let mut k = width * out_n;
 
     if depth == 1
     {


### PR DESCRIPTION
Opening this as a draft to get feedback on this before the test run.

I added these to honor the existing APIs:

```rust
    let input = &input[in_offset..];
    let out = &mut out[..width * out_n];
```

~~but I'm not sure if it's best placed here, or if the caller should figure out the appropriate slices instead.~~

but `in_offset` is always 0 and the other slice is always greater than `width * out_n` so this doesn't actually matter and these arguments can be removed.