### PR TITLE
jpeg: avoid debug panic with invalid huge dc prediction

### DIFF
--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -397,7 +397,7 @@ impl BitStream {
         self.decode_dc(reader, dc_table, dc_prediction)?;
 
         // set dc to be the dc prediction.
-        block[0] = *dc_prediction * qt_table[0];
+        block[0] = dc_prediction.wrapping_mul(qt_table[0]);
 
         while pos < 64 {
             self.refill(reader)?;


### PR DESCRIPTION
This fixes a panic when fuzzing in debug mode due to a signed integer overflow. The jpeg decoder does not validate that the dc prediction remains in the expected range; so it can grow very large if every block adds to to the dc prediction. At some point dc_prediction * qt_table[0] overflows.

To reproduce, apply `./target/debug/zune -i `to the attached image:

<img width="255" height="256" alt="fuzz-overflow" src="https://github.com/user-attachments/assets/140dab2f-551b-4e23-b77a-06c4f331426f" />
