### PR TITLE
fix: unsafe_op_in_unsafe_fn compliance for NEON + CI aarch64 coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main","dev" ]
   pull_request:
     branches: [ "main","dev" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -28,6 +29,9 @@ jobs:
         include:
           - os: ubuntu-latest
             toolchain: 1.88 # MSRV
+          - os: ubuntu-24.04-arm
+            toolchain: 1.88 # MSRV (aarch64 — catches NEON compilation issues)
+            extra_rustflags: -D unsafe_op_in_unsafe_fn
           - os: windows-latest
             toolchain: stable
             test-args: --exclude zune-benches --exclude zune-image --exclude zune-imageprocs --exclude zune-png
@@ -64,4 +68,4 @@ jobs:
                 ${{ matrix.test-args }}
         env:
           # Skip target-cpu=native for cross-compilation targets
-          RUSTFLAGS: ${{ matrix.target && '' || '-C target-cpu=native' }}
+          RUSTFLAGS: ${{ matrix.target && '' || '-C target-cpu=native' }} ${{ matrix.extra_rustflags }}

--- a/crates/zune-capi/src/errno.rs
+++ b/crates/zune-capi/src/errno.rs
@@ -104,23 +104,24 @@ pub extern "C" fn zil_status_ok(status: *const ZStatus) -> bool {
 /// Remember to free it with `zil_status_free`
 #[no_mangle]
 pub unsafe extern "C" fn zil_status_new() -> *mut ZStatus {
-    let ptr = zil_malloc(size_of::<ZStatus>());
-
-    let msg = CString::new("").unwrap();
-    let mem = unsafe { zil_malloc(msg.as_bytes_with_nul().len()) };
-    if mem.is_null() {
-        return ptr::null_mut();
-    }
-    // copy to memory
     unsafe {
+        let ptr = zil_malloc(size_of::<ZStatus>());
+
+        let msg = CString::new("").unwrap();
+        let mem = zil_malloc(msg.as_bytes_with_nul().len());
+        if mem.is_null() {
+            return ptr::null_mut();
+        }
+        // copy to memory
         libc::strcpy(mem.cast(), msg.as_ptr());
+
+        if !ptr.is_null() {
+            (*ptr.cast::<ZStatus>()).message = mem.cast();
+            (*ptr.cast::<ZStatus>()).status = ZStatusType::ZilOk;
+        }
+        // make pointer
+        ptr.cast()
     }
-    if !ptr.is_null() {
-        (*ptr.cast::<ZStatus>()).message = mem.cast();
-        (*ptr.cast::<ZStatus>()).status = ZStatusType::ZilOk;
-    }
-    // make pointer
-    ptr.cast()
 }
 
 /// Return the status code contained in the ZImStatus

--- a/crates/zune-capi/src/utils.rs
+++ b/crates/zune-capi/src/utils.rs
@@ -20,7 +20,7 @@ use crate::enums::ZImageFormat;
 ///
 #[no_mangle]
 pub unsafe extern "C" fn zil_guess_format(bytes: *const u8, size: usize) -> ZImageFormat {
-    let slice = std::slice::from_raw_parts(bytes, size);
+    let slice = unsafe { std::slice::from_raw_parts(bytes, size) };
 
     match zune_image::codecs::guess_format(ZCursor::new(slice)) {
         None => ZImageFormat::ZilUnknownFormat,
@@ -34,7 +34,7 @@ pub unsafe extern "C" fn zil_guess_format(bytes: *const u8, size: usize) -> ZIma
 /// \param size: Memory size
 #[no_mangle]
 pub unsafe extern "C" fn zil_malloc(size: size_t) -> *mut c_void {
-    libc::malloc(size)
+    unsafe { libc::malloc(size) }
 }
 
 /// Free a memory region that was allocated by zil_malloc or internally by the library
@@ -47,7 +47,7 @@ pub unsafe extern "C" fn zil_malloc(size: size_t) -> *mut c_void {
 pub unsafe extern "C" fn zil_free(ptr: *mut c_void) {
     assert!(!ptr.is_null(), "Trying to free a null ptr!!");
     if !ptr.is_null() {
-        libc::free(ptr);
+        unsafe { libc::free(ptr) };
         // set it to be null
     }
 }
@@ -60,8 +60,10 @@ pub unsafe extern "C" fn zil_free(ptr: *mut c_void) {
 #[no_mangle]
 pub unsafe extern "C" fn zil_free_and_null(ptr: *mut *mut c_void) {
     if !ptr.is_null() {
-        let deref_ptr = *ptr;
-        zil_free(deref_ptr);
-        *ptr = null_mut()
+        unsafe {
+            let deref_ptr = *ptr;
+            zil_free(deref_ptr);
+            *ptr = null_mut()
+        }
     }
 }

--- a/crates/zune-image/src/channel.rs
+++ b/crates/zune-image/src/channel.rs
@@ -214,12 +214,12 @@ impl Channel {
         // and we are bound by the zeroed trait, hence we are sure that
         // for whatever type we are going to allocate for,
         // it can be represented with a bit-representation of zero.
-        (alloc_zeroed(layout), layout)
+        unsafe { (alloc_zeroed(layout), layout) }
     }
     /// Reallocate the pointer in place increasing
     /// it's capacity
     pub unsafe fn realloc(&mut self, new_size: usize) {
-        self.ptr = realloc(self.ptr, self.layout, new_size);
+        self.ptr = unsafe { realloc(self.ptr, self.layout, new_size) };
         // set capacity to be new size
         self.capacity = new_size;
     }
@@ -230,7 +230,7 @@ impl Channel {
         // safety
         // - The same layout alignment we used for alloc is the same we are using for
         //  dealloc
-        dealloc(self.ptr, layout);
+        unsafe { dealloc(self.ptr, layout) };
     }
 
     /// Create a new channel
@@ -408,7 +408,7 @@ impl Channel {
             // reallocate to handle enough of the length.
             // realloc will set the new capacity
             // but as callers we have to set the new length
-            self.realloc(self.capacity.saturating_add(items).saturating_add(10));
+            unsafe { self.realloc(self.capacity.saturating_add(items).saturating_add(10)) };
         }
         // now we have enough space, extend
 
@@ -416,10 +416,12 @@ impl Channel {
         // - self.ptr+length cannot overflow, since it's usize
         // -  data is valid for data size
         //
-        self.ptr.wrapping_add(self.length).copy_from(
-            data.as_ptr().cast::<u8>(),
-            data.len().saturating_mul(data_size)
-        );
+        unsafe {
+            self.ptr.wrapping_add(self.length).copy_from(
+                data.as_ptr().cast::<u8>(),
+                data.len().saturating_mul(data_size)
+            );
+        }
 
         // new length becomes old length + items added
         self.length = self.length.checked_add(items).unwrap();
@@ -452,19 +454,21 @@ impl Channel {
     /// # Returns
     /// - `Some(&[T])`: THe re-interpreted bits
     unsafe fn reinterpret_as_unchecked<T: Default + 'static>(&self) -> &[T] {
-        // Safety:
-        //  validity: We own the data
-        //  well aligned: You cannot have u8 having bad alignment as the least bit denomination
-        // of alignment is a byte and u8==1 byte
-        //
-        let new_slice = unsafe { std::slice::from_raw_parts_mut::<u8>(self.ptr, self.length) };
+        unsafe {
+            // Safety:
+            //  validity: We own the data
+            //  well aligned: You cannot have u8 having bad alignment as the least bit denomination
+            // of alignment is a byte and u8==1 byte
+            //
+            let new_slice = std::slice::from_raw_parts_mut::<u8>(self.ptr, self.length);
 
-        let (a, b, c) = new_slice.align_to();
+            let (a, b, c) = new_slice.align_to();
 
-        assert!(a.is_empty(), "extra sloppy bytes");
-        assert!(c.is_empty(), "extra sloppy bytes");
+            assert!(a.is_empty(), "extra sloppy bytes");
+            assert!(c.is_empty(), "extra sloppy bytes");
 
-        b
+            b
+        }
     }
     /// Reinterpret a slice of `&[u8]` into another type
     pub fn reinterpret_as_mut<T: 'static + Pod>(&mut self) -> Result<&mut [T], ChannelErrors> {
@@ -592,7 +596,7 @@ impl Channel {
     /// This is unsafe just as a remainder that the memory is just
     /// a bag of bytes and may not be just `&[u8]`.
     pub unsafe fn alias(&self) -> &[u8] {
-        std::slice::from_raw_parts(self.ptr, self.length)
+        unsafe { std::slice::from_raw_parts(self.ptr, self.length) }
     }
 
     /// Return the raw memory layout of the channel as `mut &[u8]`
@@ -601,7 +605,7 @@ impl Channel {
     /// This is unsafe just as a remainder that the memory is just
     /// a bag of bytes and may not be just `mut &[u8]`.
     pub unsafe fn alias_mut(&mut self) -> &mut [u8] {
-        std::slice::from_raw_parts_mut(self.ptr, self.length)
+        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.length) }
     }
 }
 

--- a/crates/zune-jpeg/src/color_convert/neon64.rs
+++ b/crates/zune-jpeg/src/color_convert/neon64.rs
@@ -39,84 +39,86 @@ const C_2: u64 = u64::from_ne_bytes([
 unsafe fn ycbcr_to_rgb_baseline_no_clamp(
     y: &[i16; 16], cb: &[i16; 16], cr: &[i16; 16]
 ) -> (uint8x16_t, uint8x16_t, uint8x16_t) {
-    // NEON has 32 registers, so it is good idea to utilize a lot of variables at once
+    unsafe {
+        // NEON has 32 registers, so it is good idea to utilize a lot of variables at once
 
-    let cb_cr_bias = vdupq_n_s16(128);
-    // 0 - Y coeff, 1 - Cr, 2 - Cb, 3 - G1, 4 - G2
-    let coefficients = vcombine_s16(vcreate_s16(C_1), vcreate_s16(C_2));
+        let cb_cr_bias = vdupq_n_s16(128);
+        // 0 - Y coeff, 1 - Cr, 2 - Cb, 3 - G1, 4 - G2
+        let coefficients = vcombine_s16(vcreate_s16(C_1), vcreate_s16(C_2));
 
-    let y0 = vld1q_s16(y.as_ptr().cast());
-    let y1 = vld1q_s16(y[8..].as_ptr().cast());
+        let y0 = vld1q_s16(y.as_ptr().cast());
+        let y1 = vld1q_s16(y[8..].as_ptr().cast());
 
-    let mut cb0 = vld1q_s16(cb.as_ptr().cast());
-    let mut cb1 = vld1q_s16(cb[8..].as_ptr().cast());
+        let mut cb0 = vld1q_s16(cb.as_ptr().cast());
+        let mut cb1 = vld1q_s16(cb[8..].as_ptr().cast());
 
-    let mut cr0 = vld1q_s16(cr.as_ptr().cast());
-    let mut cr1 = vld1q_s16(cr[8..].as_ptr().cast());
+        let mut cr0 = vld1q_s16(cr.as_ptr().cast());
+        let mut cr1 = vld1q_s16(cr[8..].as_ptr().cast());
 
-    cb0 = vsubq_s16(cb0, cb_cr_bias);
-    cb1 = vsubq_s16(cb1, cb_cr_bias);
+        cb0 = vsubq_s16(cb0, cb_cr_bias);
+        cb1 = vsubq_s16(cb1, cb_cr_bias);
 
-    cr0 = vsubq_s16(cr0, cb_cr_bias);
-    cr1 = vsubq_s16(cr1, cb_cr_bias);
+        cr0 = vsubq_s16(cr0, cb_cr_bias);
+        cr1 = vsubq_s16(cr1, cb_cr_bias);
 
-    let bias = vdupq_n_s32(i32::from(YUV_RND));
+        let bias = vdupq_n_s32(i32::from(YUV_RND));
 
-    let acc0 = vmlal_laneq_s16::<0>(bias, vget_low_s16(y0), coefficients);
-    let acc1 = vmlal_high_laneq_s16::<0>(bias, y0, coefficients);
-    let acc2 = vmlal_laneq_s16::<0>(bias, vget_low_s16(y1), coefficients);
-    let acc3 = vmlal_high_laneq_s16::<0>(bias, y1, coefficients);
+        let acc0 = vmlal_laneq_s16::<0>(bias, vget_low_s16(y0), coefficients);
+        let acc1 = vmlal_high_laneq_s16::<0>(bias, y0, coefficients);
+        let acc2 = vmlal_laneq_s16::<0>(bias, vget_low_s16(y1), coefficients);
+        let acc3 = vmlal_high_laneq_s16::<0>(bias, y1, coefficients);
 
-    let r0 = vmlal_laneq_s16::<1>(acc0, vget_low_s16(cr0), coefficients);
-    let r1 = vmlal_high_laneq_s16::<1>(acc1, cr0, coefficients);
-    let r2 = vmlal_laneq_s16::<1>(acc2, vget_low_s16(cr1), coefficients);
-    let r3 = vmlal_high_laneq_s16::<1>(acc3, cr1, coefficients);
+        let r0 = vmlal_laneq_s16::<1>(acc0, vget_low_s16(cr0), coefficients);
+        let r1 = vmlal_high_laneq_s16::<1>(acc1, cr0, coefficients);
+        let r2 = vmlal_laneq_s16::<1>(acc2, vget_low_s16(cr1), coefficients);
+        let r3 = vmlal_high_laneq_s16::<1>(acc3, cr1, coefficients);
 
-    let b0 = vmlal_laneq_s16::<2>(acc0, vget_low_s16(cb0), coefficients);
-    let b1 = vmlal_high_laneq_s16::<2>(acc1, cb0, coefficients);
-    let b2 = vmlal_laneq_s16::<2>(acc2, vget_low_s16(cb1), coefficients);
-    let b3 = vmlal_high_laneq_s16::<2>(acc3, cb1, coefficients);
+        let b0 = vmlal_laneq_s16::<2>(acc0, vget_low_s16(cb0), coefficients);
+        let b1 = vmlal_high_laneq_s16::<2>(acc1, cb0, coefficients);
+        let b2 = vmlal_laneq_s16::<2>(acc2, vget_low_s16(cb1), coefficients);
+        let b3 = vmlal_high_laneq_s16::<2>(acc3, cb1, coefficients);
 
-    // Saturating shift right with signed -> unsigned saturation
-    let qr0 = vqshrun_n_s32::<14>(r0);
-    let qr1 = vqshrun_n_s32::<14>(r1);
-    let qr2 = vqshrun_n_s32::<14>(r2);
-    let qr3 = vqshrun_n_s32::<14>(r3);
+        // Saturating shift right with signed -> unsigned saturation
+        let qr0 = vqshrun_n_s32::<14>(r0);
+        let qr1 = vqshrun_n_s32::<14>(r1);
+        let qr2 = vqshrun_n_s32::<14>(r2);
+        let qr3 = vqshrun_n_s32::<14>(r3);
 
-    let mut g0 = vmlal_laneq_s16::<4>(acc0, vget_low_s16(cb0), coefficients);
-    let mut g1 = vmlal_high_laneq_s16::<4>(acc1, cb0, coefficients);
-    let mut g2 = vmlal_laneq_s16::<4>(acc2, vget_low_s16(cb1), coefficients);
-    let mut g3 = vmlal_high_laneq_s16::<4>(acc3, cb1, coefficients);
+        let mut g0 = vmlal_laneq_s16::<4>(acc0, vget_low_s16(cb0), coefficients);
+        let mut g1 = vmlal_high_laneq_s16::<4>(acc1, cb0, coefficients);
+        let mut g2 = vmlal_laneq_s16::<4>(acc2, vget_low_s16(cb1), coefficients);
+        let mut g3 = vmlal_high_laneq_s16::<4>(acc3, cb1, coefficients);
 
-    let qb0 = vqshrun_n_s32::<14>(b0);
-    let qb1 = vqshrun_n_s32::<14>(b1);
-    let qb2 = vqshrun_n_s32::<14>(b2);
-    let qb3 = vqshrun_n_s32::<14>(b3);
+        let qb0 = vqshrun_n_s32::<14>(b0);
+        let qb1 = vqshrun_n_s32::<14>(b1);
+        let qb2 = vqshrun_n_s32::<14>(b2);
+        let qb3 = vqshrun_n_s32::<14>(b3);
 
-    let r0 = vqmovn_u16(vcombine_u16(qr0, qr1));
-    let r1 = vqmovn_u16(vcombine_u16(qr2, qr3));
+        let r0 = vqmovn_u16(vcombine_u16(qr0, qr1));
+        let r1 = vqmovn_u16(vcombine_u16(qr2, qr3));
 
-    let b0 = vqmovn_u16(vcombine_u16(qb0, qb1));
-    let b1 = vqmovn_u16(vcombine_u16(qb2, qb3));
+        let b0 = vqmovn_u16(vcombine_u16(qb0, qb1));
+        let b1 = vqmovn_u16(vcombine_u16(qb2, qb3));
 
-    g0 = vmlal_laneq_s16::<3>(g0, vget_low_s16(cr0), coefficients);
-    g1 = vmlal_high_laneq_s16::<3>(g1, cr0, coefficients);
-    g2 = vmlal_laneq_s16::<3>(g2, vget_low_s16(cr1), coefficients);
-    g3 = vmlal_high_laneq_s16::<3>(g3, cr1, coefficients);
+        g0 = vmlal_laneq_s16::<3>(g0, vget_low_s16(cr0), coefficients);
+        g1 = vmlal_high_laneq_s16::<3>(g1, cr0, coefficients);
+        g2 = vmlal_laneq_s16::<3>(g2, vget_low_s16(cr1), coefficients);
+        g3 = vmlal_high_laneq_s16::<3>(g3, cr1, coefficients);
 
-    let qg0 = vqshrun_n_s32::<14>(g0);
-    let qg1 = vqshrun_n_s32::<14>(g1);
-    let qg2 = vqshrun_n_s32::<14>(g2);
-    let qg3 = vqshrun_n_s32::<14>(g3);
+        let qg0 = vqshrun_n_s32::<14>(g0);
+        let qg1 = vqshrun_n_s32::<14>(g1);
+        let qg2 = vqshrun_n_s32::<14>(g2);
+        let qg3 = vqshrun_n_s32::<14>(g3);
 
-    let g0 = vqmovn_u16(vcombine_u16(qg0, qg1));
-    let g1 = vqmovn_u16(vcombine_u16(qg2, qg3));
+        let g0 = vqmovn_u16(vcombine_u16(qg0, qg1));
+        let g1 = vqmovn_u16(vcombine_u16(qg2, qg3));
 
-    (
-        vcombine_u8(r0, r1),
-        vcombine_u8(g0, g1),
-        vcombine_u8(b0, b1)
-    )
+        (
+            vcombine_u8(r0, r1),
+            vcombine_u8(g0, g1),
+            vcombine_u8(b0, b1)
+        )
+    }
 }
 
 #[inline(always)]

--- a/crates/zune-jpeg/src/idct/neon.rs
+++ b/crates/zune-jpeg/src/idct/neon.rs
@@ -36,7 +36,6 @@ use crate::unsafe_utils::{transpose, YmmRegister};
 
 const SCALE_BITS: i32 = 512 + 65536 + (128 << 17);
 
-
 #[inline]
 #[target_feature(enable = "neon")]
 unsafe fn pack_16(a: int32x4x2_t) -> int16x8_t {
@@ -46,7 +45,7 @@ unsafe fn pack_16(a: int32x4x2_t) -> int16x8_t {
 #[inline]
 #[target_feature(enable = "neon")]
 unsafe fn condense_bottom_16(a: int32x4x2_t, b: int32x4x2_t) -> int16x8x2_t {
-    int16x8x2_t(pack_16(a), pack_16(b))
+    unsafe { int16x8x2_t(pack_16(a), pack_16(b)) }
 }
 
 #[target_feature(enable = "neon")]
@@ -58,185 +57,185 @@ unsafe fn condense_bottom_16(a: int32x4x2_t, b: int32x4x2_t) -> int16x8x2_t {
     unused_assignments,
     clippy::zero_prefixed_literal
 )]
-pub unsafe fn idct_neon(
-    in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize
-) {
-    let mut pos = 0;
+pub unsafe fn idct_neon(in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize) {
+    unsafe {
+        let mut pos = 0;
 
-    // load into registers
-    //
-    // We sign extend i16's to i32's and calculate them with extended precision and
-    // later reduce them to i16's when we are done carrying out IDCT
+        // load into registers
+        //
+        // We sign extend i16's to i32's and calculate them with extended precision and
+        // later reduce them to i16's when we are done carrying out IDCT
 
-    let mut row0 = YmmRegister::load(in_vector[00..].as_ptr().cast());
-    let mut row1 = YmmRegister::load(in_vector[08..].as_ptr().cast());
-    let mut row2 = YmmRegister::load(in_vector[16..].as_ptr().cast());
-    let mut row3 = YmmRegister::load(in_vector[24..].as_ptr().cast());
-    let mut row4 = YmmRegister::load(in_vector[32..].as_ptr().cast());
-    let mut row5 = YmmRegister::load(in_vector[40..].as_ptr().cast());
-    let mut row6 = YmmRegister::load(in_vector[48..].as_ptr().cast());
-    let mut row7 = YmmRegister::load(in_vector[56..].as_ptr().cast());
+        let mut row0 = YmmRegister::load(in_vector[00..].as_ptr().cast());
+        let mut row1 = YmmRegister::load(in_vector[08..].as_ptr().cast());
+        let mut row2 = YmmRegister::load(in_vector[16..].as_ptr().cast());
+        let mut row3 = YmmRegister::load(in_vector[24..].as_ptr().cast());
+        let mut row4 = YmmRegister::load(in_vector[32..].as_ptr().cast());
+        let mut row5 = YmmRegister::load(in_vector[40..].as_ptr().cast());
+        let mut row6 = YmmRegister::load(in_vector[48..].as_ptr().cast());
+        let mut row7 = YmmRegister::load(in_vector[56..].as_ptr().cast());
 
-    // Forward DCT and quantization may cause all the AC terms to be zero, for such
-    // cases we can try to accelerate it
+        // Forward DCT and quantization may cause all the AC terms to be zero, for such
+        // cases we can try to accelerate it
 
-    // Basically the poop is that whenever the array has 63 zeroes, its idct is
-    // (arr[0]>>3)or (arr[0]/8) propagated to all the elements.
-    // We first test to see if the array contains zero elements and if it does, we go the
-    // short way.
-    //
-    // This reduces IDCT overhead from about 39% to 18 %, almost half
+        // Basically the poop is that whenever the array has 63 zeroes, its idct is
+        // (arr[0]>>3)or (arr[0]/8) propagated to all the elements.
+        // We first test to see if the array contains zero elements and if it does, we go the
+        // short way.
+        //
+        // This reduces IDCT overhead from about 39% to 18 %, almost half
 
-    // Do another load for the first row, we don't want to check DC value, because
-    // we only care about AC terms
-    // TODO this should be a shift/shuffle, not a likely unaligned load
-    let row8 = YmmRegister::load(in_vector[1..].as_ptr().cast());
+        // Do another load for the first row, we don't want to check DC value, because
+        // we only care about AC terms
+        // TODO this should be a shift/shuffle, not a likely unaligned load
+        let row8 = YmmRegister::load(in_vector[1..].as_ptr().cast());
 
-    let or_tree = (((row1 | row8) | (row2 | row3)) | ((row4 | row5) | (row6 | row7)));
+        let or_tree = (((row1 | row8) | (row2 | row3)) | ((row4 | row5) | (row6 | row7)));
 
-    if or_tree.all_zero() {
-        // AC terms all zero, idct of the block is ( coeff[0] * qt[0] )/8 + 128 (bias)
-        // (and clamped to 255)
-        // Round by adding 0.5 * (1 << 3) and offset by adding (128 << 3) before scaling
-        let coeff = ((in_vector[0] + 4 + 1024) >> 3).clamp(0, 255) as i16;
-        let idct_value = vdupq_n_s16(coeff);
+        if or_tree.all_zero() {
+            // AC terms all zero, idct of the block is ( coeff[0] * qt[0] )/8 + 128 (bias)
+            // (and clamped to 255)
+            // Round by adding 0.5 * (1 << 3) and offset by adding (128 << 3) before scaling
+            let coeff = ((in_vector[0] + 4 + 1024) >> 3).clamp(0, 255) as i16;
+            let idct_value = vdupq_n_s16(coeff);
 
-        macro_rules! store {
-            ($pos:tt,$value:tt) => {
-                // store
+            macro_rules! store {
+                ($pos:tt,$value:tt) => {
+                    // store
+                    vst1q_s16(
+                        out_vector
+                            .get_mut($pos..$pos + 8)
+                            .unwrap()
+                            .as_mut_ptr()
+                            .cast(),
+                        $value,
+                    );
+                    $pos += stride;
+                };
+            }
+            store!(pos, idct_value);
+            store!(pos, idct_value);
+            store!(pos, idct_value);
+            store!(pos, idct_value);
+
+            store!(pos, idct_value);
+            store!(pos, idct_value);
+            store!(pos, idct_value);
+            store!(pos, idct_value);
+
+            return;
+        }
+
+        macro_rules! dct_pass {
+            ($SCALE_BITS:tt,$scale:tt) => {
+                // There are a lot of ways to do this
+                // but to keep it simple(and beautiful), ill make a direct translation of the
+                // scalar code to also make this code fully transparent(this version and the non
+                // avx one should produce identical code.)
+
+                // Compiler does a pretty good job of optimizing add + mul pairs
+                // into multiply-acumulate pairs
+
+                // even part
+                let p1 = (row2 + row6) * 2217;
+
+                let mut t2 = p1 + row6 * -7567;
+                let mut t3 = p1 + row2 * 3135;
+
+                let mut t0 = (row0 + row4).const_shl::<12>();
+                let mut t1 = (row0 - row4).const_shl::<12>();
+
+                let x0 = t0 + t3 + $SCALE_BITS;
+                let x3 = t0 - t3 + $SCALE_BITS;
+                let x1 = t1 + t2 + $SCALE_BITS;
+                let x2 = t1 - t2 + $SCALE_BITS;
+
+                let p3 = row7 + row3;
+                let p4 = row5 + row1;
+                let p1 = row7 + row1;
+                let p2 = row5 + row3;
+                let p5 = (p3 + p4) * 4816;
+
+                t0 = row7 * 1223;
+                t1 = row5 * 8410;
+                t2 = row3 * 12586;
+                t3 = row1 * 6149;
+
+                let p1 = p5 + p1 * -3685;
+                let p2 = p5 + (p2 * -10497);
+                let p3 = p3 * -8034;
+                let p4 = p4 * -1597;
+
+                t3 += p1 + p4;
+                t2 += p2 + p3;
+                t1 += p2 + p4;
+                t0 += p1 + p3;
+
+                row0 = (x0 + t3).const_shra::<$scale>();
+                row1 = (x1 + t2).const_shra::<$scale>();
+                row2 = (x2 + t1).const_shra::<$scale>();
+                row3 = (x3 + t0).const_shra::<$scale>();
+
+                row4 = (x3 - t0).const_shra::<$scale>();
+                row5 = (x2 - t1).const_shra::<$scale>();
+                row6 = (x1 - t2).const_shra::<$scale>();
+                row7 = (x0 - t3).const_shra::<$scale>();
+            };
+        }
+
+        // Process rows
+        dct_pass!(512, 10);
+        transpose(
+            &mut row0, &mut row1, &mut row2, &mut row3, &mut row4, &mut row5, &mut row6, &mut row7,
+        );
+
+        // process columns
+        dct_pass!(SCALE_BITS, 17);
+        transpose(
+            &mut row0, &mut row1, &mut row2, &mut row3, &mut row4, &mut row5, &mut row6, &mut row7,
+        );
+
+        // Pack i32 to i16's,
+        // clamp them to be between 0-255
+        // Undo shuffling
+        // Store back to array
+
+        // This could potentially be reorganized to take advantage of the multi-register stores
+        macro_rules! permute_store {
+            ($x:tt,$y:tt,$index:tt,$out:tt) => {
+                let a = condense_bottom_16($x, $y);
+
+                // Clamp the values after packing, we can clamp more values at once
+                let b = clamp256_neon(a);
+
+                // store first vector
                 vst1q_s16(
-                    out_vector
-                        .get_mut($pos..$pos + 8)
+                    ($out)
+                        .get_mut($index..$index + 8)
                         .unwrap()
                         .as_mut_ptr()
                         .cast(),
-                    $value
+                    b.0,
                 );
-                $pos += stride;
+                $index += stride;
+                // second vector
+                vst1q_s16(
+                    ($out)
+                        .get_mut($index..$index + 8)
+                        .unwrap()
+                        .as_mut_ptr()
+                        .cast(),
+                    b.1,
+                );
+                $index += stride;
             };
         }
-        store!(pos, idct_value);
-        store!(pos, idct_value);
-        store!(pos, idct_value);
-        store!(pos, idct_value);
-
-        store!(pos, idct_value);
-        store!(pos, idct_value);
-        store!(pos, idct_value);
-        store!(pos, idct_value);
-
-        return;
+        // Pack and write the values back to the array
+        permute_store!((row0.mm256), (row1.mm256), pos, out_vector);
+        permute_store!((row2.mm256), (row3.mm256), pos, out_vector);
+        permute_store!((row4.mm256), (row5.mm256), pos, out_vector);
+        permute_store!((row6.mm256), (row7.mm256), pos, out_vector);
     }
-
-    macro_rules! dct_pass {
-        ($SCALE_BITS:tt,$scale:tt) => {
-            // There are a lot of ways to do this
-            // but to keep it simple(and beautiful), ill make a direct translation of the
-            // scalar code to also make this code fully transparent(this version and the non
-            // avx one should produce identical code.)
-
-            // Compiler does a pretty good job of optimizing add + mul pairs
-            // into multiply-acumulate pairs
-
-            // even part
-            let p1 = (row2 + row6) * 2217;
-
-            let mut t2 = p1 + row6 * -7567;
-            let mut t3 = p1 + row2 * 3135;
-
-            let mut t0 = (row0 + row4).const_shl::<12>();
-            let mut t1 = (row0 - row4).const_shl::<12>();
-
-            let x0 = t0 + t3 + $SCALE_BITS;
-            let x3 = t0 - t3 + $SCALE_BITS;
-            let x1 = t1 + t2 + $SCALE_BITS;
-            let x2 = t1 - t2 + $SCALE_BITS;
-
-            let p3 = row7 + row3;
-            let p4 = row5 + row1;
-            let p1 = row7 + row1;
-            let p2 = row5 + row3;
-            let p5 = (p3 + p4) * 4816;
-
-            t0 = row7 * 1223;
-            t1 = row5 * 8410;
-            t2 = row3 * 12586;
-            t3 = row1 * 6149;
-
-            let p1 = p5 + p1 * -3685;
-            let p2 = p5 + (p2 * -10497);
-            let p3 = p3 * -8034;
-            let p4 = p4 * -1597;
-
-            t3 += p1 + p4;
-            t2 += p2 + p3;
-            t1 += p2 + p4;
-            t0 += p1 + p3;
-
-            row0 = (x0 + t3).const_shra::<$scale>();
-            row1 = (x1 + t2).const_shra::<$scale>();
-            row2 = (x2 + t1).const_shra::<$scale>();
-            row3 = (x3 + t0).const_shra::<$scale>();
-
-            row4 = (x3 - t0).const_shra::<$scale>();
-            row5 = (x2 - t1).const_shra::<$scale>();
-            row6 = (x1 - t2).const_shra::<$scale>();
-            row7 = (x0 - t3).const_shra::<$scale>();
-        };
-    }
-
-    // Process rows
-    dct_pass!(512, 10);
-    transpose(
-        &mut row0, &mut row1, &mut row2, &mut row3, &mut row4, &mut row5, &mut row6, &mut row7
-    );
-
-    // process columns
-    dct_pass!(SCALE_BITS, 17);
-    transpose(
-        &mut row0, &mut row1, &mut row2, &mut row3, &mut row4, &mut row5, &mut row6, &mut row7
-    );
-
-    // Pack i32 to i16's,
-    // clamp them to be between 0-255
-    // Undo shuffling
-    // Store back to array
-
-    // This could potentially be reorganized to take advantage of the multi-register stores
-    macro_rules! permute_store {
-        ($x:tt,$y:tt,$index:tt,$out:tt) => {
-            let a = condense_bottom_16($x, $y);
-
-            // Clamp the values after packing, we can clamp more values at once
-            let b = clamp256_neon(a);
-
-            // store first vector
-            vst1q_s16(
-                ($out)
-                    .get_mut($index..$index + 8)
-                    .unwrap()
-                    .as_mut_ptr()
-                    .cast(),
-                b.0
-            );
-            $index += stride;
-            // second vector
-            vst1q_s16(
-                ($out)
-                    .get_mut($index..$index + 8)
-                    .unwrap()
-                    .as_mut_ptr()
-                    .cast(),
-                b.1
-            );
-            $index += stride;
-        };
-    }
-    // Pack and write the values back to the array
-    permute_store!((row0.mm256), (row1.mm256), pos, out_vector);
-    permute_store!((row2.mm256), (row3.mm256), pos, out_vector);
-    permute_store!((row4.mm256), (row5.mm256), pos, out_vector);
-    permute_store!((row6.mm256), (row7.mm256), pos, out_vector);
 }
 
 #[inline]
@@ -246,14 +245,13 @@ unsafe fn clamp_neon(reg: int16x8_t) -> int16x8_t {
     let max_s = vdupq_n_s16(255);
 
     let max_v = vmaxq_s16(reg, min_s); //max(a,0)
-    let min_v = vminq_s16(max_v, max_s); //min(max(a,0),255)
-    min_v
+    vminq_s16(max_v, max_s) //min(max(a,0),255)
 }
 
 #[inline]
 #[target_feature(enable = "neon")]
 unsafe fn clamp256_neon(reg: int16x8x2_t) -> int16x8x2_t {
-    int16x8x2_t(clamp_neon(reg.0), clamp_neon(reg.1))
+    unsafe { int16x8x2_t(clamp_neon(reg.0), clamp_neon(reg.1)) }
 }
 
 #[cfg(test)]

--- a/crates/zune-jpeg/src/unsafe_utils_neon.rs
+++ b/crates/zune-jpeg/src/unsafe_utils_neon.rs
@@ -18,7 +18,7 @@ use core::ops::{Add, AddAssign, BitOr, BitOrAssign, Mul, MulAssign, Sub};
 pub type VecType = int32x4x2_t;
 
 pub unsafe fn loadu(src: *const i32) -> VecType {
-    vld1q_s32_x2(src as *const _)
+    unsafe { vld1q_s32_x2(src as *const _) }
 }
 
 /// An abstraction of an AVX ymm register that
@@ -32,7 +32,7 @@ pub struct YmmRegister {
 impl YmmRegister {
     #[inline]
     pub unsafe fn load(src: *const i32) -> Self {
-        loadu(src).into()
+        unsafe { loadu(src).into() }
     }
 
     #[inline]
@@ -190,31 +190,33 @@ impl From<VecType> for YmmRegister {
 unsafe fn transpose4(
     v0: &mut int32x4_t, v1: &mut int32x4_t, v2: &mut int32x4_t, v3: &mut int32x4_t
 ) {
-    let w0 = vtrnq_s32(
-        vreinterpretq_s32_s64(vtrn1q_s64(
-            vreinterpretq_s64_s32(*v0),
-            vreinterpretq_s64_s32(*v2)
-        )),
-        vreinterpretq_s32_s64(vtrn1q_s64(
-            vreinterpretq_s64_s32(*v1),
-            vreinterpretq_s64_s32(*v3)
-        ))
-    );
-    let w1 = vtrnq_s32(
-        vreinterpretq_s32_s64(vtrn2q_s64(
-            vreinterpretq_s64_s32(*v0),
-            vreinterpretq_s64_s32(*v2)
-        )),
-        vreinterpretq_s32_s64(vtrn2q_s64(
-            vreinterpretq_s64_s32(*v1),
-            vreinterpretq_s64_s32(*v3)
-        ))
-    );
+    unsafe {
+        let w0 = vtrnq_s32(
+            vreinterpretq_s32_s64(vtrn1q_s64(
+                vreinterpretq_s64_s32(*v0),
+                vreinterpretq_s64_s32(*v2)
+            )),
+            vreinterpretq_s32_s64(vtrn1q_s64(
+                vreinterpretq_s64_s32(*v1),
+                vreinterpretq_s64_s32(*v3)
+            ))
+        );
+        let w1 = vtrnq_s32(
+            vreinterpretq_s32_s64(vtrn2q_s64(
+                vreinterpretq_s64_s32(*v0),
+                vreinterpretq_s64_s32(*v2)
+            )),
+            vreinterpretq_s32_s64(vtrn2q_s64(
+                vreinterpretq_s64_s32(*v1),
+                vreinterpretq_s64_s32(*v3)
+            ))
+        );
 
-    *v0 = w0.0;
-    *v1 = w0.1;
-    *v2 = w1.0;
-    *v3 = w1.1;
+        *v0 = w0.0;
+        *v1 = w0.1;
+        *v2 = w1.0;
+        *v3 = w1.1;
+    }
 }
 
 /// Transpose an array of 8 by 8 i32
@@ -228,40 +230,42 @@ pub unsafe fn transpose(
     v0: &mut YmmRegister, v1: &mut YmmRegister, v2: &mut YmmRegister, v3: &mut YmmRegister,
     v4: &mut YmmRegister, v5: &mut YmmRegister, v6: &mut YmmRegister, v7: &mut YmmRegister
 ) {
-    use core::mem::swap;
+    unsafe {
+        use core::mem::swap;
 
-    let ul0 = &mut v0.mm256.0;
-    let ul1 = &mut v1.mm256.0;
-    let ul2 = &mut v2.mm256.0;
-    let ul3 = &mut v3.mm256.0;
+        let ul0 = &mut v0.mm256.0;
+        let ul1 = &mut v1.mm256.0;
+        let ul2 = &mut v2.mm256.0;
+        let ul3 = &mut v3.mm256.0;
 
-    let ur0 = &mut v0.mm256.1;
-    let ur1 = &mut v1.mm256.1;
-    let ur2 = &mut v2.mm256.1;
-    let ur3 = &mut v3.mm256.1;
+        let ur0 = &mut v0.mm256.1;
+        let ur1 = &mut v1.mm256.1;
+        let ur2 = &mut v2.mm256.1;
+        let ur3 = &mut v3.mm256.1;
 
-    let ll0 = &mut v4.mm256.0;
-    let ll1 = &mut v5.mm256.0;
-    let ll2 = &mut v6.mm256.0;
-    let ll3 = &mut v7.mm256.0;
+        let ll0 = &mut v4.mm256.0;
+        let ll1 = &mut v5.mm256.0;
+        let ll2 = &mut v6.mm256.0;
+        let ll3 = &mut v7.mm256.0;
 
-    let lr0 = &mut v4.mm256.1;
-    let lr1 = &mut v5.mm256.1;
-    let lr2 = &mut v6.mm256.1;
-    let lr3 = &mut v7.mm256.1;
+        let lr0 = &mut v4.mm256.1;
+        let lr1 = &mut v5.mm256.1;
+        let lr2 = &mut v6.mm256.1;
+        let lr3 = &mut v7.mm256.1;
 
-    swap(ur0, ll0);
-    swap(ur1, ll1);
-    swap(ur2, ll2);
-    swap(ur3, ll3);
+        swap(ur0, ll0);
+        swap(ur1, ll1);
+        swap(ur2, ll2);
+        swap(ur3, ll3);
 
-    transpose4(ul0, ul1, ul2, ul3);
+        transpose4(ul0, ul1, ul2, ul3);
 
-    transpose4(ur0, ur1, ur2, ur3);
+        transpose4(ur0, ur1, ur2, ur3);
 
-    transpose4(ll0, ll1, ll2, ll3);
+        transpose4(ll0, ll1, ll2, ll3);
 
-    transpose4(lr0, lr1, lr2, lr3);
+        transpose4(lr0, lr1, lr2, lr3);
+    }
 }
 
 #[cfg(test)]

--- a/crates/zune-jpeg/src/upsampler/neon.rs
+++ b/crates/zune-jpeg/src/upsampler/neon.rs
@@ -11,7 +11,7 @@ use core::arch::aarch64::*;
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
-pub fn upsample_horizontal_neon(
+pub unsafe fn upsample_horizontal_neon(
     input: &[i16], in_near: &[i16], in_far: &[i16], scratch: &mut [i16], output: &mut [i16]
 ) {
     assert_eq!(input.len() * 2, output.len());
@@ -80,7 +80,7 @@ pub fn upsample_horizontal_neon(
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
-pub fn upsample_vertical_neon(
+pub unsafe fn upsample_vertical_neon(
     input: &[i16], in_near: &[i16], in_far: &[i16], scratch: &mut [i16], output: &mut [i16]
 ) {
     assert_eq!(input.len() * 2, output.len());
@@ -157,23 +157,26 @@ pub fn upsample_vertical_neon(
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
-pub fn upsample_hv_neon(
+pub unsafe fn upsample_hv_neon(
     input: &[i16], in_near: &[i16], in_far: &[i16], scratch_space: &mut [i16], output: &mut [i16]
 ) {
     assert_eq!(input.len() * 4, output.len());
-    
+
     assert!(input.len() * 2 <= scratch_space.len());
     let scratch_space = &mut scratch_space[..input.len() * 2];
 
-    upsample_vertical_neon(input, in_near, in_far, &mut [], scratch_space);
+    // SAFETY: caller guarantees NEON is available
+    unsafe {
+        upsample_vertical_neon(input, in_near, in_far, &mut [], scratch_space);
 
-    let scratch_half = scratch_space.len() / 2;
-    let output_half = output.len() / 2;
+        let scratch_half = scratch_space.len() / 2;
+        let output_half = output.len() / 2;
 
-    let (scratch_top, scratch_bottom) = scratch_space.split_at_mut(scratch_half);
-    let (out_top, out_bottom) = output.split_at_mut(output_half);
+        let (scratch_top, scratch_bottom) = scratch_space.split_at_mut(scratch_half);
+        let (out_top, out_bottom) = output.split_at_mut(output_half);
 
-    let mut t = [0];
-    upsample_horizontal_neon(scratch_top, &[], &[], &mut t, out_top);
-    upsample_horizontal_neon(scratch_bottom, &[], &[], &mut t, out_bottom);
+        let mut t = [0];
+        upsample_horizontal_neon(scratch_top, &[], &[], &mut t, out_top);
+        upsample_horizontal_neon(scratch_bottom, &[], &[], &mut t, out_bottom);
+    }
 }


### PR DESCRIPTION
## Problem

Multiple `unsafe fn` functions across the codebase have bodies that call unsafe operations without explicit `unsafe {}` blocks. Under `unsafe_op_in_unsafe_fn` (deny-by-default in Rust edition 2024), these fail to compile.

The NEON upsampler functions additionally used `#[target_feature(enable = "neon")]` without being declared `unsafe fn`, which is the same class of issue fixed for AVX2 in #344.

There was also no CI coverage for aarch64 at the MSRV boundary, so these issues went undetected.

## Fix

### CI (`f87b5bda`)
- Add `workflow_dispatch` trigger to the Test workflow
- Add `ubuntu-24.04-arm` / toolchain `1.88` matrix entry with `-D unsafe_op_in_unsafe_fn` in RUSTFLAGS
- **Failing run (before fix):** https://github.com/kubijo/zune-image/actions/runs/22755012242
- **Passing run (after fix):** https://github.com/kubijo/zune-image/actions/runs/22756419888

### Code (`d10991c3`)

**`zune-jpeg`** — NEON upsampler, color convert, IDCT, and utility files:
- `upsampler/neon.rs`: `pub fn` → `pub unsafe fn` for `upsample_horizontal_neon`, `upsample_vertical_neon`, `upsample_hv_neon`; add `unsafe {}` block in `upsample_hv_neon` body
- `color_convert/neon64.rs`: wrap `ycbcr_to_rgb_baseline_no_clamp` body in `unsafe {}`
- `idct/neon.rs`: wrap `idct_neon`, `condense_bottom_16`, `clamp256_neon` bodies in `unsafe {}`
- `unsafe_utils_neon.rs`: wrap `loadu`, `YmmRegister::load`, `transpose4`, `transpose` bodies in `unsafe {}`

**`zune-image`** — channel allocator:
- `channel.rs`: wrap unsafe ops in `alloc`, `realloc`, `dealloc`, `extend_unchecked`, `reinterpret_as_unchecked`, `alias`, `alias_mut`

**`zune-capi`** — C FFI:
- `utils.rs`: wrap unsafe ops in `zil_guess_format`, `zil_malloc`, `zil_free`, `zil_free_and_null`
- `errno.rs`: wrap unsafe ops in `zil_status_new`

## Note

The three nightly CI failures are a pre-existing `portable_simd` API breakage (`Mask::select` removed), unrelated to this PR.