### PR TITLE
Better handling of EOF in read_exact_bytes

### DIFF
--- a/crates/zune-core/src/bytestream/reader/std_readers.rs
+++ b/crates/zune-core/src/bytestream/reader/std_readers.rs
@@ -15,23 +15,29 @@ impl<T: io::BufRead + io::Seek> ZByteReaderTrait for T {
     }
     #[inline(always)]
     fn read_exact_bytes(&mut self, buf: &mut [u8]) -> Result<(), ZByteIoError> {
-        match self.read(buf) {
-            Ok(bytes) => {
-                if bytes != buf.len() {
-                    // if a read succeeds but doesn't satisfy the buffer, it means it may be EOF
-                    // so we seek back to where we started because some paths may aggressively read
-                    // forward and ZCursor maintains the position.
+        let mut bytes_read = 0;
+
+        while bytes_read < buf.len() {
+            match self.read(&mut buf[bytes_read..]) {
+                Ok(0) => {
+                    // if a read returns zero bytes read, it means it encountered an EOF so we seek
+                    // back to where we started because some paths may aggressively read forward and
+                    // ZCursor maintains the position.
 
                     // NB: (cae) This adds a branch on every read, and will slow down every function
                     // resting on it. Sorry
-                    self.seek(SeekFrom::Current(-(bytes as i64)))
+                    self.seek(SeekFrom::Current(-(bytes_read as i64)))
                         .map_err(ZByteIoError::from)?;
-                    return Err(ZByteIoError::NotEnoughBytes(bytes, buf.len()));
+                    return Err(ZByteIoError::NotEnoughBytes(bytes_read, buf.len()));
                 }
-                Ok(())
+                Ok(bytes) => {
+                    bytes_read += bytes;
+                }
+                Err(e) => return Err(ZByteIoError::from(e))
             }
-            Err(e) => Err(ZByteIoError::from(e)),
         }
+
+        Ok(())
     }
 
     #[inline]


### PR DESCRIPTION
After e69b4c59a64292872790fa111bdeff140b690c4e I'm seeing that trying to read from a `BufReader` with a small buffer no longer works (using the wrapper from https://github.com/image-rs/image/pull/2198):

```rust
let decoder = JpegDecoder::new(BufReader::with_capacity(32, Cursor::new(include_bytes!("test.jpg")))).unwrap();
let mut decoded = vec![0; decoder.total_bytes() as usize];
decoder.read_image(&mut decoded).unwrap();
```

Produces:
```
I/O errors Not enough bytes, expected 14 but found 3144
```

The error is because `BufReader` sometimes returns fewer bytes than requested in a read call without it indicating that the end-of-input has been reached.

This PR changes the implementation of `ZByteReaderTrait::read_exact_bytes` to only treat zero bytes read as meaning EOF and all other partial reads get re-attempted