### PR TITLE
Expose Subsampling Info via ImageInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +131,16 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bumpalo"
@@ -240,23 +274,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
  "itertools",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -264,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
 dependencies = [
  "cast",
  "itertools",
@@ -364,12 +397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,19 +406,18 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "zune-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zune-core 0.5.0",
  "zune-jpeg 0.5.6",
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
+name = "image-webp"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -402,9 +428,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -452,18 +478,18 @@ dependencies = [
 
 [[package]]
 name = "jxl-bitstream"
-version = "0.4.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5855ff16398ffbcf81fee52c41ca65326499c8764b21bb9952c367ace98995fb"
+checksum = "b480e752277e29eb4054f69546887a9b84656fe78c08f54ba5850ced98a378fe"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "jxl-coding"
-version = "0.4.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5b5093904e940bc11ef50e872c7bdf7b6e88653f012b925f8479daf212b5c9"
+checksum = "cd972bcd125e776f1eb241ac50e39f956095a1c2770c64736c968f8946bd9a3c"
 dependencies = [
  "jxl-bitstream",
  "tracing",
@@ -471,28 +497,31 @@ dependencies = [
 
 [[package]]
 name = "jxl-color"
-version = "0.7.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb1c31e10054079df585633fc14fb9e4c96565c58c05b983c502e2472b57fa0"
+checksum = "f316b1358c1711755b3ee8e8cb5c4a1dad12e796233088a7a513440782de80b2"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
- "jxl-grid",
+ "jxl-grid 0.6.1",
+ "jxl-image",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
 ]
 
 [[package]]
 name = "jxl-frame"
-version = "0.9.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35b289aa0f24044167d83a1c29ae2b99210c5082ab7e3e90dacbcae818aa0a2"
+checksum = "2d967c6fd669c7c01060b5022d8835fa82fd46b06ffc98b549f17600a097c2b3"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
- "jxl-grid",
+ "jxl-grid 0.6.1",
  "jxl-image",
  "jxl-modular",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "jxl-vardct",
  "tracing",
@@ -508,59 +537,101 @@ dependencies = [
 ]
 
 [[package]]
-name = "jxl-image"
-version = "0.9.0"
+name = "jxl-grid"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b31b17ed3bd0e3b65e7b06628f5930e009dda6cd17638cf5159a20a3feedec6"
+checksum = "a0e0ef92d5d60e76bf41098e57e985f523185e08fad54268da448637feca6989"
+dependencies = [
+ "tracing",
+]
+
+[[package]]
+name = "jxl-image"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f752d62577c702a94dbbce4045caf08cb58639e8a4d56464b40ecf33ffe565"
 dependencies = [
  "jxl-bitstream",
- "jxl-color",
- "jxl-grid",
+ "jxl-grid 0.6.1",
+ "jxl-oxide-common",
+ "tracing",
+]
+
+[[package]]
+name = "jxl-jbr"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35d032bcec660647828527ff42c6f5776d2fd44b8357f9f6d9ac6dc07218e46"
+dependencies = [
+ "brotli-decompressor",
+ "jxl-bitstream",
+ "jxl-frame",
+ "jxl-grid 0.6.1",
+ "jxl-image",
+ "jxl-modular",
+ "jxl-oxide-common",
+ "jxl-threadpool",
+ "jxl-vardct",
  "tracing",
 ]
 
 [[package]]
 name = "jxl-modular"
-version = "0.7.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3b9fb8f46e63a14ecedefbd0f873b04162aaf8a09676b630c31bc8dadc4638"
+checksum = "da758b2f989aafd9eeb39489fe43d7be5a3a0d2ad61cf1bad705eb6990a6053c"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
- "jxl-grid",
+ "jxl-grid 0.6.1",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
 ]
 
 [[package]]
 name = "jxl-oxide"
-version = "0.8.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba1ee3895e6c62b131994807b1ee6d179013613a86c01c203369af8d1e8d2f0"
+checksum = "ee8ecd2678ed70c1eda42b811ccb2e25ab836edeb18e7f1178c1f917ed36b772"
 dependencies = [
+ "brotli-decompressor",
  "jxl-bitstream",
  "jxl-color",
  "jxl-frame",
- "jxl-grid",
+ "jxl-grid 0.6.1",
  "jxl-image",
+ "jxl-jbr",
+ "jxl-oxide-common",
  "jxl-render",
  "jxl-threadpool",
  "tracing",
 ]
 
 [[package]]
-name = "jxl-render"
-version = "0.8.2"
+name = "jxl-oxide-common"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203a79b3025b86f875cc97a6f39e1fcc6314f915b2f6b69f767fca45fd482a11"
+checksum = "b62394c5021b3a9e7e0dbb2d639d555d019090c9946c39f6d3b09d390db4157b"
 dependencies = [
+ "jxl-bitstream",
+]
+
+[[package]]
+name = "jxl-render"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa0c3100918bd3c41bb0f8ce1f4f1664e48f3032ff8eeab0d6a2cfc3276f462d"
+dependencies = [
+ "bytemuck",
  "jxl-bitstream",
  "jxl-coding",
  "jxl-color",
  "jxl-frame",
- "jxl-grid",
+ "jxl-grid 0.6.1",
  "jxl-image",
  "jxl-modular",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "jxl-vardct",
  "tracing",
@@ -568,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-threadpool"
-version = "0.1.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad9c78eaf899cce165e266300f9963d8d376d4ed95cf4d12dd7066f05542cd88"
+checksum = "25f15eb830aa77a7f21148d72e153562a26bfe570139bd4922eab1908dd499d3"
 dependencies = [
  "rayon",
  "rayon-core",
@@ -579,23 +650,24 @@ dependencies = [
 
 [[package]]
 name = "jxl-vardct"
-version = "0.7.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16af82a1ad770887cad720bfd3cc6a6d023faf377036989a24cf2c6538b649e0"
+checksum = "ce72a18c6d3a47172ab6c479be2bdb56f22066b5d7092663f03b4490820b4511"
 dependencies = [
  "jxl-bitstream",
  "jxl-coding",
- "jxl-grid",
+ "jxl-grid 0.6.1",
  "jxl-modular",
+ "jxl-oxide-common",
  "jxl-threadpool",
  "tracing",
 ]
 
 [[package]]
 name = "kamadak-exif"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4fc70d0ab7e5b6bafa30216a6b48705ea964cdfc29c050f2412295eba58077"
+checksum = "1130d80c7374efad55a117d715a3af9368f0fa7a2c54573afc15a188cd984837"
 dependencies = [
  "mutate_once",
 ]
@@ -799,6 +871,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +935,12 @@ checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1250,6 +1338,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1361,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1403,7 +1513,7 @@ dependencies = [
  "zune-image",
  "zune-imageprocs",
  "zune-inflate",
- "zune-jpeg 0.5.7",
+ "zune-jpeg 0.5.11",
  "zune-png",
  "zune-qoi",
 ]
@@ -1417,7 +1527,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_logger",
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
  "zune-image",
  "zune-imageprocs",
 ]
@@ -1427,7 +1537,7 @@ name = "zune-bmp"
 version = "0.5.0-rc4"
 dependencies = [
  "log",
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
 ]
 
 [[package]]
@@ -1435,17 +1545,9 @@ name = "zune-capi"
 version = "0.5.0"
 dependencies = [
  "libc",
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
  "zune-image",
  "zune-imageprocs",
-]
-
-[[package]]
-name = "zune-core"
-version = "0.5.0"
-dependencies = [
- "log",
- "serde",
 ]
 
 [[package]]
@@ -1455,24 +1557,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+dependencies = [
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "zune-farbfeld"
 version = "0.5.0-rc0"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
 ]
 
 [[package]]
 name = "zune-gif"
 version = "0.5.0-rc0"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
 ]
 
 [[package]]
 name = "zune-hdr"
 version = "0.5.0-rc0"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
 ]
 
 [[package]]
@@ -1480,6 +1590,7 @@ name = "zune-image"
 version = "0.5.0-rc0"
 dependencies = [
  "bytemuck",
+ "image-webp",
  "jpeg-encoder",
  "jxl-oxide",
  "kamadak-exif",
@@ -1487,10 +1598,10 @@ dependencies = [
  "num-complex",
  "serde",
  "zune-bmp",
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
  "zune-farbfeld",
  "zune-hdr",
- "zune-jpeg 0.5.7",
+ "zune-jpeg 0.5.11",
  "zune-jpegxl",
  "zune-png",
  "zune-ppm",
@@ -1505,7 +1616,7 @@ dependencies = [
  "kamadak-exif",
  "moxcms",
  "nanorand",
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
  "zune-image",
 ]
 
@@ -1522,14 +1633,14 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f520eebad972262a1dde0ec455bce4f8b298b1e5154513de58c114c4c54303e8"
 dependencies = [
- "zune-core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zune-core 0.5.0",
 ]
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.7"
+version = "0.5.11"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
  "zune-ppm",
 ]
 
@@ -1537,7 +1648,7 @@ dependencies = [
 name = "zune-jpegxl"
 version = "0.5.0-rc1"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
 ]
 
 [[package]]
@@ -1547,7 +1658,7 @@ dependencies = [
  "nanorand",
  "png 0.17.16",
  "spng",
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
  "zune-inflate",
 ]
 
@@ -1555,21 +1666,21 @@ dependencies = [
 name = "zune-ppm"
 version = "0.5.0-rc0"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
 ]
 
 [[package]]
 name = "zune-psd"
 version = "0.5.0-rc0"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
 ]
 
 [[package]]
 name = "zune-qoi"
 version = "0.5.1"
 dependencies = [
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
 ]
 
 [[package]]
@@ -1580,9 +1691,9 @@ dependencies = [
  "serde_json",
  "xxhash-rust",
  "zune-bmp",
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
  "zune-inflate",
- "zune-jpeg 0.5.7",
+ "zune-jpeg 0.5.11",
  "zune-png",
  "zune-psd",
 ]
@@ -1592,12 +1703,12 @@ name = "zune-wasm"
 version = "0.0.14"
 dependencies = [
  "console_error_panic_hook",
- "jxl-grid",
+ "jxl-grid 0.4.2",
  "wasm-bindgen",
  "wasm-bindgen-test",
  "wasm-logger",
  "web-time",
- "zune-core 0.5.0",
+ "zune-core 0.5.1",
  "zune-image",
  "zune-imageprocs",
 ]

--- a/crates/zune-jpeg/src/components.rs
+++ b/crates/zune-jpeg/src/components.rs
@@ -210,12 +210,13 @@ pub enum ComponentID {
     Q
 }
 
-#[derive(Copy, Debug, Clone, PartialEq, Eq)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq, Default)]
 pub enum SampleRatios {
     HV,
     V,
     H,
     Generic(usize, usize),
+    #[default]
     None
 }
 

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -106,7 +106,6 @@ pub struct JpegDecoder<T> {
     pub(crate) mcu_y:             usize,
     /// Is the image interleaved?
     pub(crate) is_interleaved:    bool,
-    pub(crate) sub_sample_ratio:  SampleRatios,
     /// Image input colorspace, should be YCbCr for a sane image, might be
     /// grayscale too
     pub(crate) input_colorspace:  ColorSpace,
@@ -179,7 +178,6 @@ where
             mcu_x:             0,
             mcu_y:             0,
             is_interleaved:    false,
-            sub_sample_ratio:  SampleRatios::None,
             is_progressive:    false,
             spec_start:        0,
             spec_end:          0,
@@ -835,26 +833,6 @@ where
         if self.h_max == self.v_max && self.h_max == 1 {
             return Ok(());
         }
-        match (self.h_max, self.v_max) {
-            (1, 1) => {
-                self.sub_sample_ratio = SampleRatios::None;
-            }
-            (1, 2) => {
-                self.sub_sample_ratio = SampleRatios::V;
-            }
-            (2, 1) => {
-                self.sub_sample_ratio = SampleRatios::H;
-            }
-            (2, 2) => {
-                self.sub_sample_ratio = SampleRatios::HV;
-            }
-            (hs, vs) => {
-                self.sub_sample_ratio = SampleRatios::Generic(hs, vs)
-                // return Err(DecodeErrors::Format(format!(
-                //     "Unknown down-sampling method ({hs},{vs}), cannot continue")
-                // ))
-            }
-        }
 
         for comp in &mut self.components {
             let hs = self.h_max / comp.horizontal_sample;
@@ -953,7 +931,9 @@ pub struct ImageInfo {
     /// XMP Data
     pub xmp_data: Option<Vec<u8>>,
     /// IPTC Data
-    pub iptc_data: Option<Vec<u8>>
+    pub iptc_data: Option<Vec<u8>>,
+    /// Image sub-sampling ratio
+    pub sample_ratio: SampleRatios
 }
 
 impl ImageInfo {

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -18,7 +18,9 @@ use zune_core::bytestream::ZByteReaderTrait;
 use zune_core::colorspace::ColorSpace;
 use zune_core::log::{debug, trace, warn};
 
-use crate::components::Components;
+use core::cmp::max;
+
+use crate::components::{Components, SampleRatios};
 use crate::decoder::{GainMapInfo, ICCChunk, JpegDecoder, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
 use crate::huffman::HuffmanTable;
@@ -276,6 +278,22 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
     img.info.set_sof_marker(sof);
 
     img.components = components;
+
+    let mut h_max = 1;
+    let mut v_max = 1;
+
+    for comp in &img.components {
+        h_max = max(h_max, comp.horizontal_sample);
+        v_max = max(v_max, comp.vertical_sample);
+    }
+
+    img.info.sample_ratio = match (h_max, v_max) {
+        (1, 1) => SampleRatios::None,
+        (1, 2) => SampleRatios::V,
+        (2, 1) => SampleRatios::H,
+        (2, 2) => SampleRatios::HV,
+        (hs, vs) => SampleRatios::Generic(hs, vs)
+    };
 
     Ok(())
 }

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -169,6 +169,7 @@ extern crate core;
 
 pub use zune_core;
 
+pub use crate::components::SampleRatios;
 pub use crate::decoder::{ImageInfo, JpegDecoder};
 pub use crate::marker::Marker;
 mod bitstream;

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -110,8 +110,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         if self.is_interleaved
             && self.input_colorspace.num_components() > 1
             && self.options.jpeg_get_out_colorspace().num_components() == 1
-            && (self.sub_sample_ratio == SampleRatios::V
-                || self.sub_sample_ratio == SampleRatios::HV)
+            && (self.info.sample_ratio == SampleRatios::V
+                || self.info.sample_ratio == SampleRatios::HV)
         {
             // For a specific set of images, e.g interleaved,
             // when converting from YcbCr to grayscale, we need to
@@ -136,7 +136,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
         let width = usize::from(self.info.width);
 
-        let padded_width = calculate_padded_width(width, self.sub_sample_ratio);
+        let padded_width = calculate_padded_width(width, self.info.sample_ratio);
 
         let mut stream = BitStream::new();
         let mut tmp = [0_i32; DCT_BLOCK];
@@ -333,7 +333,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let is_hv = usize::from(self.is_interleaved);
         let upsampler_scratch_size = is_hv * self.components[0].width_stride;
         let width = usize::from(self.info.width);
-        let padded_width = calculate_padded_width(width, self.sub_sample_ratio);
+        let padded_width = calculate_padded_width(width, self.info.sample_ratio);
 
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
 
@@ -914,7 +914,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 .enumerate()
                 .for_each(|(pos, x)| channels_ref[pos] = &x.raw_coeff);
 
-            if let SampleRatios::Generic(_, v) = self.sub_sample_ratio {
+            if let SampleRatios::Generic(_, v) = self.info.sample_ratio {
                 color_conv_function(8 * v * self.coeff, channels_ref)?;
             } else {
                 color_conv_function(8 * self.coeff, channels_ref)?;

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -80,8 +80,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         if self.is_interleaved
             && self.input_colorspace.num_components() > 1
             && self.options.jpeg_get_out_colorspace().num_components() == 1
-            && (self.sub_sample_ratio == SampleRatios::V
-                || self.sub_sample_ratio == SampleRatios::HV)
+            && (self.info.sample_ratio == SampleRatios::V
+                || self.info.sample_ratio == SampleRatios::HV)
         {
             // For a specific set of images, e.g interleaved,
             // when converting from YcbCr to grayscale, we need to
@@ -516,7 +516,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let is_hv = usize::from(self.is_interleaved);
         let upsampler_scratch_size = is_hv * self.components[0].width_stride;
         let width = usize::from(self.info.width);
-        let padded_width = calculate_padded_width(width, self.sub_sample_ratio);
+        let padded_width = calculate_padded_width(width, self.info.sample_ratio);
 
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
         let mut tmp = [0_i32; DCT_BLOCK];
@@ -641,7 +641,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         */
         self.h_max = 1;
         self.v_max = 1;
-        self.sub_sample_ratio = SampleRatios::None;
+        self.info.sample_ratio = SampleRatios::None;
         self.is_interleaved = false;
         self.components[0].vertical_sample = 1;
         self.components[0].width_stride = (((self.info.width as usize) + 7) / 8) * 8;

--- a/crates/zune-jpeg/tests/metadata.rs
+++ b/crates/zune-jpeg/tests/metadata.rs
@@ -18,3 +18,39 @@ fn iptc_metadata() {
     decoder.decode_headers().unwrap();
     assert_eq!(decoder.iptc(), Some(&EXPECTED_DATA.to_vec()))
 }
+
+#[test]
+fn test_sample_ratios() {
+    use zune_jpeg::SampleRatios;
+
+    let images = [
+        (
+            include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg").as_slice(),
+            SampleRatios::None,
+        ),
+        (
+            include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg").as_slice(),
+            SampleRatios::HV,
+        ),
+        (
+            include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg").as_slice(),
+            SampleRatios::H,
+        ),
+        (
+            include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg").as_slice(),
+            SampleRatios::V,
+        ),
+    ];
+
+    for (data, expected) in images {
+        let mut decoder = JpegDecoder::new(Cursor::new(data));
+        decoder.decode_headers().unwrap();
+
+        let info = decoder.info().unwrap();
+        assert_eq!(
+            info.sample_ratio, expected,
+            "Expected sample ratio {:?} for image",
+            expected
+        );
+    }
+}


### PR DESCRIPTION
This PR exposes `SampleRatios` as part of `ImageInfo`. This is useful if one wants to roundtrip the chosen chroma subsampling. :)