### PR TITLE
fix miscalculated offset in Image::from_fn

### DIFF
--- a/crates/zune-image/src/image.rs
+++ b/crates/zune-image/src/image.rs
@@ -373,7 +373,7 @@ impl Image {
             for x in 0..width {
                 (func)(y, x, &mut pxs);
 
-                let offset = y * height + x;
+                let offset = y * width + x;
 
                 for i in 0..COMPONENTS {
                     channels_ref[i][offset] = pxs[i];


### PR DESCRIPTION
The offset calculation in `Image::from_fn` is incorrect.