### PR TITLE
Backport #187 to zune-jpeg 0.4.x

### DIFF
--- a/crates/zune-jpeg/Cargo.toml
+++ b/crates/zune-jpeg/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zune-jpeg"
-version = "0.4.13"
+version = "0.4.14"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg"

--- a/crates/zune-jpeg/Cargo.toml
+++ b/crates/zune-jpeg/Cargo.toml
@@ -16,8 +16,6 @@ description = "A fast, correct and safe jpeg decoder"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 
 
-[lib]
-crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 x86 = []


### PR DESCRIPTION
This is a PR to the zune-jpeg 0.4 branch that cherry-picks the fix in PR #187 and bump the release version.
Please make a new release with this fix. 
This bug prevent us to upgrade to the image crate to its version 0.25.x,  but if a 0.4.x version of the zune-jpeg would be released with this fix, that would solve the problem.
Thanks.