### PR TITLE
png: Make bytemuck optional

### DIFF
--- a/zune-png/Cargo.toml
+++ b/zune-png/Cargo.toml
@@ -22,7 +22,6 @@ default = ["sse", "std"]
 zune-core = { path = "../zune-core", version = "0.2" }
 log = "0.4.17"
 zune-inflate = { path = "../zune-inflate", version = "0.2", default-features = false, features = ["zlib"] }
-bytemuck = { version = "1.13.1", default-features = false }
 
 [dev-dependencies]
 nanorand = { version = "0.7.0", default-features = false, features = ["wyrand"] } # testing purposes.

--- a/zune-png/src/decoder.rs
+++ b/zune-png/src/decoder.rs
@@ -27,7 +27,7 @@ use crate::filters::de_filter::{
 use crate::options::default_chunk_handler;
 use crate::utils::{
     add_alpha, convert_be_to_target_endian_u16, expand_bits_to_byte, expand_palette, expand_trns,
-    is_le
+    is_le, convert_u16_to_u8_slice
 };
 
 /// A palette entry.
@@ -777,11 +777,8 @@ impl<T: ZReaderTrait> PngDecoder<T> {
         {
             &mut out_u8
         } else {
-            let (a, b, c) = bytemuck::pod_align_to_mut::<u16, u8>(&mut out_u16);
+            let b = convert_u16_to_u8_slice(&mut out_u16);
 
-            // a and c should be empty since we do not expect slop bytes on either edge
-            assert!(a.is_empty());
-            assert!(c.is_empty());
             assert_eq!(b.len(), new_len * 2); // length should be twice that of u8
             b
         };

--- a/zune-png/src/utils.rs
+++ b/zune-png/src/utils.rs
@@ -350,3 +350,14 @@ pub(crate) fn add_alpha(input: &[u8], output: &mut [u8], colorspace: PngColor, d
         (a, b) => panic!("Unknown combination of depth {a:?} and color type for expand alpha {b:?}")
     }
 }
+
+pub fn convert_u16_to_u8_slice(slice: &mut [u16]) -> &mut [u8] {
+    // Converting a u16 slice to a u8 slice is always correct because
+    // the alignment of the target is smaller.
+    unsafe {
+        std::slice::from_raw_parts_mut(
+            slice.as_ptr() as *mut u8,
+            slice.len().checked_mul(2).unwrap(),
+        )
+    }
+}


### PR DESCRIPTION
For `zune-png`, `bytemuck`, the crate, is used just once, to convert u16 slice to u8 slice. 

This PR does not alter the default behavior: this conversion is still going through the crate. 
But without `bytemuck` feature it is just `slice.align_to_mut::<u8>()`. 

I tested the new code on the hdr PNG triggering this codepath and it all seems to still work fine.

New function looks ugly, but, unfortunately, attributes on regions are not yet stable and that was the simplest workaround I've seen.

_I do have a PR for the `log` in queue :D Not like `bytemuck` and `log` are that big, but having them under a feature-flag would be really nice!_