### PR TITLE
Remove unnecessary cdylib crate-type

### DIFF
--- a/crates/zune-jpeg/Cargo.toml
+++ b/crates/zune-jpeg/Cargo.toml
@@ -10,8 +10,6 @@ categories = ["multimedia::images"]
 exclude = ["/benches/images/*", "/tests/*", "/.idea/*", "/.gradle/*", "/test-images/*", "fuzz/*"]
 description = "A fast, correct and safe jpeg decoder"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 x86 = []


### PR DESCRIPTION
Creating a shared library seems not necessary for this crate (as opposed to say zune-capi), while at the same time cdylib as crate type may break compilation when using it in another cdylib while cross-compiling on Linux:

Typically cross-builds on Linux (against Yocto, for example) require the use of --sysroot (and potentially other linker flags). In Slint (https://github.com/slint-ui/slint/tree/master/api/cpp), we create a cdylib for use with CMake with the help of Corrosion (https://github.com/corrosion-rs/corrosion), which passes --sysroot to the final link line (corrosion_link_args). But since the cargo crate type to build is cdylib, any cdylibs on the way seem to be created as well, which would include zune-jpeg. Linking that would fail as --sysroot is not supplied.

It seems however that this isn't necessarily overall, so removing this fixes it and also speeds up the general build.