### PR TITLE
Properly sets marker after stream end

### DIFF
--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -32,7 +32,7 @@ use crate::bitstream::BitStream;
 use crate::components::{ComponentID, SampleRatios};
 use crate::decoder::{JpegDecoder, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
-use crate::headers::{parse_sos};
+use crate::headers::parse_sos;
 use crate::marker::Marker;
 use crate::mcu::DCT_BLOCK;
 use crate::misc::{calculate_padded_width, setup_component_params};
@@ -49,7 +49,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     )]
     #[inline(never)]
     pub(crate) fn decode_mcu_ycbcr_progressive(
-        &mut self, pixels: &mut [u8],
+        &mut self, pixels: &mut [u8]
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
 
@@ -81,7 +81,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             && self.input_colorspace.num_components() > 1
             && self.options.jpeg_get_out_colorspace().num_components() == 1
             && (self.sub_sample_ratio == SampleRatios::V
-            || self.sub_sample_ratio == SampleRatios::HV)
+                || self.sub_sample_ratio == SampleRatios::HV)
         {
             // For a specific set of images, e.g interleaved,
             // when converting from YcbCr to grayscale, we need to
@@ -117,7 +117,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             self.succ_high,
             self.succ_low,
             self.spec_start,
-            self.spec_end,
+            self.spec_end
         );
 
         // there are multiple scans in the stream, this should resolve the first scan
@@ -143,7 +143,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         self.succ_high,
                         self.succ_low,
                         self.spec_start,
-                        self.spec_end,
+                        self.spec_end
                     );
                     // after every SOS, marker, parse data for that scan.
                     self.parse_entropy_coded_data(&mut stream, &mut block)?;
@@ -182,6 +182,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     marker = marker_n;
                 }
                 Err(e) => {
+                    marker = Marker::EOI;
                     if self.options.strict_mode() {
                         return Err(e);
                     }
@@ -195,7 +196,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     #[allow(clippy::too_many_lines, clippy::cast_sign_loss)]
     fn parse_entropy_coded_data(
-        &mut self, stream: &mut BitStream, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        &mut self, stream: &mut BitStream, buffer: &mut [Vec<i16>; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         stream.reset();
         self.components.iter_mut().for_each(|x| x.dc_pred = 0);
@@ -229,7 +230,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
             if self.components[k].component_id == ComponentID::Y
                 && (self.components[k].vertical_sample != 1
-                || self.components[k].horizontal_sample != 1)
+                    || self.components[k].horizontal_sample != 1)
                 || !self.is_interleaved
             {
                 // For Y channel  or non interleaved scans ,
@@ -281,7 +282,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 &mut self.stream,
                                 dc_table,
                                 &mut data[0],
-                                dc_pred,
+                                dc_pred
                             )?;
                         } else {
                             // refining scans for this MCU
@@ -384,11 +385,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 let position = 64 * (x2 + y2 * component.width_stride / 8);
                                 let buf_n = &mut buffer[n];
 
-
                                 let Some(data) = &mut buf_n.get_mut(position) else {
                                     // TODO: (CAE), this is another weird sub-sampling bug, so on fix
                                     // remove this
-                                    return Err(DecodeErrors::FormatStatic("Invalid image"))
+                                    return Err(DecodeErrors::FormatStatic("Invalid image"));
                                 };
 
                                 if self.succ_high == 0 {
@@ -396,7 +396,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                         &mut self.stream,
                                         huff_table,
                                         data,
-                                        &mut component.dc_pred,
+                                        &mut component.dc_pred
                                     )?;
                                 } else {
                                     stream.decode_prog_dc_refine(&mut self.stream, data)?;
@@ -420,7 +420,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::needless_range_loop, clippy::cast_sign_loss)]
     fn finish_progressive_decoding(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], _mcu_width: usize, pixels: &mut [u8],
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], _mcu_width: usize, pixels: &mut [u8]
     ) -> Result<(), DecodeErrors> {
         // This function is complicated because we need to replicate
         // the function in mcu.rs
@@ -466,7 +466,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // components.
             if min(
                 self.options.jpeg_get_out_colorspace().num_components() - 1,
-                pos,
+                pos
             ) == pos
                 || self.input_colorspace == ColorSpace::YCCK
                 || self.input_colorspace == ColorSpace::CMYK
@@ -524,13 +524,13 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
                         // See https://github.com/etemesi254/zune-image/issues/262 sample 3.
                         let Some(qt_slice) = slice.get(start..start + 64) else {
-                            return Err(DecodeErrors::FormatStatic("Invalid slice , would panic, invalid image"))
+                            return Err(DecodeErrors::FormatStatic(
+                                "Invalid slice , would panic, invalid image"
+                            ));
                         };
                         // dequantize
-                        for ((x, out), qt_val) in qt_slice
-                            .iter()
-                            .zip(tmp.iter_mut())
-                            .zip(qt_table.iter())
+                        for ((x, out), qt_val) in
+                            qt_slice.iter().zip(tmp.iter_mut()).zip(qt_table.iter())
                         {
                             *out = i32::from(*x) * qt_val;
                         }
@@ -560,7 +560,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 width,
                 padded_width,
                 &mut pixels_written,
-                &mut upsampler_scratch_space,
+                &mut upsampler_scratch_space
             )?;
         }
 
@@ -592,10 +592,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 ///
 /// This reads until it gets a marker or end of file is encountered
 pub fn get_marker<T>(
-    reader: &mut ZReader<T>, stream: &mut BitStream,
+    reader: &mut ZReader<T>, stream: &mut BitStream
 ) -> Result<Marker, DecodeErrors>
 where
-    T: ZByteReaderTrait,
+    T: ZByteReaderTrait
 {
     if let Some(marker) = stream.marker {
         stream.marker = None;


### PR DESCRIPTION
After stream end marker of stream end wasn't set so it causes excessive reads.
Run rustfmt also on that file.

This is not complete fix, it only returns the behaviour of previous versions. Therefore, it does only partial progressive decoding. 

Closes #270 