### PR TITLE
Add repository field to crates missing it

### DIFF
--- a/crates/zune-bin/Cargo.toml
+++ b/crates/zune-bin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-bin"
 version = "0.4.0"
 edition = "2021"
+repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-bin"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-capi/Cargo.toml
+++ b/crates/zune-capi/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-capi"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-capi"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-gif/Cargo.toml
+++ b/crates/zune-gif/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-gif"
 version = "0.1.0"
 edition = "2021"
+repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-gif"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -11,3 +12,4 @@ log = ["zune-core/log"]
 
 [dependencies]
 zune-core = { version = "0.4", path = "../zune-core", default-features = false }
+

--- a/crates/zune-inflate/Cargo.toml
+++ b/crates/zune-inflate/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-inflate"
 version = "0.2.0"
 edition = "2021"
+repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-inflate"
 description = "A heavily optimized deflate decompressor in Pure Rust"
 exclude = ["tests/"]
 homepage = "https://github.com/etemesi254/zune-image/tree/main/zune-inflate"

--- a/crates/zune-opencl/Cargo.toml
+++ b/crates/zune-opencl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-opencl"
 version = "0.4.0"
 edition = "2021"
+repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-opencl"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -12,3 +13,4 @@ ocl = "0.19.4"
 zune-image = { path = "../zune-image" }
 zune-core = { path = "../zune-core" }
 bytemuck = "1.13.1"
+

--- a/crates/zune-python/Cargo.toml
+++ b/crates/zune-python/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-python"
 version = "0.4.0"
 edition = "2021"
+repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-python"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
@@ -15,3 +16,4 @@ zune-core = { path = "../zune-core", features = ["log"] }
 zune-imageprocs = { path = "../zune-imageprocs", features = ["threads", "exif"] }
 numpy = "0.20.0"
 pyo3-log = "0.9.0"
+

--- a/crates/zune-wasm/Cargo.toml
+++ b/crates/zune-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "zune-wasm"
 version = "0.4.0"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 edition = "2018"
+repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-wasm"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
While auditing our dependencies we've discovered a few of your crates are missing the `repository` field. This field is very useful as it allows many tools to easily find out about the git repo of the project and take action on it.
This patch adds the `repo` field to all crates that were missing it.