### PR TITLE
Refine newline in zune-python/README.md

### DIFF
--- a/crates/zune-python/README.md
+++ b/crates/zune-python/README.md
@@ -74,7 +74,7 @@ Wait until you see
 ```
 
 8. call `python` or `ipython` to get an interactive shell.
-   9Import `zil` from there and decode an image
+9. Import `zil` from there and decode an image
 
 ```python
 # Import the package


### PR DESCRIPTION
There is a typo in the zune-python/README.md
![image](https://github.com/etemesi254/zune-image/assets/4865550/8ad1ef24-79a2-455a-9f5e-cbc14a3c516f)
