### PR TITLE
[#325] adding rust-version to all Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "zune-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zune-jpeg 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zune-jpeg 0.5.6",
 ]
 
 [[package]]
@@ -1403,7 +1403,7 @@ dependencies = [
  "zune-image",
  "zune-imageprocs",
  "zune-inflate",
- "zune-jpeg 0.5.6",
+ "zune-jpeg 0.5.7",
  "zune-png",
  "zune-qoi",
 ]
@@ -1490,7 +1490,7 @@ dependencies = [
  "zune-core 0.5.0",
  "zune-farbfeld",
  "zune-hdr",
- "zune-jpeg 0.5.6",
+ "zune-jpeg 0.5.7",
  "zune-jpegxl",
  "zune-png",
  "zune-ppm",
@@ -1519,18 +1519,18 @@ dependencies = [
 [[package]]
 name = "zune-jpeg"
 version = "0.5.6"
-dependencies = [
- "zune-core 0.5.0",
- "zune-ppm",
-]
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f520eebad972262a1dde0ec455bce4f8b298b1e5154513de58c114c4c54303e8"
 dependencies = [
  "zune-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.7"
+dependencies = [
+ "zune-core 0.5.0",
+ "zune-ppm",
 ]
 
 [[package]]
@@ -1582,7 +1582,7 @@ dependencies = [
  "zune-bmp",
  "zune-core 0.5.0",
  "zune-inflate",
- "zune-jpeg 0.5.6",
+ "zune-jpeg 0.5.7",
  "zune-png",
  "zune-psd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune"
 version = "0.5.3"
+rust-version = "1.87.0"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Zlib"
 repository = "https://github.com/etemesi254/zune-image.git"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-benches"
 version = "0.1.0"
+rust-version = "1.87.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/zune-bin/Cargo.toml
+++ b/crates/zune-bin/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-bin"
 version = "0.5.0-rc1"
+rust-version = "1.87.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-bin"
 

--- a/crates/zune-bmp/Cargo.toml
+++ b/crates/zune-bmp/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-bmp"
 version = "0.5.0-rc4"
+rust-version = "1.87.0"
 edition = "2021"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-bmp"

--- a/crates/zune-bmp/fuzz/Cargo.toml
+++ b/crates/zune-bmp/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-bmp-fuzz"
 version = "0.0.0"
+rust-version = "1.87.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"

--- a/crates/zune-capi/Cargo.toml
+++ b/crates/zune-capi/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-capi"
 version = "0.5.0"
+rust-version = "1.87.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-capi"
 

--- a/crates/zune-core/Cargo.toml
+++ b/crates/zune-core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-core"
 version = "0.5.0"
+rust-version = "1.87.0"
 edition = "2021"
 description = "Core utilities for image processing in the zune family of crates"
 exclude = ["tests/"]

--- a/crates/zune-farbfeld/Cargo.toml
+++ b/crates/zune-farbfeld/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-farbfeld"
 version = "0.5.0-rc0"
+rust-version = "1.87.0"
 edition = "2021"
 description = "Farbfeld image decoder"
 exclude = ["tests/"]

--- a/crates/zune-gif/Cargo.toml
+++ b/crates/zune-gif/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-gif"
 version = "0.5.0-rc0"
+rust-version = "1.87.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-gif"
 

--- a/crates/zune-hdr/Cargo.toml
+++ b/crates/zune-hdr/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-hdr"
 version = "0.5.0-rc0"
+rust-version = "1.87.0"
 edition = "2021"
 description = "Radiance/HDR image decoder and encoder"
 exclude = ["fuzz/"]

--- a/crates/zune-hdr/fuzz/Cargo.toml
+++ b/crates/zune-hdr/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-hdr-fuzz"
 version = "0.0.0"
+rust-version = "1.87.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"

--- a/crates/zune-image/Cargo.toml
+++ b/crates/zune-image/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-image"
 version = "0.5.0-rc0"
+rust-version = "1.87.0"
 edition = "2021"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-image"

--- a/crates/zune-imageprocs/Cargo.toml
+++ b/crates/zune-imageprocs/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-imageprocs"
 version = "0.5.0-rc0"
+rust-version = "1.87.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-imageprocs"
 license = "MIT OR Apache-2.0 OR Zlib"

--- a/crates/zune-inflate/Cargo.toml
+++ b/crates/zune-inflate/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-inflate"
 version = "0.2.0"
+rust-version = "1.87.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-inflate"
 description = "A heavily optimized deflate decompressor in Pure Rust"

--- a/crates/zune-inflate/fuzz/Cargo.toml
+++ b/crates/zune-inflate/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-inflate-fuzz"
 version = "0.0.0"
+rust-version = "1.87.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"

--- a/crates/zune-jpeg/Cargo.toml
+++ b/crates/zune-jpeg/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-jpeg"
 version = "0.5.7"
+rust-version = "1.87.0"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg"

--- a/crates/zune-jpeg/fuzz/Cargo.toml
+++ b/crates/zune-jpeg/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-jpeg-fuzz"
 version = "0.0.0"
+rust-version = "1.87.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"

--- a/crates/zune-jpegxl/Cargo.toml
+++ b/crates/zune-jpegxl/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-jpegxl"
 version = "0.5.0-rc1"
+rust-version = "1.87.0"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpegxl"

--- a/crates/zune-png/Cargo.toml
+++ b/crates/zune-png/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-png"
 version = "0.5.0-rc1"
+rust-version = "1.87.0"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/zune-png"

--- a/crates/zune-png/fuzz/Cargo.toml
+++ b/crates/zune-png/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-png-fuzz"
 version = "0.0.0"
+rust-version = "1.87.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"

--- a/crates/zune-ppm/Cargo.toml
+++ b/crates/zune-ppm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-ppm"
 version = "0.5.0-rc0"
+rust-version = "1.87.0"
 edition = "2021"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-ppm"

--- a/crates/zune-ppm/fuzz/Cargo.toml
+++ b/crates/zune-ppm/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-ppm-fuzz"
 version = "0.0.0"
+rust-version = "1.87.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"

--- a/crates/zune-psd/Cargo.toml
+++ b/crates/zune-psd/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-psd"
 version = "0.5.0-rc0"
+rust-version = "1.87.0"
 edition = "2021"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-psd"

--- a/crates/zune-psd/fuzz/Cargo.toml
+++ b/crates/zune-psd/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-psd-fuzz"
 version = "0.0.0"
+rust-version = "1.87.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"

--- a/crates/zune-python/Cargo.toml
+++ b/crates/zune-python/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-python"
 version = "0.4.0"
+rust-version = "1.87.0"
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-python"
 

--- a/crates/zune-qoi/Cargo.toml
+++ b/crates/zune-qoi/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-qoi"
 version = "0.5.1"
+rust-version = "1.87.0"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 edition = "2021"
 repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-qoi"

--- a/crates/zune-qoi/fuzz/Cargo.toml
+++ b/crates/zune-qoi/fuzz/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-qoi-fuzz"
 version = "0.0.0"
+rust-version = "1.87.0"
 authors = ["Automatically generated"]
 publish = false
 edition = "2018"

--- a/crates/zune-wasm/Cargo.toml
+++ b/crates/zune-wasm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "zune-wasm"
 description = "Zune image libraries (rust) webassembly version"
 version = "0.0.14"
+rust-version = "1.87.0"
 authors = ["caleb <etemesicaleb@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Zlib"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zune-tests"
 version = "0.1.0"
+rust-version = "1.87.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Setting minimum rustc version to 1.87.0 as earlier versions are not supported. Resolves #325.