### PR TITLE
Make log optional

### DIFF
--- a/zune-bmp/Cargo.toml
+++ b/zune-bmp/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+log = ["zune-core/log"]
+
 [dependencies]
 zune-core = { version = "0.2", path = "../zune-core" }
-log = "0.4.17"

--- a/zune-bmp/src/decoder.rs
+++ b/zune-bmp/src/decoder.rs
@@ -98,7 +98,7 @@
 use alloc::vec::Vec;
 use alloc::{format, vec};
 
-use log::{trace, warn};
+use zune_core::log::{trace, warn};
 use zune_core::bit_depth::BitDepth;
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;

--- a/zune-core/Cargo.toml
+++ b/zune-core/Cargo.toml
@@ -19,4 +19,5 @@ std = []
 
 [dependencies]
 bitflags = "2.1.0"
+log = { version = "0.4.17", optional = true }
 serde = { version = "1.0.52", optional = true }

--- a/zune-core/src/lib.rs
+++ b/zune-core/src/lib.rs
@@ -30,6 +30,12 @@
 #![macro_use]
 extern crate alloc;
 
+#[cfg(not(feature = "log"))]
+pub mod log;
+
+#[cfg(feature = "log")]
+pub use log;
+
 pub mod bit_depth;
 pub mod bytestream;
 pub mod colorspace;

