### PR TITLE
Avoid bitshifts in progressive dc hotpath

### DIFF
--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -424,6 +424,8 @@ where
 
                     self.parse_marker_inner(n)?;
 
+                    // break after reading the start of scan.
+                    // what follows is the image data
                     if n == Marker::SOS {
                         self.headers_decoded = true;
                         trace!("Input colorspace {:?}", self.input_colorspace);
@@ -519,10 +521,6 @@ where
             // Start of Scan Data
             Marker::SOS => {
                 parse_sos(self)?;
-
-                // break after reading the start of scan.
-                // what follows is the image data
-                return Ok(());
             }
             Marker::EOI => return Err(DecodeErrors::FormatStatic("Premature End of image")),
 


### PR DESCRIPTION
Since the `successive_low` changes infrequently, it is probably faster to store the progressively added bit mask in a precalculated form rather than having bit shifts for every single time it is applied.

---

I'm a bit confused, where'd the benchmarks go?