### PR TITLE
Fix mod path for compiling neon64.rs with rustc 1.84

### DIFF
--- a/crates/zune-jpeg/src/color_convert/neon64.rs
+++ b/crates/zune-jpeg/src/color_convert/neon64.rs
@@ -10,7 +10,7 @@
 //! NEON is mandatory on aarch64.
 
 #![cfg(all(feature = "neon", target_arch = "aarch64"))]
-use std::arch::aarch64::*;
+use core::arch::aarch64::*;
 
 use crate::color_convert::scalar::{CB_CF, CR_CF, C_G_CB_COEF_2, C_G_CR_COEF_1, YUV_RND, Y_CF};
 


### PR DESCRIPTION
While running cargo tests for zune-jpeg with neon feature enabled (with Rust 1.84), we run into:  error[E0433]: failed to resolve: use of undeclared crate or module `std` The import should be from core::arch instead of std::arch

Test log: https://objectstorage.prodstack5.canonical.com/swift/v1/AUTH_0f9aae918d5b4744bf7b827671c86842/autopkgtest-questing/questing/arm64/r/rust-zune-jpeg/20250628_130958_25317@/log.gz