### PR TITLE
jpeg: stop zero-filling entropy stream after EOF overread

### DIFF
--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -238,7 +238,7 @@ impl BitStream {
 
         // 32 bits is enough for a decode(16 bits) and receive_extend(max 16 bits)
         if self.bits_left < 32 {
-            if self.marker.is_some() || self.overread_by > 0 || self.seen_eoi {
+            if self.marker.is_some() || self.seen_eoi {
                 // found a marker, or we are in EOI
                 // also we are in over-reading mode, where we fill it with zeroes
 
@@ -246,6 +246,15 @@ impl BitStream {
                 self.buffer <<= 32;
                 self.bits_left += 32;
                 self.aligned_buffer = self.buffer << (64 - self.bits_left);
+                return Ok(true);
+            }
+
+            if self.overread_by > 0 {
+                if self.bits_left == 0 {
+                    return Err(DecodeErrors::ExhaustedData);
+                }
+                // We already hit EOF while refilling. Continue consuming the buffered bits
+                // but don't synthesize additional bytes from zero-fill.
                 return Ok(true);
             }
 


### PR DESCRIPTION
This patch address most of issue #273 

All of the problematic images in that issue are truncated (EOF before EOI).  In the case of a truncated image, the existing behavior of zune-jpeg is to keep filling the stream with zeros.  This results in artifacts in the decoded images.

This patch changes that behavior to: exhaust the remaining "real" bits in the buffer, then stop decoding.

Measuring the MAE before and after this patch on the images in issue #273

**Improved:**
  - 13561Bb1-0.jpg (8.1935 -> 2.3041)
  - 407-72-304.jpg (4.4907 -> 0.0069)
  - 582121.11.450x300.jpg (11.7257 -> 1.8400)
  - Ireland-Cary-1805.jpg (25.0909 -> 1.4794)
  - SAM_0967-1024x683.jpg (3.7244 -> 0.2094)
  - image.jpg.448 (5.0877 -> 0.0050)
  - invito-CERRITO.jpg (5.5625 -> 0.1394)
  - kingarms_bg.jpg (6.7174 -> 0.1187)
  - nBkSUhL2hFMhmc-_Ir6BrNOp2Z398pj21yHDh_fH_nKUPXuaDyXTjHou4MVO6BCVoZKf9GqVe5Q_CPawk214LyWK9G1N5ho=KYXkaEnG3y-qsG-V1lF3BA.jpg (4.5948 -> 0.1366)
  - ossby-electric-roja.jpg (5.6154 -> 0.2562)
  - propiedad-menu.jpg (2.4702 -> 0.9252)

**Unchanged:**
  - 3m-logo-ye.jpg (0.0487 -> 0.0487)
  - 512x384.jpg (0.1275 -> 0.1275)
  - lyrics_hardcover_2.jpg (0.0775 -> 0.0775)
  - mini-banner-ultimolanzamiento-revo.jpg (0.0722 -> 0.0722)


I did not see any more visible glitches/artifacts on any of those images, after this patch.  The images with MAE still above 0.3:

  - 13561Bb1-0.jpg (2.3041)
  - 582121.11.450x300.jpg (1.8400)
  - Ireland-Cary-1805.jpg (1.4794)

Those have all improved, however there appears to be some additional work that libjpeg-turbo (the MAE reference) does in case of a truncated file.  I don't think that's worth chasing, as these are extreme edge cases of already broken files and this patch eliminates all the obvious artifacts.


## `test-images/jpeg/incomplete_image.jpg`

This patch will cause at least one check to fail because it changes the results of decoding the existing test image: `test-images/jpeg/incomplete_image.jpg`.  I did not notice any meaningful change in the decoding result of that image, but it's checked by hash so the test fails regardless.


## Regressions

This patch causes no regressions that I could find.  I swept through 10k internet images and found no change in MAE on any of them comparing with and without the patch.

I also did not notice any changes in _strict_ behavior with this patch: all truncated images (correctly) failed both before and after.