### PR TITLE
Fix building with no-std

### DIFF
--- a/zune-core/Cargo.toml
+++ b/zune-core/Cargo.toml
@@ -12,9 +12,10 @@ license = "MIT OR Apache-2.0 OR Zlib"
 [features]
 # When present, we can use std facilities to detect
 # if a specific feature exists
+# Not enabled by default. Other zune crates can enable dep:zune-core/std by default.
+# But if we enable it here, they can't disable it anymore.
+# See: https://github.com/rust-lang/cargo/issues/8366
 std = []
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-default = ["std"]
 
 [dependencies]
 bitflags = "2.1.0"


### PR DESCRIPTION
Trying to build in an no-std doesn't work.
Example with zune-jpg and x86_64-unknown-uefi:

```
> cargo build -p zune-jpeg --target x86_64-unknown-uefi --no-default-features
   Compiling zune-core v0.2.13 (/home/zoid/clone/active/zune-image/zune-core)
error[E0463]: can't find crate for `std`
  |
  = note: the `x86_64-unknown-uefi` target may not support the standard library
  = note: `std` is required by `zune_core` because it does not declare `#![no_std]`
[...]
```

This seems to be due to a bug (or expected behavior) in the cargo worktrees: https://github.com/rust-lang/cargo/issues/8366

From zune-jpeg we can't disable the default features of zune-core. But that's no problem, since zune-jpeg already enabled the std feature in zune-core, whenver its std feature is enabled.

With this patch, compilation succeeds:

```
> cargo build -p zune-jpeg --target x86_64-unknown-uefi --no-default-features
   Compiling zune-jpeg v0.3.16 (/home/zoid/clone/active/zune-image/zune-jpeg)
warning: dropping unsupported crate type `cdylib` for target `x86_64-unknown-uefi`

warning: `zune-jpeg` (lib) generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
```