### PR TITLE
(zune-jpeg) tweak truncated file behavior to help with issue #273

### DIFF
--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -187,8 +187,17 @@ impl BitStream {
         macro_rules! refill {
             ($buffer:expr,$byte:expr,$bits_left:expr) => {
                 // read a byte from the stream
-                $byte = u64::from(reader.read_u8());
-                self.overread_by += usize::from(reader.eof()?);
+                match reader.read_u8_err() {
+                    Ok(b) => {
+                        $byte = u64::from(b);
+                    }
+                    Err(_) => {
+                        // Premature EOF: mark EOI and pad with zero bits (libjpeg-style concealment).
+                        self.seen_eoi = true;
+                        self.marker = Some(Marker::EOI);
+                        $byte = 0;
+                    }
+                }
                 // append to the buffer
                 // JPEG is a MSB type buffer so that means we append this
                 // to the lower end (0..8) of the buffer and push the rest bits above..

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -332,6 +332,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     self.todo -= 1;
 
                     self.handle_rst_main(stream)?;
+                    if stream.seen_eoi {
+                        return Ok(());
+                    }
                 }
             }
         } else {
@@ -421,6 +424,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     self.todo -= 1;
                     // after every scan that's a mcu, count down restart markers.
                     self.handle_rst_main(stream)?;
+                    if stream.seen_eoi {
+                        return Ok(());
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request helps fix one of the images in issue #273 .

Image `582121.11.450x300.jpg` in that issue is a truncated JPEG.  jpeg-turbo will decode the image into something reasonable, whereas zune-jpeg puts a noise pattern over the image.

This patch does a small change to zune-jpeg's behavior here to eliminate the noise pattern.  This reduces the MAE between zune-jpeg and jpeg-turbo from ~8 to ~1.

## MAJOR NOTES

1) `582121.11.450x300.jpg` is a _broken_ image.  Normally I wouldn't care much how a library behaves on broken images.  But this patch is very small, and seems to improve zune-jpeg's behavior in these extreme edge cases.  So I figure it's worth it?

2) I ran a sweep across 10k random images on my end to make sure this patch doesn't affect anything else.  I didn't notice any regressions.

3) I ran a sweep across the images in test-images/jpeg and noticed **one regression**.  https://github.com/etemesi254/zune-image/blob/dev/test-images/jpeg/incomplete_image.jpg  It changes the color of the truncated blocks on that image from grey to a cream color that matches the rest of the image.  I actually think that _looks_ better, but it is a divergence from jpeg-turbo's behavior here (which outputs grey for those blocks).


## Minor Notes

1) cargo test passed on my machine
2) cargo fmt (nightly) did not throw any warnings on the lines of this patch