### PR TITLE
Re-enable avx2 IDCT

### DIFF
--- a/crates/zune-jpeg/src/idct.rs
+++ b/crates/zune-jpeg/src/idct.rs
@@ -86,7 +86,7 @@ pub fn choose_idct_4x4_func(_options: &DecoderOptions) -> IDCTPtr {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[cfg(feature = "x86")]
     {
-        if false && _options.use_avx2() {
+        if _options.use_avx2() {
             debug!("Using vector integer IDCT");
             return |a: &mut [i32; 64], b: &mut [i16], c: usize| {
                 // SAFETY: `options.use_avx2()` only returns true if avx2 is supported.


### PR DESCRIPTION
For #320 I'd disabled avx2 to get the reproduction to work on the `image` configuration, obviously we want avx2 acceleration in the eventual release. Thanks @awxkee for spotting it.