### PR TITLE
zune-jpeg skip unknown marker instead of errors.

### DIFF
--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -212,13 +212,7 @@ impl BitStream {
                                 self.aligned_buffer = $buffer << (64 - $bits_left);
                             }
 
-                            self.marker =
-                                Some(Marker::from_u8(next_byte as u8).ok_or_else(|| {
-                                    DecodeErrors::Format(format!(
-                                        "Unknown marker 0xFF{:X}",
-                                        next_byte
-                                    ))
-                                })?);
+                            self.marker = Marker::from_u8(next_byte as u8);
                             return Ok(false);
                         }
                     }


### PR DESCRIPTION
A better choice would be to skip unknown markers
Related issues:
[https://github.com/etemesi254/zune-image/issues/251](url)
[https://github.com/etemesi254/zune-image/issues/246](url)