--- a/zune-core/src/log.rs
+++ b/zune-core/src/log.rs
@@ -1,0 +1,68 @@
+#[repr(usize)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+pub enum Level {
+    Error = 1,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __log_enabled {
+    ($lvl:expr) => {{
+        let _ = $lvl;
+        false
+    }}
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __error {
+    ($($arg:tt)+) => (
+        #[cfg(feature = "std")]
+        {
+            panic!($($arg)+);
+        }
+    )
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __warn {
+    ($($arg:tt)+) => (
+        #[cfg(feature = "std")]
+        {
+            panic!($($arg)+);
+        }
+    )
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __info {
+    ($($arg:tt)+) => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __debug {
+    ($($arg:tt)+) => {};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __trace {
+    ($($arg:tt)+) => {};
+}
+
+// #[macro_export] is required to make macros works across crates
+// but it always put the macro in the crate root.
+// #[doc(hidden)] + "pub use" is a workaround to namespace a macro.
+pub use crate::__error as error;
+pub use crate::__warn as warn;
+pub use crate::__info as info;
+pub use crate::__debug as debug;
+pub use crate::__trace as trace;
+pub use crate::__log_enabled as log_enabled;

--- a/zune-farbfeld/Cargo.toml
+++ b/zune-farbfeld/Cargo.toml
@@ -10,6 +10,8 @@ categories = ["multimedia::images", "multimedia::encoding"]
 license = "MIT OR Apache-2.0 OR Zlib"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+log = ["zune-core/log"]
+
 [dependencies]
 zune-core = { path = "../zune-core", version = "0.2" }
-log = "0.4.17"

--- a/zune-farbfeld/src/decoder.rs
+++ b/zune-farbfeld/src/decoder.rs
@@ -9,7 +9,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitDepth;
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;

--- a/zune-hdr/Cargo.toml
+++ b/zune-hdr/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+log = ["zune-core/log"]
+
 [dependencies]
 zune-core = { version = "0.2.13", path = "../zune-core" }
-log = "0.4.17"

--- a/zune-hdr/src/decoder.rs
+++ b/zune-hdr/src/decoder.rs
@@ -14,7 +14,7 @@ use core::iter::Iterator;
 use core::option::Option::{self, *};
 use core::result::Result::{self, *};
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;
 use zune_core::options::DecoderOptions;

--- a/zune-image/Cargo.toml
+++ b/zune-image/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 # Single based image decoders and encoders
+log = ["zune-core/log"]
 ppm = ["zune-ppm"]
 jpeg = ["zune-jpeg", "jpeg-encoder"]
 png = ["zune-png"]
@@ -15,7 +16,6 @@ qoi = ["zune-qoi"]
 jpeg-xl = ["zune-jpegxl"]
 hdr = ["zune-hdr"]
 bmp = ["zune-bmp"]
-
 # Serde serialization support
 serde-support = ["zune-core/serde", "serde"]
 # All image formats
@@ -31,7 +31,7 @@ threads = ["zune-jpegxl/threads"]
 # Simd support
 simd = ["zune-jpeg/x86", "zune-png/sse", "zune-imageprocs/avx2", "zune-imageprocs/sse2", "zune-imageprocs/sse3", "zune-imageprocs/sse41"]
 
-all = ["image_formats", "serde-support", "metadata", "threads", "filters", "simd"]
+all = ["image_formats", "serde-support", "metadata", "threads", "filters", "simd", "log"]
 
 [dependencies]
 zune-imageprocs = { path = "../zune-imageprocs", optional = true }
@@ -47,8 +47,6 @@ zune-qoi = { path = "../zune-qoi", optional = true }
 zune-jpegxl = { path = "../zune-jpegxl", optional = true }
 zune-hdr = { path = "../zune-hdr", optional = true }
 zune-bmp = { path = "../zune-bmp", optional = true }
-# Logging information
-log = "0.4.17"
 # Channel conversions in a safe way
 bytemuck = { version = "1.13.1", default-features = false }
 # Serializing info

--- a/zune-image/src/codecs.rs
+++ b/zune-image/src/codecs.rs
@@ -34,7 +34,7 @@
 
 use std::path::Path;
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::options::{DecoderOptions, EncoderOptions};
 

--- a/zune-image/src/codecs/jpeg.rs
+++ b/zune-image/src/codecs/jpeg.rs
@@ -15,7 +15,7 @@
 //! The decoder and encoder both support metadata extraction and saving.
 //!
 use jpeg_encoder::{ColorType, EncodingError};
-use log::warn;
+use zune_core::log::warn;
 use zune_core::bit_depth::BitDepth;
 use zune_core::bytestream::ZReaderTrait;
 use zune_core::colorspace::ColorSpace;

--- a/zune-image/src/codecs/png.rs
+++ b/zune-image/src/codecs/png.rs
@@ -16,6 +16,7 @@ use zune_core::bytestream::ZReaderTrait;
 use zune_core::colorspace::ColorSpace;
 use zune_core::options::EncoderOptions;
 use zune_core::result::DecodingResult;
+use zune_core::log::warn;
 pub use zune_png::*;
 
 use crate::codecs::{create_options_for_encoder, ImageFormat};
@@ -153,7 +154,7 @@ impl EncoderTrait for PngEncoder {
                     if result.is_ok() {
                         encoder.add_exif_segment(buf.get_ref());
                     } else {
-                        log::warn!("Writing exif failed {:?}", result);
+                        warn!("Writing exif failed {:?}", result);
                     }
                 }
             }

--- a/zune-image/src/core_filters/colorspace.rs
+++ b/zune-image/src/core_filters/colorspace.rs
@@ -12,7 +12,7 @@
 //! This contains simple colorspace conversion routines
 //! that convert between different colorspaces in image
 //!
-use log::warn;
+use zune_core::log::warn;
 use zune_core::bit_depth::BitType;
 use zune_core::colorspace::{ColorSpace, ALL_COLORSPACES};
 

--- a/zune-image/src/core_filters/depth.rs
+++ b/zune-image/src/core_filters/depth.rs
@@ -26,7 +26,7 @@
 //! when moving from `BitDepth::Eight` to `BitDepth::F32`, the library will automatically
 //! divide all pixels by `255.0` after converting them to f32's
 //!
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::{BitDepth, BitType};
 
 use crate::channel::Channel;

--- a/zune-image/src/filters/box_blur.rs
+++ b/zune-image/src/filters/box_blur.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitType;
 use zune_imageprocs::box_blur::{box_blur_f32, box_blur_u16, box_blur_u8};
 

--- a/zune-image/src/filters/convolve.rs
+++ b/zune-image/src/filters/convolve.rs
@@ -8,7 +8,7 @@
 
 #![allow(dead_code)]
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitType;
 use zune_imageprocs::convolve::convolve;
 

--- a/zune-image/src/filters/gamma.rs
+++ b/zune-image/src/filters/gamma.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitType;
 use zune_imageprocs::gamma::gamma;
 

--- a/zune-image/src/filters/gaussian_blur.rs
+++ b/zune-image/src/filters/gaussian_blur.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitType;
 use zune_imageprocs::gaussian_blur::{gaussian_blur_f32, gaussian_blur_u16, gaussian_blur_u8};
 

--- a/zune-image/src/filters/median.rs
+++ b/zune-image/src/filters/median.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitType;
 use zune_imageprocs::median::median;
 

--- a/zune-image/src/filters/orientation.rs
+++ b/zune-image/src/filters/orientation.rs
@@ -8,7 +8,7 @@
 
 #![cfg(feature = "metadata")]
 
-use log::warn;
+use zune_core::log::warn;
 use zune_core::bit_depth::BitType;
 
 use crate::errors::ImageErrors;

--- a/zune-image/src/filters/premul_alpha.rs
+++ b/zune-image/src/filters/premul_alpha.rs
@@ -8,7 +8,7 @@
 
 //! Change image from pre-multiplied alpha to
 //! un-premultiplied alpha and vice versa
-use log::warn;
+use zune_core::log::warn;
 use zune_core::bit_depth::{BitDepth, BitType};
 use zune_imageprocs::premul_alpha::{
     create_unpremul_table_u16, create_unpremul_table_u8, premultiply_f32, premultiply_u16,

--- a/zune-image/src/filters/statistics.rs
+++ b/zune-image/src/filters/statistics.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitType;
 use zune_imageprocs::spatial_ops::spatial_ops;
 pub use zune_imageprocs::spatial_ops::StatisticOperations;

--- a/zune-image/src/filters/threshold.rs
+++ b/zune-image/src/filters/threshold.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::warn;
+use zune_core::log::warn;
 use zune_core::bit_depth::BitType;
 use zune_imageprocs::threshold::threshold;
 pub use zune_imageprocs::threshold::ThresholdMethod;

--- a/zune-image/src/filters/unsharpen.rs
+++ b/zune-image/src/filters/unsharpen.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitType;
 use zune_imageprocs::unsharpen::{unsharpen_u16, unsharpen_u8};
 

--- a/zune-image/src/metadata/exif.rs
+++ b/zune-image/src/metadata/exif.rs
@@ -8,7 +8,7 @@
 
 #![cfg(feature = "metadata")]
 
-use log::{error, trace};
+use zune_core::log::{error, trace};
 
 use crate::image::Image;
 use crate::metadata::ImageMetadata;

--- a/zune-image/src/traits.rs
+++ b/zune-image/src/traits.rs
@@ -4,7 +4,7 @@
  * This software is free software; You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::{BitDepth, BitType};
 use zune_core::bytestream::ZReaderTrait;
 use zune_core::colorspace::{ColorSpace, ALL_COLORSPACES};

--- a/zune-image/src/workflow.rs
+++ b/zune-image/src/workflow.rs
@@ -6,8 +6,8 @@
 
 use std::time::Instant;
 
-use log::Level::Trace;
-use log::{log_enabled, trace, Level};
+use zune_core::log::Level::Trace;
+use zune_core::log::{log_enabled, trace, Level};
 
 use crate::codecs::ImageFormat;
 use crate::errors::ImageErrors;

--- a/zune-imageprocs/Cargo.toml
+++ b/zune-imageprocs/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log="0.4.17"
+zune-core = { path = "../zune-core", version = "0.2" }
 
 
 [features]
@@ -16,7 +16,7 @@ sse3 = []
 sse41 = []
 ## Needs nightly, disabled by default
 benchmarks=[]
-
+log = ["zune-core/log"]
 default = ["avx2", "sse2", "sse3", "sse41"]
 
 

--- a/zune-imageprocs/src/box_blur.rs
+++ b/zune-imageprocs/src/box_blur.rs
@@ -8,7 +8,7 @@
 
 use std::f32;
 
-use log::warn;
+use zune_core::log::warn;
 
 use crate::mathops::{compute_mod_u32, fastdiv_u32};
 use crate::traits::NumOps;

--- a/zune-imageprocs/src/convolve.rs
+++ b/zune-imageprocs/src/convolve.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use log::error;
+use zune_core::log::error;
 
 use crate::pad::{pad, PadMethod};
 use crate::traits::NumOps;

--- a/zune-imageprocs/src/transpose.rs
+++ b/zune-imageprocs/src/transpose.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Once;
 
-use log::trace;
+use zune_core::log::trace;
 
 use crate::transpose::scalar::transpose_scalar;
 

--- a/zune-jpeg/Cargo.toml
+++ b/zune-jpeg/Cargo.toml
@@ -17,11 +17,10 @@ crate-type = ["cdylib", "rlib"]
 x86 = []
 neon = []
 std = ["zune-core/std"]
+log = ["zune-core/log"]
 default = ["x86", "neon", "std"]
 
-
 [dependencies]
-log = "0.4.11" # logging facilities
 zune-core = { path = "../zune-core", version = "0.2" }
 
 

--- a/zune-jpeg/src/color_convert.rs
+++ b/zune-jpeg/src/color_convert.rs
@@ -65,6 +65,7 @@ pub fn choose_ycbcr_to_rgb_convert_func(
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[cfg(feature = "x86")]
     {
+        use zune_core::log::debug;
         if options.use_avx2() {
             debug!("Using AVX optimised color conversion functions");
 

--- a/zune-jpeg/src/components.rs
+++ b/zune-jpeg/src/components.rs
@@ -14,6 +14,8 @@
 use alloc::vec::Vec;
 use alloc::{format, vec};
 
+use zune_core::log::trace;
+
 use crate::decoder::MAX_COMPONENTS;
 use crate::errors::DecodeErrors;
 use crate::upsampler::upsample_no_op;

--- a/zune-jpeg/src/decoder.rs
+++ b/zune-jpeg/src/decoder.rs
@@ -13,6 +13,7 @@ use alloc::string::ToString;
 use alloc::vec::Vec;
 use alloc::{format, vec};
 
+use zune_core::log::{trace, warn, error};
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;
 use zune_core::options::DecoderOptions;

--- a/zune-jpeg/src/headers.rs
+++ b/zune-jpeg/src/headers.rs
@@ -14,6 +14,7 @@ use alloc::format;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
+use zune_core::log::{debug, trace, warn, error};
 use zune_core::bytestream::ZReaderTrait;
 use zune_core::colorspace::ColorSpace;
 

--- a/zune-jpeg/src/idct.rs
+++ b/zune-jpeg/src/idct.rs
@@ -33,6 +33,7 @@
     clippy::wildcard_imports
 )]
 
+use zune_core::log::debug;
 use zune_core::options::DecoderOptions;
 
 use crate::decoder::IDCTPtr;

--- a/zune-jpeg/src/lib.rs
+++ b/zune-jpeg/src/lib.rs
@@ -103,8 +103,6 @@
 #![macro_use]
 extern crate alloc;
 extern crate core;
-#[macro_use]
-extern crate log;
 
 pub use zune_core;
 

--- a/zune-jpeg/src/mcu.rs
+++ b/zune-jpeg/src/mcu.rs
@@ -9,6 +9,7 @@
 use alloc::{format, vec};
 use core::cmp::min;
 
+use zune_core::log::{warn, error, trace};
 use zune_core::bytestream::ZReaderTrait;
 use zune_core::colorspace::ColorSpace;
 

--- a/zune-jpeg/src/mcu_prog.rs
+++ b/zune-jpeg/src/mcu_prog.rs
@@ -24,6 +24,7 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::cmp::min;
 
+use zune_core::log::{warn, error, debug};
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;
 

--- a/zune-jpeg/src/misc.rs
+++ b/zune-jpeg/src/misc.rs
@@ -13,6 +13,7 @@ use alloc::format;
 use core::cmp::max;
 use core::fmt;
 
+use zune_core::log::trace;
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;
 

--- a/zune-jpegxl/Cargo.toml
+++ b/zune-jpegxl/Cargo.toml
@@ -7,12 +7,11 @@ edition = "2021"
 
 [dependencies]
 zune-core = { version = "0.2.1", path = "../zune-core" }
-log = "0.4.17"
-
 
 [features]
 threads = []
 std = []
+log = ["zune-core/log"]
 default = ["threads", "std"]
 
 [dev-dependencies]

--- a/zune-jpegxl/src/encoder.rs
+++ b/zune-jpegxl/src/encoder.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 use core::cmp::{max, min};
 use core::marker::PhantomData;
 
-use log::{log_enabled, trace, Level};
+use zune_core::log::{log_enabled, trace, Level};
 use zune_core::bit_depth::BitDepth;
 use zune_core::options::EncoderOptions;
 

--- a/zune-png/Cargo.toml
+++ b/zune-png/Cargo.toml
@@ -16,11 +16,11 @@ description = "A fast, correct and safe png decoder"
 [features]
 sse = []
 std = ["zune-core/std"]
+log = ["zune-core/log"]
 default = ["sse", "std"]
 
 [dependencies]
 zune-core = { path = "../zune-core", version = "0.2" }
-log = "0.4.17"
 zune-inflate = { path = "../zune-inflate", version = "0.2", default-features = false, features = ["zlib"] }
 
 [dev-dependencies]

--- a/zune-png/src/decoder.rs
+++ b/zune-png/src/decoder.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::cmp::min;
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::{BitDepth, ByteEndian};
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;

--- a/zune-png/src/headers/readers.rs
+++ b/zune-png/src/headers/readers.rs
@@ -6,7 +6,7 @@
 
 use alloc::{format, vec};
 
-use log::{trace, warn};
+use zune_core::log::{trace, warn};
 use zune_core::bytestream::ZReaderTrait;
 use zune_inflate::DeflateDecoder;
 

--- a/zune-png/src/options.rs
+++ b/zune-png/src/options.rs
@@ -8,7 +8,7 @@
 
 use alloc::format;
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 
 use crate::error::PngDecodeErrors;

--- a/zune-ppm/Cargo.toml
+++ b/zune-ppm/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+log = ["zune-core/log"]
+
 [dependencies]
 zune-core = { path = "../zune-core", version = "0.2.1" }
 log = "0.4.17"

--- a/zune-ppm/src/decoder.rs
+++ b/zune-ppm/src/decoder.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::fmt::{Debug, Formatter};
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::{BitDepth, BitType, ByteEndian};
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;

--- a/zune-psd/Cargo.toml
+++ b/zune-psd/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+log = ["zune-core/log"]
+
 [dependencies]
 zune-core = { path = "../zune-core", version = "0.2.1" }
-log = "0.4.17"

--- a/zune-psd/src/decoder.rs
+++ b/zune-psd/src/decoder.rs
@@ -20,7 +20,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::cmp::Ordering;
 
-use log::trace;
+use zune_core::log::trace;
 use zune_core::bit_depth::BitDepth;
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;

--- a/zune-qoi/Cargo.toml
+++ b/zune-qoi/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+log = ["zune-core/log"]
+
 [dependencies]
 zune-core = { path = "../zune-core", version = "0.2.1" }
-log = "0.4.17"

--- a/zune-qoi/src/decoder.rs
+++ b/zune-qoi/src/decoder.rs
@@ -9,7 +9,7 @@
 use alloc::vec::Vec;
 use alloc::{format, vec};
 
-use log::{error, trace};
+use zune_core::log::{error, trace};
 use zune_core::bit_depth::BitDepth;
 use zune_core::bytestream::{ZByteReader, ZReaderTrait};
 use zune_core::colorspace::ColorSpace;

--- a/zune-wasm/Cargo.toml
+++ b/zune-wasm/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [features]
+log = ["zune-core/log"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
@@ -19,7 +20,6 @@ zune-core = { path = "../zune-core", version = "0.2.1" }
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
-log = "0.4.17"
 wasm-logger = "0.2.0"
 
 [dev-dependencies]

--- a/zune-wasm/src/lib.rs
+++ b/zune-wasm/src/lib.rs
@@ -8,7 +8,7 @@
 
 use std::ops::{Deref, DerefMut};
 
-use log::{debug, error, info};
+use zune_core::log::{debug, error, info};
 use wasm_bindgen::prelude::*;
 use zune_core::bit_depth::BitDepth;
 // use zune_core::colorspace::ColorSpace;


### PR DESCRIPTION
By default, with the "log" feature on "zune-core" will re-export the log crate.
Without "log", "zune-core" exports some stubs over `eprintln!`. 
The only change required for "zune-*" crate: use `zune_core::log::trace` instead of `log::trace`.

To remove "log-rs" dependency in zune-image user's Cargo.toml:
```
zune-jpeg = {version = "0.3", default-features = false, features = ["x86", "neon", "std"]}
```
I do not really like that it requires "x86" etc, but I guess its fine? Not having `log` as a default featulre will be a breaking change - for everyone who actually used `log-rs`, all the logs from `zune` will suddenly disappear, not ideal.

Let me know if the idea is OK, I'll finish this PR with the rest of "zune-*" crates. 