### PR TITLE
Added functions to extend image with custom codecs

### DIFF
--- a/crates/zune-image/src/codecs.rs
+++ b/crates/zune-image/src/codecs.rs
@@ -655,6 +655,30 @@ impl Image {
             ))
         }
     }
+
+    /// Open a new file from memory with the configured decoder
+    ///  
+    /// # Arguments
+    ///  - `decoder`: The configured decoder
+    /// # Example
+    /// - Open a memory source with the ppm decoder
+    ///
+    ///```no_run
+    /// // requires ppm feature
+    /// use zune_image::codecs::ppm::PPMDecoder;
+    /// use zune_image::image::Image;
+    ///
+    /// // create a simple ppm p5 grayscale format
+    /// let decoder = PPMDecoder::new(b"P5 1 1 255 1");
+    ///
+    /// let image = Image::from_decoder(decoder);
+    ///```
+    pub fn from_decoder<T>(mut decoder: impl DecoderTrait<T>) -> Result<Image, ImageErrors>
+    where
+        T: ZReaderTrait
+    {
+        decoder.decode()
+    }
 }
 /// Guess the format of an image based on it's magic bytes
 ///

--- a/crates/zune-image/src/codecs.rs
+++ b/crates/zune-image/src/codecs.rs
@@ -545,6 +545,42 @@ impl Image {
         }
     }
 
+    /// Encode an image returning a vector containing the result
+    /// of the encoding using the specified encoder
+    ///
+    /// # Arguments
+    ///
+    /// * `encoder`: The encoder to use for encoding
+    ///
+    /// returns: `Result<Vec<u8, Global>, ImageErrors>`
+    ///
+    /// # Examples
+    ///
+    /// - Encode a simple image to JPEG format
+    /// ```
+    /// use zune_core::colorspace::ColorSpace;
+    /// // requires jpeg feature
+    /// use zune_image::codecs::jpeg::JpegEncoder;
+    /// use zune_image::image::Image;
+    /// 
+    /// let encoder = JpegEncoder::new();
+    /// 
+    /// // create an image using from fn, to generate a gradient image
+    /// let image = Image::from_fn::<u8,_>(300,300,ColorSpace::RGB,|x,y,px|{
+    ///         let r = (0.3 * x as f32) as u8;
+    ///         let b = (0.3 * y as f32) as u8;
+    ///         px[0] = r;
+    ///         px[2] = b;
+    /// });
+    /// // write to jpeg now
+    /// let contents = image.write_with_encoder(encoder).unwrap();
+    /// ```
+    pub fn write_with_encoder(
+        &self, mut encoder: impl EncoderTrait
+    ) -> Result<Vec<u8>, ImageErrors> {
+        encoder.encode(self)
+    }
+
     /// Open an encoded file for which the library has a configured decoder for it
     ///
     /// # Note

--- a/crates/zune-image/src/image.rs
+++ b/crates/zune-image/src/image.rs
@@ -15,7 +15,6 @@ use std::mem::size_of;
 
 use bytemuck::{Pod, Zeroable};
 use zune_core::bit_depth::BitDepth;
-use zune_core::bytestream::ZByteWriterTrait;
 use zune_core::colorspace::ColorSpace;
 
 use crate::channel::{Channel, ChannelErrors};
@@ -25,7 +24,7 @@ use crate::deinterleave::{deinterleave_f32, deinterleave_u16, deinterleave_u8};
 use crate::errors::ImageErrors;
 use crate::frame::Frame;
 use crate::metadata::ImageMetadata;
-use crate::traits::{EncoderTrait, OperationsTrait, ZuneInts};
+use crate::traits::{OperationsTrait, ZuneInts};
 
 /// Maximum supported color channels
 pub const MAX_CHANNELS: usize = 4;
@@ -320,12 +319,6 @@ impl Image {
             4 => Image::from_fn_inner::<_, _, 4>(width, height, func, colorspace),
             _ => unreachable!()
         }
-    }
-
-    pub fn write_with_encoder<T: ZByteWriterTrait>(
-        &self, mut encoder: impl EncoderTrait, sink: T
-    ) -> Result<usize, ImageErrors> {
-        encoder.encode(self, sink)
     }
 
     /// Template code to use with from_fn which engraves component number


### PR DESCRIPTION
Added functions `write_with_encoder` and `from_decoder`. This makes easier to integrate custom codecs without hacking the compiler like so
```rs
let mut decoder = AvifDecoder::try_new(reader)?;

return <AvifDecoder<ZByteReader<Vec<u8>>> as DecoderTrait<Vec<u8>>>::decode(
    &mut decoder,
);
```