### PR TITLE
jpeg: Add mpf offset to ImageInfo

### DIFF
--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -999,7 +999,9 @@ pub struct ImageInfo {
     /// Extended XMP Guid
     pub extended_xmp_guid: Option<Vec<u8>>,
     /// Image sub-sampling ratio
-    pub sample_ratio: SampleRatios
+    pub sample_ratio: SampleRatios,
+    /// The offset at which Multi picture information was found
+    pub multi_picture_information_offset: Option<u64>,
 }
 
 impl ImageInfo {

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -666,6 +666,7 @@ pub(crate) fn parse_app2<T: ZByteReaderTrait>(
         trace!("MPF Signature present");
         length = length.saturating_sub(MPF_DATA.len());
         decoder.stream.skip(MPF_DATA.len())?;
+        decoder.info.multi_picture_information_offset = Some(decoder.stream.position()?);
         // MPF signature taken from here
         // https://github.com/google/libultrahdr/blob/bf2aa439eea9ad5da483003fa44182f990f74091/lib/include/ultrahdr/multipictureformat.h#L50
         // https://github.com/google/libultrahdr/blob/bf2aa439eea9ad5da483003fa44182f990f74091/lib/src/multipictureformat.cpp#L36


### PR DESCRIPTION
The multi_picture_information data may contain offsets in it that are relative to the start of the mpf data. So the data itself is not completely useful without the start offset.

Add a new field to ImageInfo that exposes the start offset.