### PR TITLE
`no_std` Tidy-up

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -24,15 +24,16 @@ jobs:
         # Target below does not have a standard library
       - run: rustup target add x86_64-unknown-uefi
         # Below targets run in no-std environments
-      - run: cargo build -p zune-core     --target x86_64-unknown-uefi --no-default-features
-      - run: cargo build -p zune-inflate  --target x86_64-unknown-uefi --no-default-features
-      - run: cargo build -p zune-jpeg     --target x86_64-unknown-uefi --no-default-features
-      - run: cargo build -p zune-png      --target x86_64-unknown-uefi --no-default-features
-      - run: cargo build -p zune-ppm      --target x86_64-unknown-uefi --no-default-features
-      - run: cargo build -p zune-qoi      --target x86_64-unknown-uefi --no-default-features
-      - run: cargo build -p zune-farbfeld --target x86_64-unknown-uefi --no-default-features
-      - run: cargo build -p zune-psd      --target x86_64-unknown-uefi --no-default-features
-      - run: cargo build -p zune-bmp      --target x86_64-unknown-uefi --no-default-features
-
+      - run: cargo build -p zune-core       --target x86_64-unknown-uefi --no-default-features --features log,serde
+      - run: cargo build -p zune-inflate    --target x86_64-unknown-uefi --no-default-features --features zlib,gzip
+      - run: cargo build -p zune-jpeg       --target x86_64-unknown-uefi --no-default-features --features log
+      - run: cargo build -p zune-png        --target x86_64-unknown-uefi --no-default-features --features log
+      - run: cargo build -p zune-ppm        --target x86_64-unknown-uefi --no-default-features --features log
+      - run: cargo build -p zune-qoi        --target x86_64-unknown-uefi --no-default-features --features log
+      - run: cargo build -p zune-farbfeld   --target x86_64-unknown-uefi --no-default-features --features log
+      - run: cargo build -p zune-psd        --target x86_64-unknown-uefi --no-default-features --features log
+      - run: cargo build -p zune-bmp        --target x86_64-unknown-uefi --no-default-features --features log,rgb_inverse
+      - run: cargo build -p zune-gif        --target x86_64-unknown-uefi --no-default-features --features log
+      - run: cargo build -p zune-jpegxl     --target x86_64-unknown-uefi --no-default-features --features log
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/.DS_Store
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Zlib"
 repository = "https://github.com/etemesi254/zune-image.git"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [workspace]

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-benches"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-bin/Cargo.toml
+++ b/crates/zune-bin/Cargo.toml
@@ -3,6 +3,7 @@ name = "zune-bin"
 version = "0.5.0-rc0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-bin"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-bmp/Cargo.toml
+++ b/crates/zune-bmp/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["bmp", "bmp-decoder", "decoder"]
 categories = ["multimedia::images"]
 exclude = ["fuzz/*"]
 description = "A fast BMP decoder"
-
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-bmp/Cargo.toml
+++ b/crates/zune-bmp/Cargo.toml
@@ -15,9 +15,11 @@ rust-version = "1.81.0"
 
 [features]
 log = ["zune-core/log"]
-std = ["zune-core/std"]
 rgb_inverse = []
 
 [dependencies]
 zune-core = { version = "0.5.0-rc1", path = "../zune-core" }
 log = "0.4.21"
+
+[dev-dependencies]
+zune-core = { version = "0.5.0-rc1", path = "../zune-core", features = ["std"] }

--- a/crates/zune-bmp/fuzz/Cargo.toml
+++ b/crates/zune-bmp/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.81.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/zune-bmp/src/lib.rs
+++ b/crates/zune-bmp/src/lib.rs
@@ -54,9 +54,6 @@
 //! use zune_bmp::BmpDecoder;
 //! // read from a file
 //! let source = BufReader::new(File::open("./image.bmp").unwrap());
