### PR TITLE
Fix decoding on 'scalar' idct, fulfill contract for 4x4 IDCT on scalar

### DIFF
--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -133,6 +133,9 @@ pub struct JpegDecoder<T: ZByteReaderTrait> {
     // of this struct, we check if we can switch to a faster one which
     // depend on certain CPU extensions.
     pub(crate) idct_func: IDCTPtr,
+    /// Specialized IDCT when we can guarantee only few coefficients are non-zero.
+    ///
+    /// **The callee must uphold a contract**. See [`choose_idct_4x4_func`].
     pub(crate) idct_4x4_func: IDCTPtr,
     pub(crate) idct_1x1_func: IDCTPtr,
     // Color convert function which acts on 16 YCbCr values

--- a/crates/zune-jpeg/src/idct.rs
+++ b/crates/zune-jpeg/src/idct.rs
@@ -76,11 +76,17 @@ pub fn choose_idct_func(options: &DecoderOptions) -> IDCTPtr {
     return idct_int;
 }
 
+/// Choose a function to implement 4x4 IDCT.
+///
+/// These functions get the same input but have an extra contract: Only the first 4x4 block of
+/// coefficients are non-zero. All other entries are zeroed.
+///
+/// **The callee must uphold that contract on return**
 pub fn choose_idct_4x4_func(_options: &DecoderOptions) -> IDCTPtr {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[cfg(feature = "x86")]
     {
-        if _options.use_avx2() {
+        if false && _options.use_avx2() {
             debug!("Using vector integer IDCT");
             return |a: &mut [i32; 64], b: &mut [i16], c: usize| {
                 // SAFETY: `options.use_avx2()` only returns true if avx2 is supported.

--- a/crates/zune-jpeg/src/idct/scalar.rs
+++ b/crates/zune-jpeg/src/idct/scalar.rs
@@ -297,4 +297,9 @@ pub fn idct4x4(in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize)
 
         pos += stride;
     }
+
+    in_vector[32..36].fill(0);
+    in_vector[40..44].fill(0);
+    in_vector[48..52].fill(0);
+    in_vector[56..60].fill(0);
 }


### PR DESCRIPTION
sorry for the broken release `0.5.5` that resulted off that.

In [5ffef721ed9ccc0d36120aec4092efb981a62572](https://github.com/etemesi254/zune-image/pull/306/commits/5ffef721ed9ccc0d36120aec4092efb981a62572) (from #306, it probably should have had separate PRs) I had introduced an optimization that would avoid overwriting the whole 64 coefficient entries for cases where only the upper 4x4 matrix was touched.

However, I overlooked the implications on the scalar code for this. Contrary to its SIMD counterpart it would clobber entries in the first column of the matrix (i.e indices 32-36, 40-44 so on). There was an implicit contract in place now that it would not do so. It is important we reset these entries as the other code will not.

This issues them as separate writes that LLVM should be smart enough to interleave with the rest of the code here.

The result of this was that the _next_ full IDCT block of 8x8 coefficients would get some corrupted non-zero entries where it should have had zeroed entries.