### PR TITLE
crates/jpeg/idct: Fix bad coefficient rounding on the no AC coeff fast paths

### DIFF
--- a/crates/zune-jpeg/src/idct/neon.rs
+++ b/crates/zune-jpeg/src/idct/neon.rs
@@ -112,10 +112,11 @@ pub unsafe fn idct_int_neon_inner(
     let or_tree = (((row1 | row8) | (row2 | row3)) | ((row4 | row5) | (row6 | row7)));
 
     if or_tree.all_zero() {
-        // AC terms all zero, idct of the block is  is ( coeff[0] * qt[0] )/8 + 128 (bias)
+        // AC terms all zero, idct of the block is ( coeff[0] * qt[0] )/8 + 128 (bias)
         // (and clamped to 255)
-        let clamped_16 = ((in_vector[0] >> 3) + 128).clamp(0, 255) as i16;
-        let idct_value = vdupq_n_s16(clamped_16);
+        // Round by adding 0.5 * (1 << 3) and offset by adding (128 << 3) before scaling
+        let coeff = ((in_vector[0] + 4 + 1024) >> 3).clamp(0, 255) as i16;
+        let idct_value = vdupq_n_s16(coeff);
 
         macro_rules! store {
             ($pos:tt,$value:tt) => {

--- a/crates/zune-jpeg/src/idct/scalar.rs
+++ b/crates/zune-jpeg/src/idct/scalar.rs
@@ -27,8 +27,10 @@ pub fn idct_int(in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize
     // Don't check for zeroes inside loop, lift it and check outside
     // we want to accelerate the case with 63 0 ac coeff
     if &in_vector[1..] == &[0_i32; 63] {
-        // okay then if you work, yay, let's write you really quick
-        let coeff = [(((in_vector[0] >> 3) + 128) as i16).clamp(0, 255); 8];
+        // AC terms all zero, idct of the block is ( coeff[0] * qt[0] )/8 + 128 (bias)
+        // (and clamped to 255)
+        // Round by adding 0.5 * (1 << 3) and offset by adding (128 << 3) before scaling
+        let coeff = [((in_vector[0] + 4 + 1024) >> 3).clamp(0, 255) as i16; 8];
 
         macro_rules! store {
             ($index:tt) => {


### PR DESCRIPTION
IDCT calculations (all scalar and SIMD) on the fast paths with no AC coefficients incorrectly scaled the DC coefficient without rounding

This patch applies the correct formula with proper rounding

Fixes the remaining parts of issue:
https://github.com/etemesi254/zune-image/issues/249