### PR TITLE
[zune-jpegxl] Implement Display and Error for JxlEncodeErrors

### DIFF
--- a/crates/zune-jpegxl/src/errors.rs
+++ b/crates/zune-jpegxl/src/errors.rs
@@ -83,3 +83,12 @@ impl From<ZByteIoError> for JxlEncodeErrors {
         JxlEncodeErrors::IoErrors(value)
     }
 }
+
+impl core::fmt::Display for JxlEncodeErrors {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        writeln!(f, "{:?}", self)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for JxlEncodeErrors {}


### PR DESCRIPTION
I was interested in using this encoder directly instead of via `zune-image`, and tripped here while trying to handle the error that came. This PR adds impls of `core::fmt::Display` and `std::error::Error` (the latter gated on feature "std") for `JxlEncodeError` so that it can be used as an error directly.