### PR TITLE
Fix handling of truncated images

### DIFF
--- a/tests/tests/jpeg.json
+++ b/tests/tests/jpeg.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "incomplete_image.jpg",
-    "hash": 126839255814149225135854928139070914903,
+    "hash": 112983843699345551343619021597037243902,
     "comment": "The image isn't full"
   },
   {


### PR DESCRIPTION
This PR improves how zune-jpeg handles truncated files. More specifically:

1. Fix premature end detection: While 37 is a wonderful lucky prime, I think the previous detection logic didn't quite work. At least I could never get that branch to trigger, and I had some images for which it (incorrectly) never triggered.
My amateur understanding is that `overread_by` is only ever increased by `usize::from(reader.eof()?);`, so I don't quite understand how we could produce false negatives here. Testing seems to confirm that. Please take a look, you have more expertise here. :)
2. Fill the remaining image with gray pixels. This is often visually nicer (and also matches what libjpeg-turbo does). Happy to take that part out if you think it doesn't make sense.

Thanks!