### PR TITLE
Prefer the use of div_ceil, error messages on components

### DIFF
--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -281,14 +281,14 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
 
 /// Parse a start of scan data
 pub(crate) fn parse_sos<T: ZByteReaderTrait>(
-    image: &mut JpegDecoder<T>
+    image: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors> {
     // Scan header length
     let ls = image.stream.get_u16_be_err()?;
     // Number of image components in scan
     let ns = image.stream.read_u8_err()?;
 
-    let mut seen = [-1; { MAX_COMPONENTS + 1 }];
+    let mut seen: [_; 5] = [-1; { MAX_COMPONENTS + 1 }];
 
     image.num_scans = ns;
 
@@ -301,7 +301,7 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
     // Check number of components.
     if !(1..5).contains(&ns) {
         return Err(DecodeErrors::SosError(format!(
-            "Number of components in start of scan should be less than 3 but more than 0. Found {ns}"
+            "Invalid number of components in start of scan {ns}, expected in range 1..5"
         )));
     }
 
@@ -340,9 +340,9 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
 
         if j == image.info.components {
             return Err(DecodeErrors::SofError(format!(
-                "Invalid component id {}, expected a value between 0 and {}",
+                "Invalid component id {}, expected one one of {:?}",
                 id,
-                image.components.len()
+                image.components.iter().map(|c| c.id).collect::<Vec<_>>()
             )));
         }
 

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -237,8 +237,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             {
                 // For Y channel  or non interleaved scans ,
                 // mcu's is the image dimensions divided by 8
-                mcu_width = ((self.info.width + 7) / 8) as usize;
-                mcu_height = ((self.info.height + 7) / 8) as usize;
+                mcu_width = self.info.width.div_ceil(8) as usize;
+                mcu_height = self.info.height.div_ceil(8) as usize;
             } else {
                 // For other channels, in an interleaved mcu, number of MCU's
                 // are determined by some weird maths done in headers.rs->parse_sos()
@@ -475,7 +475,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         } else {
             // For non-interleaved images( (1*1) subsampling)
             // number of MCU's are the widths (+7 to account for paddings) divided by 8.
-            ((self.info.height + 7) / 8) as usize
+            self.info.height.div_ceil(8) as usize
         };
 
         // Size of our output image(width*height)

--- a/crates/zune-jpeg/src/misc.rs
+++ b/crates/zune-jpeg/src/misc.rs
@@ -218,9 +218,9 @@ pub(crate) fn setup_component_params<T: ZByteReaderTrait>(
         img.mcu_width = img.h_max * 8;
         img.mcu_height = img.v_max * 8;
         // Number of MCU's per width
-        img.mcu_x = (usize::from(img.info.width) + img.mcu_width - 1) / img.mcu_width;
+        img.mcu_x = usize::from(img.info.width).div_ceil(img.mcu_width);
         // Number of MCU's per height
-        img.mcu_y = (usize::from(img.info.height) + img.mcu_height - 1) / img.mcu_height;
+        img.mcu_y = usize::from(img.info.height).div_ceil(img.mcu_height);
 
         if img.h_max != 1 || img.v_max != 1 {
             // interleaved images have horizontal and vertical sampling factors

--- a/crates/zune-jpeg/src/misc.rs
+++ b/crates/zune-jpeg/src/misc.rs
@@ -51,6 +51,8 @@ pub const START_OF_FRAME_PROG_DCT_AR: u16 = 0xffca;
 pub const START_OF_FRAME_LOS_SEQ_AR: u16 = 0xffcb;
 
 /// Undo run length encoding of coefficients by placing them in natural order
+///
+/// This is an index from position-in-bitstream to position-in-row-major-order.
 #[rustfmt::skip]
 pub const UN_ZIGZAG: [usize; 64 + 16] = [
      0,  1,  8, 16,  9,  2,  3, 10,


### PR DESCRIPTION
Using `div_ceil` (rust-version 1.73) avoids any concerns of overflows that might occur while running this operation and is, imo, far easier to read by avoiding the duplication of divisor. While reviewing these I came across two error messages related to components that were incongruent to the code they error'd on.