-//! // only run when std is enabled, otherwise zune_core doesn't implement the ZByteReader trait
-//! // on File since it doesn't exist in `no_std` land
-//! #[cfg(feature = "std")]
 //! let decoder = BmpDecoder::new(source);
 //!
 //! ```
@@ -71,9 +68,8 @@
 //! benchmark just in case you think it's slowing you down in any way.
 //!
 #![no_std]
-#![macro_use]
-extern crate alloc;
 
+extern crate alloc;
 extern crate core;
 
 pub use zune_core;

--- a/crates/zune-capi/Cargo.toml
+++ b/crates/zune-capi/Cargo.toml
@@ -3,6 +3,7 @@ name = "zune-capi"
 version = "0.5.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-capi"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-core/Cargo.toml
+++ b/crates/zune-core/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/etemesi254/zune-image"
 keywords = ["image"]
 categories = ["multimedia::images", "multimedia::encoding"]
 license = "MIT OR Apache-2.0 OR Zlib"
+rust-version = "1.81.0"
 
 [features]
 # When present, we can use std facilities to detect

--- a/crates/zune-core/Cargo.toml
+++ b/crates/zune-core/Cargo.toml
@@ -20,4 +20,4 @@ std = []
 
 [dependencies]
 log = { version = "0.4.17", optional = true }
-serde = { version = "1.0.52", optional = true }
+serde = { version = "1.0.52", optional = true, default-features = false }

--- a/crates/zune-core/src/bytestream/reader.rs
+++ b/crates/zune-core/src/bytestream/reader.rs
@@ -453,6 +453,6 @@ where
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         use std::io::ErrorKind;
         self.read_bytes(buf)
-            .map_err(|e| std::io::Error::new(ErrorKind::Other, format!("{:?}", e)))
+            .map_err(|e| std::io::Error::new(ErrorKind::Other, alloc::format!("{:?}", e)))
     }
 }

--- a/crates/zune-core/src/bytestream/reader/std_readers.rs
+++ b/crates/zune-core/src/bytestream/reader/std_readers.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "std")]
 
+use alloc::vec::Vec;
 use std::io;
 use std::io::SeekFrom;
 

--- a/crates/zune-core/src/lib.rs
+++ b/crates/zune-core/src/lib.rs
@@ -43,10 +43,13 @@
 //!
 //!  
 //!
-#![cfg_attr(not(feature = "std"), no_std)]
-#![macro_use]
+#![no_std]
+
 extern crate alloc;
 extern crate core;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(not(feature = "log"))]
 pub mod log;

