### PR TITLE
feat(python): `resize()`

### DIFF
--- a/crates/zune-python/src/lib.rs
+++ b/crates/zune-python/src/lib.rs
@@ -28,7 +28,7 @@ use py_functions::*;
 use py_image::*;
 use pyo3::prelude::*;
 
-use crate::py_enums::{ColorSpace, ImageDepth, ImageFormat, ImageThresholdType};
+use crate::py_enums::{ColorSpace, ImageDepth, ImageFormat, ImageThresholdType, ResizeMethod};
 
 mod py_enums;
 mod py_functions;
@@ -52,6 +52,7 @@ fn zune_image(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Image>()?;
     m.add_class::<ImageDepth>()?;
     m.add_class::<ImageThresholdType>()?;
+    m.add_class::<ResizeMethod>()?;
     m.add_function(wrap_pyfunction!(init_logger, m)?)?;
 
     m.add_function(wrap_pyfunction!(guess_format, m)?)?;

--- a/crates/zune-python/src/py_enums.rs
+++ b/crates/zune-python/src/py_enums.rs
@@ -11,11 +11,12 @@ use zune_core::bit_depth::BitDepth;
 use zune_core::colorspace::ColorSpace as ZColorSpace;
 use zune_image::codecs::ImageFormat as ZImageFormat;
 use zune_image::errors::ImageErrors;
+use zune_imageprocs::resize::ResizeMethod as ZResizeMethod;
 use zune_imageprocs::threshold::ThresholdMethod;
 
 #[pyclass]
 pub struct ZImageErrors {
-    pub(crate) error: zune_image::errors::ImageErrors
+    pub(crate) error: zune_image::errors::ImageErrors,
 }
 
 impl From<ImageErrors> for ZImageErrors {
@@ -38,7 +39,7 @@ pub enum ImageFormat {
     Qoi,
     JPEG_XL,
     HDR,
-    Unknown
+    Unknown,
 }
 
 impl ImageFormat {
@@ -53,7 +54,7 @@ impl ImageFormat {
             ImageFormat::Qoi => ZImageFormat::QOI,
             ImageFormat::JPEG_XL => ZImageFormat::JPEG_XL,
             ImageFormat::HDR => ZImageFormat::HDR,
-            ImageFormat::Unknown => ZImageFormat::Unknown
+            ImageFormat::Unknown => ZImageFormat::Unknown,
         }
     }
     /// Return true if an image format has an encoder
@@ -80,7 +81,7 @@ impl From<ZImageFormat> for ImageFormat {
             ZImageFormat::JPEG_XL => ImageFormat::JPEG_XL,
             ZImageFormat::HDR => ImageFormat::HDR,
             ZImageFormat::BMP => ImageFormat::BMP,
-            _ => ImageFormat::Unknown
+            _ => ImageFormat::Unknown,
         }
     }
 }
@@ -100,7 +101,7 @@ pub enum ColorSpace {
     CMYK,
     Unknown,
     HSL,
-    HSV
+    HSV,
 }
 
 impl ColorSpace {
@@ -116,7 +117,7 @@ impl ColorSpace {
             ColorSpace::CMYK => ZColorSpace::CMYK,
             ColorSpace::HSL => ZColorSpace::HSL,
             ColorSpace::HSV => ZColorSpace::HSV,
-            ColorSpace::Unexposed | ColorSpace::Unknown => ZColorSpace::Unknown
+            ColorSpace::Unexposed | ColorSpace::Unknown => ZColorSpace::Unknown,
         }
     }
 }
@@ -135,7 +136,7 @@ impl From<ZColorSpace> for ColorSpace {
             ZColorSpace::BGRA => ColorSpace::BGRA,
             ZColorSpace::HSL => ColorSpace::HSL,
             ZColorSpace::HSV => ColorSpace::HSV,
-            _ => ColorSpace::Unknown
+            _ => ColorSpace::Unknown,
         }
     }
 }
@@ -146,7 +147,7 @@ pub enum ImageDepth {
     U8,
     U16,
     F32,
-    Unknown
+    Unknown,
 }
 
 impl ImageDepth {
@@ -155,7 +156,7 @@ impl ImageDepth {
             ImageDepth::U8 => BitDepth::Eight,
             ImageDepth::U16 => BitDepth::Sixteen,
             ImageDepth::F32 => BitDepth::Float32,
-            ImageDepth::Unknown => BitDepth::Unknown
+            ImageDepth::Unknown => BitDepth::Unknown,
         }
     }
 }
@@ -166,7 +167,7 @@ impl From<BitDepth> for ImageDepth {
             BitDepth::Eight => ImageDepth::U8,
             BitDepth::Sixteen => ImageDepth::U16,
             BitDepth::Float32 => ImageDepth::F32,
-            _ => ImageDepth::Unknown
+            _ => ImageDepth::Unknown,
         }
     }
 }
@@ -178,7 +179,7 @@ pub enum ImageThresholdType {
     Binary,
     BinaryInv,
     ThreshTrunc,
-    ThreshToZero
+    ThreshToZero,
 }
 
 impl ImageThresholdType {
@@ -187,7 +188,32 @@ impl ImageThresholdType {
             ImageThresholdType::Binary => ThresholdMethod::Binary,
             ImageThresholdType::BinaryInv => ThresholdMethod::BinaryInv,
             ImageThresholdType::ThreshTrunc => ThresholdMethod::ThreshTrunc,
-            ImageThresholdType::ThreshToZero => ThresholdMethod::ThreshToZero
+            ImageThresholdType::ThreshToZero => ThresholdMethod::ThreshToZero,
+        }
+    }
+}
+
+#[pyclass]
+#[derive(Copy, Clone)]
+pub enum ResizeMethod {
+    Bilinear,
+    Bicubic,
+}
+
+impl ResizeMethod {
+    pub(crate) fn to_resizemethod(self) -> ZResizeMethod {
+        match self {
+            ResizeMethod::Bilinear => ZResizeMethod::Bilinear,
+            ResizeMethod::Bicubic => ZResizeMethod::Bicubic,
+        }
+    }
+}
+
+impl From<ZResizeMethod> for ResizeMethod {
+    fn from(value: ZResizeMethod) -> Self {
+        match value {
+            ZResizeMethod::Bilinear => ResizeMethod::Bilinear,
+            ZResizeMethod::Bicubic => ResizeMethod::Bicubic,
         }
     }
 }


### PR DESCRIPTION
resolves #232

Quickly tested that it compiles with `maturin develop --release` and the following code runs:

```python
import zil

im_rust = zil.Image.open("r6.jpg")
im_rust.resize(500, 500, zil.ResizeMethod.Bilinear, in_place=True)
im_rust.save("a.png", format=zil.ImageFormat.PNG)
im_np = im_rust.to_numpy()
print(im_rust.dimensions())
print(im_np.shape)
```