### PR TITLE
image: only pull dependencies if the specific feature is activated

### DIFF
--- a/crates/zune-image/Cargo.toml
+++ b/crates/zune-image/Cargo.toml
@@ -30,9 +30,9 @@ metadata = ["kamadak-exif"]
 # Every supported thing
 default = ["all"]
 # Whether to use threads or not for some operations
-threads = ["zune-jpegxl/threads", "jxl-oxide/rayon"]
+threads = ["zune-jpegxl?/threads", "jxl-oxide?/rayon"]
 # Simd support
-simd = ["zune-jpeg/x86", "zune-png/sse", "avx2", "sse41"]
+simd = ["zune-jpeg?/x86", "zune-png?/sse", "avx2", "sse41"]
 benchmarks = []
 avx2 = []
 sse41 = []


### PR DESCRIPTION
Currently, if a user wants to only use the png format with simd, activating the `simd` feature will pull `zune-jpeg` too because the dependent feature isn't optional.

This change that by adding a `?` which means the feature will only be activated if `zune-jpeg` was pulled in the first place.

An excerpt from the [cargo docs](https://doc.rust-lang.org/cargo/reference/features.html#dependency-features) : 
> The "package-name/feature-name" syntax will also enable package-name if it is an optional dependency. Often this is not what you want. You can add a ? as in "package-name?/feature-name" which will only enable the given feature if something else enables the optional dependency.

>    Note: The ? syntax is only available starting with Rust 1.60.

>For example, let’s say we have added some serialization support to our library, and it requires enabling a corresponding feature in some optional dependencies. That can be done like this:

> [dependencies]
> serde = { version = "1.0.133", optional = true }
> rgb = { version = "0.8.25", optional = true }

> [features]
> serde = ["dep:serde", "rgb?/serde"]

> In this example, enabling the serde feature will enable the serde dependency. It will also enable the serde feature for the rgb dependency, but only if something else has enabled the rgb dependency.

I did the same thing for the `threads` feature.