### PR TITLE
Handle MCU height other than 8 when decoding to Luma

### DIFF
--- a/zune-jpeg/src/mcu.rs
+++ b/zune-jpeg/src/mcu.rs
@@ -410,7 +410,7 @@ impl<T: ZReaderTrait> JpegDecoder<T>
             )?;
 
             // increment pointer to number of pixels written
-            *pixels_written += width * out_colorspace_components * 8;
+            *pixels_written += width * out_colorspace_components * self.mcu_height;
         }
 
         Ok(())


### PR DESCRIPTION
I noticed that the issue I openned (https://github.com/etemesi254/zune-image/issues/134) only happen when subsampling makes `mcu_height` larger than 8.

This is a quick fix.
