### PR TITLE
(JPEG) Fix progressive non‑interleaved scan grid for subsampled components (4:2:0)

### DIFF
--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -249,20 +249,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
             let (mcu_width, mcu_height);
 
-            if self.components[k].vertical_sample != 1
-                || self.components[k].horizontal_sample != 1
-                || !self.is_interleaved
-            {
-                // For non interleaved scans
-                // mcu's is the image dimensions divided by 8
-                mcu_width = self.info.width.div_ceil(8) as usize;
-                mcu_height = self.info.height.div_ceil(8) as usize;
-            } else {
-                // For other channels, in an interleaved mcu, number of MCU's
-                // are determined by some weird maths done in headers.rs->parse_sos()
-                mcu_width = self.mcu_x;
-                mcu_height = self.mcu_y;
-            }
+            // For non-interleaved scans, iterate over the component's actual data-unit grid.
+            let component = &self.components[k];
+            mcu_width = (self.info.width as usize * component.horizontal_sample + self.h_max * 8
+                - 1)
+                / (self.h_max * 8);
+            mcu_height = (self.info.height as usize * component.vertical_sample + self.v_max * 8
+                - 1)
+                / (self.v_max * 8);
 
             for i in 0..mcu_height {
                 for j in 0..mcu_width {


### PR DESCRIPTION
There appears to be a bug in JPEG decoding which gets occasionally triggered.  It looks like this (https://github.com/etemesi254/zune-image/blob/33d808a81db8e7006f71d38ae2b87590d628f6c3/crates/zune-jpeg/src/mcu_prog.rs#L252) part of the code, which handles decoding the segment for progressive, non-interleaved data, calculates the number of blocks to read incorrectly in the case of subsampled components.

If I understand the JPEG spec correctly, in the case of non-interleaved data you should first calculate the size of that component's plane:

```
Xi = ceil(image_width * h_samples / h_max)
Yi = ceil(image_height * v_samples / v_max)
```

And then the number of blocks:

```
x_blocks = ceil(Xi / 8)
y_blocks = ceil(Yi / 8)
```

The existing code in mcu_prog.rs for this case of progressive, non-interleaved data is doing some kind of odd check on whether the image is interleaved or not?  Even though line 233 means this section of the code is already in the non-interleaved case.

For the case of progressive, non-interleaved, subsampled data it looks like the current code will simply use `mcu_x` and `mcu_y`, which I think is the number of MCUs for the interleaved case.  This will be _often_ correct by accident, but in edge cases it will be wrong.

This patch corrects the calculation to simply:

```
mcu_width = (self.info.width as usize * component.horizontal_sample + self.h_max * 8 - 1) / (self.h_max * 8);
mcu_height = (self.info.height as usize * component.vertical_sample + self.v_max * 8 - 1) / (self.v_max * 8);
```

which is the simplified form of the above Xi, x_blocks, etc calculations.

I ran rustfmt nightly on the patch to ensure it matches the repo's formatting.

Here is a synthetic test image which decodes correctly in libjpeg-turbo but incorrectly in zune-jpeg as of 3cdedbe15b78a0aeb1da003d533eeeb767b6d381:

![synthetic-patch-trigger-533x800](https://github.com/user-attachments/assets/18b1a826-b74c-49e6-a6e8-75ec1719a771)

With 3cdedbe15b78a0aeb1da003d533eeeb767b6d381:

<img width="533" height="800" alt="rust-broken" src="https://github.com/user-attachments/assets/fbfcb004-bef3-468f-9a20-d4f20075ce9f" />

With this patch:

<img width="533" height="800" alt="rust-output" src="https://github.com/user-attachments/assets/8a144659-56eb-4f88-a5d6-6684b593795f" />

I also ran a sweep of 10,000 images from a random subset of my local dataset of internet scraped images.  With this patch compared to without this patch there were no changes in MAE for any images except the one image that trigger this bug (which fell from ~8 MAE to 0.1 MAE).

All tests under zune-jpeg passed on my local machine.