### PR TITLE
Implement DecodeInto for more formats

### DIFF
--- a/crates/zune-farbfeld/src/lib.rs
+++ b/crates/zune-farbfeld/src/lib.rs
@@ -29,6 +29,7 @@ extern crate alloc;
 
 pub use decoder::*;
 pub use encoder::*;
+pub use errors::*;
 
 mod decoder;
 mod encoder;

--- a/crates/zune-image/src/codecs/farbfeld.rs
+++ b/crates/zune-image/src/codecs/farbfeld.rs
@@ -30,7 +30,7 @@ where
     fn decode(&mut self) -> Result<Image, ImageErrors> {
         let pixels = self
             .decode()
-            .map_err(|e| ImageErrors::ImageDecodeErrors(format!("{:?}", e)))?;
+            .map_err(ImageErrors::from)?;
         let colorspace = self.colorspace();
         let (width, height) = self.dimensions().unwrap();
 
@@ -74,6 +74,12 @@ where
         };
 
         Ok(Some(metadata))
+    }
+}
+
+impl From<FarbFeldErrors> for ImageErrors {
+    fn from(value: FarbFeldErrors) -> Self {
+        Self::ImageDecodeErrors(format!("ff: {value:?}"))
     }
 }
 
@@ -148,6 +154,6 @@ impl EncoderTrait for FarbFeldEncoder {
 
 impl From<FarbFeldEncoderErrors> for ImgEncodeErrors {
     fn from(value: FarbFeldEncoderErrors) -> Self {
-        ImgEncodeErrors::ImageEncodeErrors(format!("{:?}", value))
+        ImgEncodeErrors::ImageEncodeErrors(format!("ff: {:?}", value))
     }
 }

--- a/crates/zune-image/src/codecs/farbfeld.rs
+++ b/crates/zune-image/src/codecs/farbfeld.rs
@@ -157,3 +157,25 @@ impl From<FarbFeldEncoderErrors> for ImgEncodeErrors {
         ImgEncodeErrors::ImageEncodeErrors(format!("ff: {:?}", value))
     }
 }
+
+impl<T> DecodeInto for FarbFeldDecoder<T>
+where
+    T: ZByteReaderTrait
+{
+    type BufferType = u16;
+
+    fn decode_into(&mut self, buffer: &mut [Self::BufferType]) -> Result<(), ImageErrors> {
+        self.decode_into(buffer)
+            .map_err(<FarbFeldErrors as Into<ImageErrors>>::into)?;
+
+        Ok(())
+    }
+
+    fn output_buffer_size(&mut self) -> Result<usize, ImageErrors> {
+        self.decode_headers()
+            .map_err(<FarbFeldErrors as Into<ImageErrors>>::into)?;
+
+        // unwrap is okay because we successfully decoded image headers
+        Ok(self.output_buffer_size().unwrap())
+    }
+}

--- a/crates/zune-image/src/codecs/jpeg.rs
+++ b/crates/zune-image/src/codecs/jpeg.rs
@@ -262,6 +262,8 @@ impl<T> DecodeInto for JpegDecoder<T>
 where
     T: ZByteReaderTrait
 {
+    type BufferType = u8;
+
     fn decode_into(&mut self, buffer: &mut [u8]) -> Result<(), ImageErrors> {
         self.decode_into(buffer)
             .map_err(<DecodeErrors as Into<ImageErrors>>::into)?;

--- a/crates/zune-image/src/codecs/qoi.rs
+++ b/crates/zune-image/src/codecs/qoi.rs
@@ -167,7 +167,9 @@ impl<T> DecodeInto for QoiDecoder<T>
 where
     T: ZByteReaderTrait
 {
-    fn decode_into(&mut self, buffer: &mut [u8]) -> Result<(), ImageErrors> {
+    type BufferType = u8;
+
+    fn decode_into(&mut self, buffer: &mut [Self::BufferType]) -> Result<(), ImageErrors> {
         self.decode_into(buffer)?;
 
         Ok(())

--- a/crates/zune-image/src/traits.rs
+++ b/crates/zune-image/src/traits.rs
@@ -480,13 +480,15 @@ impl ZuneInts<f32> for f32 {
 /// can write data as raw native endian into
 /// a buffer of u8
 pub trait DecodeInto {
+    type BufferType: Sized;
+
     /// Decode raw image bytes into a buffer that can
     /// hold u8 bytes
     ///
     /// The rationale is that u8 bytes can alias any type
     /// and higher bytes offer ways to construct types from
     /// u8's hence they can be used as a base type
-    fn decode_into(&mut self, buffer: &mut [u8]) -> Result<(), ImageErrors>;
+    fn decode_into(&mut self, buffer: &mut [Self::BufferType]) -> Result<(), ImageErrors>;
 
     /// Minimum buffer length which is needed to decode this image
     ///


### PR DESCRIPTION
I just implemented the `DecodeInto` trait for more image formats that already have a `decode_into(buf: &mut [BufferType])` like function. For better image format support, I've also added `type BufferType` to `DecodeInto` so that eg. hdr can output in f32 instead of forced u8.

My use-case is to directly write into buffers allocated with vulkan that the GPU can directly read from, eliminating an extra copy from a `Vec<u8>`. Something `image-rs` does not at all support.

While making this I've noticed some minor inconsistencies between the crates:
* bmp: calls it `output_buf_size()` instead of `output_buffer_size()`, didn't change it as to not break compatability
* some decode errors seem to prepend the image format, some do not
