### PR TITLE
make compatible with old rustc nightly-2023-09-30

### DIFF
--- a/crates/zune-image/src/deinterleave.rs
+++ b/crates/zune-image/src/deinterleave.rs
@@ -45,7 +45,7 @@ fn deinterleave_generic<T: Default + Clone + Copy + 'static + Zeroable + Pod>(
             ImageOperationsErrors::InvalidChannelLayout("Extra pixels in the colorspace")
         ));
     }
-    let size = (interleaved_pixels.len() / colorspace.num_components()) * size_of::<T>();
+    let size = (interleaved_pixels.len() / colorspace.num_components()) * core::mem::size_of::<T>();
 
     if size == 0 {
         return Err(ImageErrors::GenericStr(

--- a/crates/zune-image/src/frame.rs
+++ b/crates/zune-image/src/frame.rs
@@ -665,7 +665,7 @@ impl Frame {
 #[allow(unused_imports)]
 #[cfg(test)]
 mod tests {
-    use std::num::{NonZero, NonZeroU32, NonZeroUsize};
+    use std::num::{NonZeroU32, NonZeroUsize};
 
     use zune_core::colorspace::ColorSpace;
 


### PR DESCRIPTION
I'm still stuck on this old compiler version due to rust-gpu, and it only needs very few changes to make it compile. 

Though I have no need to guarantee compatibility in the future, as hopefully rust-gpu will be updated soonish.