--- a/crates/zune-core/src/options/decoder.rs
+++ b/crates/zune-core/src/options/decoder.rs
@@ -450,7 +450,7 @@ impl DecoderOptions {
             // where we can do runtime check if feature is present
             #[cfg(feature = "std")]
             {
-                if is_x86_feature_detected!("sse2") {
+                if std::is_x86_feature_detected!("sse2") {
                     return true;
                 }
             }
@@ -483,7 +483,7 @@ impl DecoderOptions {
             // where we can do runtime check if feature is present
             #[cfg(feature = "std")]
             {
-                if is_x86_feature_detected!("sse3") {
+                if std::is_x86_feature_detected!("sse3") {
                     return true;
                 }
             }
@@ -515,7 +515,7 @@ impl DecoderOptions {
             // where we can do runtime check if feature is present
             #[cfg(feature = "std")]
             {
-                if is_x86_feature_detected!("sse4.1") {
+                if std::is_x86_feature_detected!("sse4.1") {
                     return true;
                 }
             }
@@ -547,7 +547,7 @@ impl DecoderOptions {
             // where we can do runtime check if feature is present
             #[cfg(feature = "std")]
             {
-                if is_x86_feature_detected!("avx") {
+                if std::is_x86_feature_detected!("avx") {
                     return true;
                 }
             }
@@ -579,7 +579,7 @@ impl DecoderOptions {
             // where we can do runtime check if feature is present
             #[cfg(feature = "std")]
             {
-                if is_x86_feature_detected!("avx2") {
+                if std::is_x86_feature_detected!("avx2") {
                     return true;
                 }
             }

--- a/crates/zune-farbfeld/Cargo.toml
+++ b/crates/zune-farbfeld/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-farbfe
 keywords = ["image"]
 categories = ["multimedia::images", "multimedia::encoding"]
 license = "MIT OR Apache-2.0 OR Zlib"
+rust-version = "1.81.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/crates/zune-farbfeld/src/lib.rs
+++ b/crates/zune-farbfeld/src/lib.rs
@@ -24,7 +24,7 @@
 //!
 //!
 #![no_std]
-#![macro_use]
+
 extern crate alloc;
 
 pub use decoder::*;

--- a/crates/zune-gif/Cargo.toml
+++ b/crates/zune-gif/Cargo.toml
@@ -3,6 +3,7 @@ name = "zune-gif"
 version = "0.5.0-rc0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-gif"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-gif/src/decoder.rs
+++ b/crates/zune-gif/src/decoder.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::log::trace;
 use zune_core::options::DecoderOptions;

--- a/crates/zune-gif/src/errors.rs
+++ b/crates/zune-gif/src/errors.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use std::fmt::Formatter;
+use core::fmt::Formatter;
 
 use zune_core::bytestream::ZByteIoError;
 
@@ -18,7 +18,7 @@ pub enum GifDecoderErrors {
     TooSmallSize(usize, usize)
 }
 impl Debug for GifDecoderErrors {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
             GifDecoderErrors::NotAGif => {
                 writeln!(f, "Not a gif, magic bytes didn't match")

--- a/crates/zune-gif/src/lib.rs
+++ b/crates/zune-gif/src/lib.rs
@@ -1,3 +1,9 @@
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate core;
+
 mod decoder;
 mod enums;
 mod errors;

--- a/crates/zune-hdr/Cargo.toml
+++ b/crates/zune-hdr/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-hdr"
 keywords = ["image"]
 categories = ["multimedia::images", "multimedia::encoding", ]
 license = "MIT OR Apache-2.0 OR Zlib"
+rust-version = "1.81.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/crates/zune-hdr/fuzz/Cargo.toml
+++ b/crates/zune-hdr/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.81.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/zune-image/Cargo.toml
+++ b/crates/zune-image/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 keywords = ["image", "decoder", "encoder", "image-processing"]
 categories = ["multimedia::images"]
 description = "An image library, contiaining necessary capabilities to decode, manipulate and encode images"
+rust-version = "1.81.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 # Single based image decoders and encoders

--- a/crates/zune-imageprocs/Cargo.toml
+++ b/crates/zune-imageprocs/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 keywords = ["image", "image-processing"]
 categories = ["multimedia::images"]
 description = "Common image processing routines for zune-image"
-
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-inflate/Cargo.toml
+++ b/crates/zune-inflate/Cargo.toml
@@ -15,10 +15,8 @@ rust-version = "1.81.0"
 [features]
 zlib = ["simd-adler32"]
 gzip = []
-std = ["simd-adler32/std"]
 
-
-default = ["zlib", "gzip", "std"]
+default = ["zlib", "gzip"]
 
 [dependencies]
 simd-adler32 = { version = "0.3.4", optional = true, default-features = false }

--- a/crates/zune-inflate/Cargo.toml
+++ b/crates/zune-inflate/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/etemesi254/zune-image/tree/main/zune-inflate"
 keywords = ["compression", "inflate", "deflate"]
 categories = ["compression"]
 license = "MIT OR Apache-2.0 OR Zlib"
+rust-version = "1.81.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]

--- a/crates/zune-inflate/fuzz/Cargo.toml
+++ b/crates/zune-inflate/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.81.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/zune-inflate/src/errors.rs
+++ b/crates/zune-inflate/src/errors.rs
@@ -114,5 +114,4 @@ impl Display for InflateDecodeErrors {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for InflateDecodeErrors {}
+impl core::error::Error for InflateDecodeErrors {}

--- a/crates/zune-inflate/src/lib.rs
+++ b/crates/zune-inflate/src/lib.rs
@@ -86,7 +86,8 @@
 //! [libdeflater]: https://github.com/adamkewley/libdeflater
 //! [flate2-rs]: https://github.com/rust-lang/flate2-rs
 //!
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
 extern crate alloc;
 
 pub use crate::decoder::{DeflateDecoder, DeflateOptions};

--- a/crates/zune-jpeg/Cargo.toml
+++ b/crates/zune-jpeg/Cargo.toml
@@ -21,9 +21,8 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
 [features]
 x86 = []
 neon = []
-std = ["zune-core/std"]
 log = ["zune-core/log"]
-default = ["x86", "neon", "std"]
+default = ["x86", "neon"]
 
 
 [dependencies]

--- a/crates/zune-jpeg/Cargo.toml
+++ b/crates/zune-jpeg/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["jpeg", "jpeg-decoder", "decoder"]
 categories = ["multimedia::images"]
 exclude = ["/benches/images/*", "/tests/*", "/.idea/*", "/.gradle/*", "/test-images/*", "fuzz/*"]
 description = "A fast, correct and safe jpeg decoder"
+rust-version = "1.81.0"
 
 [lints.rust]
 # Disable feature checker for fuzzing since it's used and cargo doesn't

--- a/crates/zune-jpeg/fuzz/Cargo.toml
+++ b/crates/zune-jpeg/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.81.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/zune-jpeg/src/errors.rs
+++ b/crates/zune-jpeg/src/errors.rs
@@ -53,8 +53,7 @@ pub enum DecodeErrors {
     IoErrors(ZByteIoError)
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeErrors {}
+impl core::error::Error for DecodeErrors {}
 
 impl From<&'static str> for DecodeErrors {
     fn from(data: &'static str) -> Self {

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -102,8 +102,9 @@
 // no_std compatibility
 #![deny(clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
 #![cfg_attr(not(any(feature = "x86", feature = "neon")), forbid(unsafe_code))]
-#![cfg_attr(not(feature = "std"), no_std)]
-#![macro_use]
+#![no_std]
+
+#[macro_use]
 extern crate alloc;
 extern crate core;
 

--- a/crates/zune-jpegxl/Cargo.toml
+++ b/crates/zune-jpegxl/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.81.0"
 zune-core = { version = "^0.5.0-rc0", path = "../zune-core" }
 
 [features]
-threads = []
+threads = ["std"]
 std = []
 log = ["zune-core/log"]
 default = ["threads", "std"]

--- a/crates/zune-jpegxl/Cargo.toml
+++ b/crates/zune-jpegxl/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["jpeg-xl", "jpeg-xl-decoder", "decoder", "jxl"]
 categories = ["multimedia::images"]
 exclude = []
 description = "A simple, fast and fully safe modular jxl encoder"
+rust-version = "1.81.0"
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/zune-jpegxl/src/errors.rs
+++ b/crates/zune-jpegxl/src/errors.rs
@@ -90,5 +90,4 @@ impl core::fmt::Display for JxlEncodeErrors {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for JxlEncodeErrors {}
+impl core::error::Error for JxlEncodeErrors {}

--- a/crates/zune-jpegxl/src/lib.rs
+++ b/crates/zune-jpegxl/src/lib.rs
@@ -81,10 +81,13 @@
 //! ```
 //!
 #![forbid(unsafe_code)]
-#![cfg_attr(not(feature = "std"), no_std)]
-#![macro_use]
+#![no_std]
+
 extern crate alloc;
 extern crate core;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub use encoder::JxlSimpleEncoder;
 pub use errors::JxlEncodeErrors;

--- a/crates/zune-opencl/Cargo.toml
+++ b/crates/zune-opencl/Cargo.toml
@@ -3,6 +3,7 @@ name = "zune-opencl"
 version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-opencl"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-png/Cargo.toml
+++ b/crates/zune-png/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["png", "png-decoder", "decoder"]
 categories = ["multimedia::images"]
 exclude = ["/benches/images/*", "/tests/*", "/.idea/*", "/.gradle/*", "/test-images/*", "fuzz/*"]
 description = "A fast, correct and safe png decoder"
-
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-png/fuzz/Cargo.toml
+++ b/crates/zune-png/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.81.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/zune-png/src/error.rs
+++ b/crates/zune-png/src/error.rs
@@ -39,8 +39,7 @@ impl Display for PngDecodeErrors {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for PngDecodeErrors {}
+impl core::error::Error for PngDecodeErrors {}
 
 impl Debug for PngDecodeErrors {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/crates/zune-png/src/filters/sse4.rs
+++ b/crates/zune-png/src/filters/sse4.rs
@@ -191,7 +191,7 @@ unsafe fn de_filter_sub_generic_sse2<const SIZE: usize>(raw: &[u8], current: &mu
 pub fn de_filter_sub_sse2<const SIZE: usize>(raw: &[u8], current: &mut [u8]) {
     #[cfg(feature = "std")]
     {
-        if !is_x86_feature_detected!("sse2") {
+        if !std::is_x86_feature_detected!("sse2") {
             panic!("Internal error, calling platform specific function where not supported")
         }
     }
@@ -268,7 +268,7 @@ unsafe fn de_filter_paeth_sse41_inner<const SIZE: usize>(
 pub fn de_filter_paeth_sse41<const SIZE: usize>(prev_row: &[u8], raw: &[u8], current: &mut [u8]) {
     #[cfg(feature = "std")]
     {
-        if !is_x86_feature_detected!("sse4.1") {
+        if !std::is_x86_feature_detected!("sse4.1") {
             panic!("Internal error, calling platform specific function where not supported")
         }
     }
@@ -325,7 +325,7 @@ unsafe fn defilter_avg_sse2_inner<const SIZE: usize>(
 pub fn defilter_avg_sse<const SIZE: usize>(prev_row: &[u8], raw: &[u8], current: &mut [u8]) {
     #[cfg(feature = "std")]
     {
-        if !is_x86_feature_detected!("sse2") {
+        if !std::is_x86_feature_detected!("sse2") {
             panic!("Internal error, calling platform specific function where not supported")
         }
     }

--- a/crates/zune-png/src/lib.rs
+++ b/crates/zune-png/src/lib.rs
@@ -160,10 +160,14 @@
 //!
 //!
 //!
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![allow(clippy::op_ref, clippy::identity_op)]
+
 extern crate alloc;
 extern crate core;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "std")]
 pub use apng::post_process_image;

--- a/crates/zune-png/src/utils.rs
+++ b/crates/zune-png/src/utils.rs
@@ -36,12 +36,12 @@ fn convert_be_to_le_u16(out: &mut [u8], _use_sse4: bool) {
     #[cfg(feature = "std")]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        if _use_sse4 && is_x86_feature_detected!("avx2") {
+        if _use_sse4 && std::is_x86_feature_detected!("avx2") {
             unsafe {
                 return avx::convert_be_to_ne_avx(out);
             };
         }
-        if _use_sse4 && is_x86_feature_detected!("ssse3") {
+        if _use_sse4 && std::is_x86_feature_detected!("ssse3") {
             unsafe {
                 return sse::convert_be_to_ne_sse4(out);
             }

--- a/crates/zune-ppm/Cargo.toml
+++ b/crates/zune-ppm/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["ppm", "ppm-decoder", "decoder"]
 categories = ["multimedia::images"]
 exclude = ["fuzz/*"]
 description = "Portable Pixmap and Portable Floatmap Format Decoder and Encoder"
-
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-ppm/fuzz/Cargo.toml
+++ b/crates/zune-ppm/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.81.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/zune-psd/Cargo.toml
+++ b/crates/zune-psd/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["psd", "psd-decoder", "decoder"]
 categories = ["multimedia::images"]
 exclude = ["fuzz/*"]
 description = "Photoshop Simple PSD decoder"
-
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/zune-psd/fuzz/Cargo.toml
+++ b/crates/zune-psd/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.81.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/zune-python/Cargo.toml
+++ b/crates/zune-python/Cargo.toml
@@ -3,6 +3,7 @@ name = "zune-python"
 version = "0.4.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-python"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/crates/zune-qoi/Cargo.toml
+++ b/crates/zune-qoi/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["qoi", "qoi-decoder", "decoder", "qoi-encoder", "encoder"]
 categories = ["multimedia::images"]
 exclude = ["fuzz/*"]
 description = "Quite Ok Image (QOI) decoder and encoder part of the zune-image family"
-
+rust-version = "1.81.0"
 
 [features]
 log = ["zune-core/log"]

--- a/crates/zune-qoi/Cargo.toml
+++ b/crates/zune-qoi/Cargo.toml
@@ -13,8 +13,7 @@ rust-version = "1.81.0"
 
 [features]
 log = ["zune-core/log"]
-std = ["zune-core/std"]
-default = ["std", "log"]
+default = ["log"]
 [dependencies]
 zune-core = { path = "../zune-core", version = "^0.5.0-rc0" }
 

--- a/crates/zune-qoi/fuzz/Cargo.toml
+++ b/crates/zune-qoi/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"
+rust-version = "1.81.0"
 
 [package.metadata]
 cargo-fuzz = true

--- a/crates/zune-qoi/src/errors.rs
+++ b/crates/zune-qoi/src/errors.rs
@@ -147,11 +147,9 @@ impl Display for QoiErrors {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for QoiEncodeErrors {}
+impl core::error::Error for QoiEncodeErrors {}
 
-#[cfg(feature = "std")]
-impl std::error::Error for QoiErrors {}
+impl core::error::Error for QoiErrors {}
 
 impl From<ZByteIoError> for QoiEncodeErrors {
     fn from(value: ZByteIoError) -> Self {

--- a/crates/zune-qoi/src/lib.rs
+++ b/crates/zune-qoi/src/lib.rs
@@ -17,8 +17,8 @@
 //! ## `no_std`
 //! You can use `no_std` with alloc feature to compile for `no_std` endpoints
 
-#![cfg_attr(not(feature = "std"), no_std)]
-#![macro_use]
+#![no_std]
+
 extern crate alloc;
 extern crate core;
 

--- a/crates/zune-wasm/Cargo.toml
+++ b/crates/zune-wasm/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["caleb <etemesicaleb@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Zlib"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-wasm"
+rust-version = "1.81.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-tests"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Objective

- Split off low-controversy component of #263

## Solution

__Refer to individual commits for further details__

- Added `rust-version = "1.81.0"` to all crates, making it easier to maintain MSRV going forward. Exact version chosen for compatibility with `core::error::Error`.
- Switched to `core` implicit prelude instead of conditionally changing the prelude based on a possible `std` feature. This makes migrating currently `std`-only features to `no_std` easier in the future.
- Updated CI to test all `no_std` compatible features, not just `--no-default-features`.
- Updated `zune-core` to allow `serde` feature in `no_std`
- Updated `zune-inflate` to remove `std` feature (unused)
- Updated `zune-jpeg` to remove `std` feature (unused)
- Updated `zune-qoi` to remove `std` feature (unused)
- Updated `zune-bmp` to remove `std` feature (unused), opting for adding `std` feature in `dev-dependencies` instead
- Made `zune-gif` `no_std` (only minor changes required)
- Updated `zune-jpegxl` to explicitly require `std` in the `threads` feature