### PR TITLE
Remove ZByteReaderTrait from struct bounds

### DIFF
--- a/crates/zune-core/src/bytestream/reader.rs
+++ b/crates/zune-core/src/bytestream/reader.rs
@@ -123,7 +123,7 @@ impl From<&'static str> for ZByteIoError {
 /// utilities like endian aware byte functions.
 ///
 /// This prevents each implementation from providing its own
-pub struct ZReader<T: ZByteReaderTrait> {
+pub struct ZReader<T> {
     inner:       T,
     temp_buffer: Vec<u8>
 }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -79,7 +79,7 @@ pub(crate) struct ICCChunk {
 
 /// A JPEG Decoder Instance.
 #[allow(clippy::upper_case_acronyms, clippy::struct_excessive_bools)]
-pub struct JpegDecoder<T: ZByteReaderTrait> {
+pub struct JpegDecoder<T> {
     /// Struct to hold image information from SOI
     pub(crate) info:              ImageInfo,
     ///  Quantization tables, will be set to none and the tables will


### PR DESCRIPTION
This trait does not say anything about the representation of its implementing types. The same is true for the decoders that use this reader that implements the bound. This is similar to a previous situation in `std::collections::HashMap` which no longer requires the key bounds (`Hash + Eq`) for the _type_ but only on methods which actually touch the key.

This is more flexible. Since bounds are viral any downstream must also add its bounds that demonstrate the reader is satisfied on types with the decoders in fields. This is particularly annoying if it offer only a limited number of public methods that make use of the decoder directly (e.g. only behind a boxed interface) but the trait bound requires the bounds to be mentioned on all other methods and mentions of the wrapper type. Moving the bound to the impl-methods ensures limits the virality of the bounds to uses of the type / field.

I've done this for `zune-jpeg` due to immediate need but of course that probably applies to the other crates, too. Let me know if you prefer me to change these as well in the PR.