### PR TITLE
jpeg: fix crash on malformed non-interleaved scans with multiple components

### DIFF
--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -450,7 +450,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // For non-interleaved scans (PROGRESSIVE=true), each scan contains a single component
         // and we iterate over that component's actual data unit count, not the interleaved MCU
         // width multiplied by sampling factor.
-        let scan_du_width = if PROGRESSIVE {
+        let mut scan_du_width = if PROGRESSIVE {
             let k = z_scans[0];
             let comp = &self.components[k];
             // Calculate actual data units for this component: ceil(width / (8 * subsampling_ratio))
@@ -459,6 +459,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         } else {
             mcu_width
         };
+        // In malformed scans that list multiple components, clamp to the smallest row capacity
+        // to avoid writing past the row buffer.
+        if PROGRESSIVE && z_scans.len() > 1 {
+            let min_du = z_scans
+                .iter()
+                .map(|&k| self.components[k].width_stride / 8)
+                .min()
+                .unwrap_or(0);
+            scan_du_width = scan_du_width.min(min_du);
+        }
 
         for j in 0..scan_du_width {
             // iterate over components


### PR DESCRIPTION
The fuzzer found a crash in zune-jpeg with this malformed input:
![fuzz-malformed-noninterleaved](https://github.com/user-attachments/assets/739567af-cc61-4e32-8c0d-9f253a5ce843)

You can confirm the crash with `cargo +nightly fuzz run --fuzz-dir crates/zune-jpeg/fuzz decode_buffer fuzz-malformed-noninterleaved.jpg`

Looks like it declares itself as a noninterleaved, baseline JPEG, but then has a segment with multiple components.  This is a malformed input, but zune-jpeg in non-strict mode correctly tries to decode it anyway.  Problem is, the row buffer might not be sized large enough for these scenarios, causing IDCT to write past the end of the row buffer.

I bisected and discovered that this crash bug was introduced on commit 9fd97ddbfba8e790486fbe6957cd1360384f4f94

In this very specific scenario this pull request fixes the bug by clamping the scan to the smallest row capacity.

Sweeps over my dataset showed no regressions.  I wouldn't expect any, as this code should only apply in malformed files.

NOTE: This bug showed up when the CI fuzzer ran here (https://github.com/etemesi254/zune-image/actions/runs/21576890977/job/62165950396).  I also got it to show up on my local machine by running the fuzzer -j8 for 5 minutes on HEAD.  The fuzzer did not find any other bugs.