### PR TITLE
Lower zune-jpeg MSRV to 1.75 for default features

### DIFF
--- a/crates/zune-jpeg/Cargo.toml
+++ b/crates/zune-jpeg/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "zune-jpeg"
+version = "0.5.8"
+rust-version = "1.75.0"
+authors = ["caleb <etemesicaleb@gmail.com>"]
+edition = "2021"
+repository = "https://github.com/etemesi254/zune-image/tree/dev/crates/zune-jpeg"
+license = "MIT OR Apache-2.0 OR Zlib"
+keywords = ["jpeg", "jpeg-decoder", "decoder"]
+categories = ["multimedia::images"]
+exclude = ["/benches/images/*", "/tests/*", "/.idea/*", "/.gradle/*", "/test-images/*", "fuzz/*"]
+description = "A fast, correct and safe jpeg decoder"
+
+[lints.rust]
+# Disable feature checker for fuzzing since it's used and cargo doesn't
+# seem to recognise fuzzing
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+x86 = []
+neon = []
+std = ["zune-core/std"]
+# NOTE: portable_simd requires Rust 1.87+
+portable_simd = []
+log = ["zune-core/log"]
+default = ["x86", "neon", "std"]
+
+
+[dependencies]
+zune-core = { path = "../zune-core", version = "^0.5" }
+
+
+[dev-dependencies]
+zune-ppm = { path = "../zune-ppm" }


### PR DESCRIPTION
## Summary

This PR lowers the `rust-version` for `zune-jpeg` from 1.87.0 to 1.75.0, and adds a comment noting that the `portable_simd` feature requires Rust 1.87+.

## Rationale

The `portable_simd` feature requires Rust 1.87+, but it's **optional** and not included in default features (`["x86", "neon", "std"]`). Users who don't enable this feature shouldn't be blocked by its Rust version requirement.

This is the standard pattern used by major crates - optional features that require newer Rust don't raise the MSRV for the entire crate.

## Changes

- `rust-version`: 1.87.0 → 1.75.0
- Added comment: `# NOTE: portable_simd requires Rust 1.87+`

## Impact

This unblocks usage in Linux distributions currently shipping Rust 1.85.x:
- Fedora 42
- Debian 13 (Trixie)
- openSUSE Tumbleweed/Leap

## Testing

The default feature set should build fine on Rust 1.75+. The `portable_simd` feature will naturally fail to compile on Rust < 1.87, which is the expected behavior for feature-gated functionality.

Fixes #338