### PR TITLE
Introduce minimal state machine for resumable decoding in JpegDecoder

### DIFF
--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -80,7 +80,7 @@ pub(crate) enum DecodingState {
     /// Headers not yet fully decoded.
     DecodeHeaders,
     /// Headers decoded; scan data starts at `scan_start_position`.
-    DecodeScan { scan_start_position: u64 },
+    DecodeScan { scan_start_position: usize },
 }
 
 /// An encapsulation of an ICC chunk
@@ -570,7 +570,8 @@ where
 
                         // Transition to scan phase, remembering where scan data starts.
                         if self.state == DecodingState::DecodeHeaders {
-                            let pos = self.stream.position()?;
+                            #[allow(clippy::cast_possible_truncation)]
+                            let pos = self.stream.position()? as usize;
                             self.state = DecodingState::DecodeScan {
                                 scan_start_position: pos,
                             };
@@ -918,7 +919,7 @@ where
             }
             DecodingState::DecodeScan { scan_start_position } => {
                 // Seek back to scan start (needed for retry after more data arrived).
-                self.stream.set_position(scan_start_position as usize)?;
+                self.stream.set_position(scan_start_position)?;
             }
         }
 
@@ -985,8 +986,8 @@ where
     fn reset_header_state(&mut self) {
         self.info = ImageInfo::default();
         self.qt_tables = [None, None, None, None];
-        self.dc_huffman_tables = [None, None, None, None];
-        self.ac_huffman_tables = [None, None, None, None];
+        self.entropy_tables.dc_huffman = [None, None, None, None];
+        self.entropy_tables.ac_huffman = [None, None, None, None];
         self.components.clear();
         self.h_max = 1;
         self.v_max = 1;

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -74,6 +74,15 @@ pub type ColorConvert16Ptr = fn(&[i16; 16], &[i16; 16], &[i16; 16], &mut [u8], &
 /// Carry out IDCT (type 3 dct) on ach block of 64 i16's
 pub type IDCTPtr = fn(&mut [i32; 64], &mut [i16], usize);
 
+/// Tracks the current decoding phase for incremental decoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DecodingState {
+    /// Headers not yet fully decoded.
+    DecodeHeaders,
+    /// Headers decoded; scan data starts at `scan_start_position`.
+    DecodeScan { scan_start_position: u64 },
+}
+
 /// An encapsulation of an ICC chunk
 pub(crate) struct ICCChunk {
     pub(crate) seq_no:      u8,
@@ -175,6 +184,8 @@ pub struct JpegDecoder<T> {
     pub(crate) coeff:    usize, // Solves some weird bug :)
     /// Extended XMP segments
     pub(crate) extended_xmp_segments: Vec<ExtendedXmpSegment>,
+    /// Current decoding phase for incremental decoding.
+    state: DecodingState,
 }
 
 impl<T> JpegDecoder<T>
@@ -238,6 +249,7 @@ where
             is_mjpeg:          false,
             coeff:             1,
             extended_xmp_segments: vec![],
+            state:             DecodingState::DecodeHeaders,
         }
     }
     /// Decode a buffer already in memory
@@ -887,7 +899,14 @@ where
     ///
     ///
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
-        self.decode_headers_internal()?;
+        // Ensure headers are decoded (idempotent if already done).
+        self.decode_headers()?;
+
+        // At this point state is guaranteed to be DecodeScan.
+        if let DecodingState::DecodeScan { scan_start_position } = self.state {
+            // Seek back to scan start (needed for retry after more data arrived).
+            self.stream.set_position(scan_start_position as usize)?;
+        }
 
         let expected_size = self.output_buffer_size().unwrap();
 
@@ -936,11 +955,70 @@ where
     /// println!("Number of components in the image are {}", decoder.info().unwrap().components);
     /// ```
     /// # Errors
-    /// See DecodeErrors enum for list of possible errors during decoding
+    /// See DecodeErrors enum for list of possible errors during decoding.
+    ///
+    /// If the reader runs out of data the error will satisfy
+    /// [`is_recoverable_eof()`](crate::errors::DecodeErrors::is_recoverable_eof);
+    /// the decoder resets and the caller may retry after providing more data.
     pub fn decode_headers(&mut self) -> Result<(), DecodeErrors> {
-        self.decode_headers_internal()?;
-        Ok(())
+        match self.decode_headers_internal() {
+            Ok(()) => {
+                // Transition to scan phase, remembering where scan data starts.
+                if self.state == DecodingState::DecodeHeaders {
+                    let pos = self.stream.position()?;
+                    self.state = DecodingState::DecodeScan {
+                        scan_start_position: pos,
+                    };
+                }
+                Ok(())
+            }
+            Err(e) => {
+                if e.is_recoverable_eof() {
+                    self.reset_header_state();
+                }
+                Err(e)
+            }
+        }
     }
+
+    /// Reset all state set during header parsing so that
+    /// `decode_headers_internal` can be called again from scratch.
+    // NB: fields here must stay in sync with `fn default()`.
+    fn reset_header_state(&mut self) {
+        self.info = ImageInfo::default();
+        self.qt_tables = [None, None, None, None];
+        self.dc_huffman_tables = [None, None, None, None];
+        self.ac_huffman_tables = [None, None, None, None];
+        self.components.clear();
+        self.h_max = 1;
+        self.v_max = 1;
+        self.mcu_height = 0;
+        self.mcu_width = 0;
+        self.mcu_x = 0;
+        self.mcu_y = 0;
+        self.is_interleaved = false;
+        self.is_progressive = false;
+        self.spec_start = 0;
+        self.spec_end = 0;
+        self.succ_high = 0;
+        self.succ_low = 0;
+        self.num_scans = 0;
+        self.scan_subsampled = false;
+        self.input_colorspace = ColorSpace::YCbCr;
+        self.z_order = [0; MAX_COMPONENTS];
+        self.restart_interval = 0;
+        self.todo = 0x7fff_ffff;
+        self.headers_decoded = false;
+        self.seen_sof = false;
+        self.icc_data.clear();
+        self.is_mjpeg = false;
+        self.coeff = 1;
+        self.extended_xmp_segments.clear();
+        self.state = DecodingState::DecodeHeaders;
+        // Best-effort seek to start; may fail for non-seekable streams.
+        let _ = self.stream.set_position(0);
+    }
+
     /// Create a new decoder with the specified options to be used for decoding
     /// an image
     ///

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -448,9 +448,14 @@ where
     ///  - DAC -> Images using Arithmetic tables
     ///  - JPG(n)
     fn decode_headers_internal(&mut self) -> Result<(), DecodeErrors> {
-        if self.headers_decoded {
-            trace!("Headers decoded!");
-            return Ok(());
+        match self.state {
+            DecodingState::DecodeScan { .. } => {
+                return Ok(());
+            }
+            DecodingState::DecodeHeaders => {
+                // Reset any partial state from a prior incomplete attempt.
+                self.reset_header_state();
+            }
         }
 
         // match output colorspace here
@@ -561,6 +566,14 @@ where
                         // Image is RGB, change colorspace
                         if is_rgb {
                             self.input_colorspace = ColorSpace::RGB;
+                        }
+
+                        // Transition to scan phase, remembering where scan data starts.
+                        if self.state == DecodingState::DecodeHeaders {
+                            let pos = self.stream.position()?;
+                            self.state = DecodingState::DecodeScan {
+                                scan_start_position: pos,
+                            };
                         }
 
                         return Ok(());
@@ -899,13 +912,14 @@ where
     ///
     ///
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
-        // Ensure headers are decoded (idempotent if already done).
-        self.decode_headers()?;
-
-        // At this point state is guaranteed to be DecodeScan.
-        if let DecodingState::DecodeScan { scan_start_position } = self.state {
-            // Seek back to scan start (needed for retry after more data arrived).
-            self.stream.set_position(scan_start_position as usize)?;
+        match self.state {
+            DecodingState::DecodeHeaders => {
+                self.decode_headers_internal()?;
+            }
+            DecodingState::DecodeScan { scan_start_position } => {
+                // Seek back to scan start (needed for retry after more data arrived).
+                self.stream.set_position(scan_start_position as usize)?;
+            }
         }
 
         let expected_size = self.output_buffer_size().unwrap();
@@ -959,26 +973,10 @@ where
     ///
     /// If the reader runs out of data the error will satisfy
     /// [`is_recoverable_eof()`](crate::errors::DecodeErrors::is_recoverable_eof);
-    /// the decoder resets and the caller may retry after providing more data.
+    /// the caller may retry after providing more data.
     pub fn decode_headers(&mut self) -> Result<(), DecodeErrors> {
-        match self.decode_headers_internal() {
-            Ok(()) => {
-                // Transition to scan phase, remembering where scan data starts.
-                if self.state == DecodingState::DecodeHeaders {
-                    let pos = self.stream.position()?;
-                    self.state = DecodingState::DecodeScan {
-                        scan_start_position: pos,
-                    };
-                }
-                Ok(())
-            }
-            Err(e) => {
-                if e.is_recoverable_eof() {
-                    self.reset_header_state();
-                }
-                Err(e)
-            }
-        }
+        self.decode_headers_internal()?;
+        Ok(())
     }
 
     /// Reset all state set during header parsing so that

--- a/crates/zune-jpeg/src/errors.rs
+++ b/crates/zune-jpeg/src/errors.rs
@@ -58,6 +58,30 @@ pub enum DecodeErrors {
 #[cfg(feature = "std")]
 impl std::error::Error for DecodeErrors {}
 
+impl DecodeErrors {
+    /// Returns `true` when this error indicates the reader ran out of
+    /// data, as opposed to a format or data-corruption error.
+    ///
+    /// Useful for incremental decoding: feed more bytes and retry.
+    #[must_use]
+    pub fn is_recoverable_eof(&self) -> bool {
+        match self {
+            DecodeErrors::ExhaustedData => true,
+            DecodeErrors::IoErrors(io) => {
+                if matches!(io, ZByteIoError::NotEnoughBytes(_, _)) {
+                    return true;
+                }
+                #[cfg(feature = "std")]
+                if let ZByteIoError::StdIoError(e) = io {
+                    return e.kind() == std::io::ErrorKind::UnexpectedEof;
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+}
+
 impl From<&'static str> for DecodeErrors {
     fn from(data: &'static str) -> Self {
         return Self::FormatStatic(data);

--- a/crates/zune-jpeg/src/errors.rs
+++ b/crates/zune-jpeg/src/errors.rs
@@ -67,16 +67,7 @@ impl DecodeErrors {
     pub fn is_recoverable_eof(&self) -> bool {
         match self {
             DecodeErrors::ExhaustedData => true,
-            DecodeErrors::IoErrors(io) => {
-                if matches!(io, ZByteIoError::NotEnoughBytes(_, _)) {
-                    return true;
-                }
-                #[cfg(feature = "std")]
-                if let ZByteIoError::StdIoError(e) = io {
-                    return e.kind() == std::io::ErrorKind::UnexpectedEof;
-                }
-                false
-            }
+            DecodeErrors::IoErrors(io) => io.is_recoverable_eof(),
             _ => false,
         }
     }

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -14,74 +14,18 @@
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::JpegDecoder;
 
-/// Find the smallest prefix of `data` for which `decode_headers` succeeds.
-/// Returns the length of that prefix.
-fn find_header_boundary(data: &[u8]) -> usize {
-    for n in 1..=data.len() {
-        let mut dec = JpegDecoder::new(ZCursor::new(&data[..n]));
-        if dec.decode_headers().is_ok() {
-            return n;
-        }
-    }
-    panic!("decode_headers never succeeded");
-}
-
-/// Feed `data` to the decoder in chunks of `chunk_size` bytes for the
-/// header phase, growing the visible window one chunk at a time.
-/// Each time `decode_headers` returns a recoverable EOF, a **new decoder**
-/// is created with a larger slice (since `ZCursor<&[u8]>` is immutable).
-/// Once headers are decoded, the scan is run with the full data.
-///
-/// Returns the decoded pixels.
-fn decode_chunked_headers(data: &[u8], chunk_size: usize) -> Vec<u8> {
-    assert!(chunk_size > 0);
-
-    let mut available = chunk_size.min(data.len());
-
-    // Phase 1: decode headers, growing the window until success
-    let mut decoder;
-    loop {
-        decoder = JpegDecoder::new(ZCursor::new(&data[..available]));
-        match decoder.decode_headers() {
-            Ok(()) => break,
-            Err(ref e) if e.is_recoverable_eof() => {
-                if available >= data.len() {
-                    panic!(
-                        "decode_headers: EOF with all {} bytes available",
-                        data.len()
-                    );
-                }
-                available = (available + chunk_size).min(data.len());
-                // Create a new decoder with the larger slice on next iteration
-            }
-            Err(e) => panic!("decode_headers error at available={available}: {e:?}"),
-        }
-    }
-
-    // Phase 2: headers succeeded; if the decoder doesn't have the full
-    // data yet, create a final decoder with everything.
-    if available < data.len() {
-        decoder = JpegDecoder::new(ZCursor::new(data));
-        decoder.decode_headers().unwrap();
-    }
-
-    let size = decoder.output_buffer_size().unwrap();
-    let mut out = vec![0u8; size];
-    decoder.decode_into(&mut out).unwrap();
-    out
-}
-
 fn decode_oneshot(data: &[u8]) -> Vec<u8> {
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode().expect("one-shot decode failed")
 }
 
-/// Feeding the entire file at once must still work — no regressions.
+/// Feeding the entire file at once via decode_headers + decode_into must
+/// produce byte-identical output to decode() — no regressions.
 #[test]
 fn full_decode_unchanged() {
     let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
     let expected = decode_oneshot(data);
-    // Use decode_headers + decode_into explicitly.
+
     let mut decoder = JpegDecoder::new(ZCursor::new(&data[..]));
     decoder.decode_headers().unwrap();
     let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
@@ -89,147 +33,94 @@ fn full_decode_unchanged() {
     assert_eq!(out, expected);
 }
 
-/// Chunked header decode with 100-byte pieces must produce byte-identical output.
+/// Truncated input must return a recoverable EOF from decode_headers.
+/// Non-EOF errors (bad magic, format errors) must NOT be recoverable.
 #[test]
-fn chunked_headers_100_bytes() {
+fn incomplete_data_returns_recoverable_eof() {
+    // Empty input → recoverable EOF
+    let mut dec = JpegDecoder::new(ZCursor::new(&[] as &[u8]));
+    let err = dec.decode_headers().unwrap_err();
+    assert!(err.is_recoverable_eof(), "empty input: expected recoverable EOF, got: {err:?}");
+
+    // Truncated just after SOI → recoverable EOF
     let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
-    let expected = decode_oneshot(data);
-    let actual = decode_chunked_headers(data, 100);
-    assert_eq!(actual, expected);
-}
+    let mut dec = JpegDecoder::new(ZCursor::new(&data[..2]));
+    let err = dec.decode_headers().unwrap_err();
+    assert!(err.is_recoverable_eof(), "truncated after SOI: expected recoverable EOF, got: {err:?}");
 
-/// Chunked header decode with 1-byte pieces (stress test on a tiny image).
-#[test]
-fn chunked_headers_1_byte() {
-    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
-    let expected = decode_oneshot(data);
-    let actual = decode_chunked_headers(data, 1);
-    assert_eq!(actual, expected);
-}
+    // Bad magic bytes → NOT recoverable
+    let mut dec = JpegDecoder::new(ZCursor::new(&[0x00, 0x00]));
+    let err = dec.decode_headers().unwrap_err();
+    assert!(!err.is_recoverable_eof(), "bad magic: should not be recoverable, got: {err:?}");
 
-/// Chunk larger than the file — never triggers a recoverable EOF.
-#[test]
-fn chunked_headers_larger_than_file() {
-    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
-    let expected = decode_oneshot(data);
-    let actual = decode_chunked_headers(data, data.len() + 1);
-    assert_eq!(actual, expected);
-}
-
-/// Progressive JPEG: chunked header decode must produce the same output.
-#[test]
-fn chunked_headers_progressive() {
-    let data =
-        include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
-    let expected = decode_oneshot(data);
-    let actual = decode_chunked_headers(data, 512);
-    assert_eq!(actual, expected);
-}
-
-/// JPEG with restart markers: chunked header decode.
-#[test]
-fn chunked_headers_restart_markers() {
-    let data = include_bytes!("../../../test-images/jpeg/fox410.jpg");
-    let expected = decode_oneshot(data);
-    let actual = decode_chunked_headers(data, 256);
-    assert_eq!(actual, expected);
-}
-
-/// Empty input must return a recoverable EOF error from decode_headers.
-#[test]
-fn empty_input_is_recoverable_eof() {
-    let mut decoder = JpegDecoder::new(ZCursor::new(&[] as &[u8]));
-    let err = decoder.decode_headers().unwrap_err();
-    assert!(
-        err.is_recoverable_eof(),
-        "expected recoverable EOF, got: {err:?}"
-    );
-}
-
-/// Non-interleaved JPEG: chunked header decode.
-#[test]
-fn chunked_headers_non_interleaved() {
-    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
-    let expected = decode_oneshot(data);
-    let actual = decode_chunked_headers(data, 200);
-    assert_eq!(actual, expected);
-}
-
-/// Down-sampled image (4:2:0): chunked header decode.
-#[test]
-fn chunked_headers_420_subsampled() {
-    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
-    let expected = decode_oneshot(data);
-    let actual = decode_chunked_headers(data, 300);
-    assert_eq!(actual, expected);
-}
-
-/// `is_recoverable_eof` returns false for non-EOF errors.
-#[test]
-fn non_eof_errors_are_not_recoverable() {
+    // Non-EOF error variants → NOT recoverable
     use zune_jpeg::errors::DecodeErrors;
     assert!(!DecodeErrors::ZeroError.is_recoverable_eof());
-    assert!(!DecodeErrors::IllegalMagicBytes(0x1234).is_recoverable_eof());
     assert!(!DecodeErrors::FormatStatic("bad").is_recoverable_eof());
 }
 
-/// After decode_headers recovers from EOF, the header boundary is correct:
-/// we can get the exact same position where scan data starts.
+/// Core resumable decoding test: decode_headers on truncated data returns
+/// a recoverable EOF, then a new decoder with the full data succeeds and
+/// produces byte-identical output to a one-shot decode.
 #[test]
-fn header_boundary_is_consistent() {
-    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
-
-    // Find the minimal amount of data needed for headers to succeed.
-    let boundary = find_header_boundary(data);
-    assert!(boundary > 2, "header boundary should be past SOI");
-    assert!(boundary < data.len(), "header boundary should be before EOF");
-
-    // Verify that feeding exactly `boundary` bytes works via chunked headers.
-    let expected = decode_oneshot(data);
-    let actual = decode_chunked_headers(data, boundary);
-    assert_eq!(actual, expected);
-}
-
-/// After a recoverable EOF, creating a new decoder with more data
-/// and decoding from scratch must produce the correct result.
-#[test]
-fn retry_with_new_decoder() {
+fn resumable_decode_after_eof() {
     let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
     let expected = decode_oneshot(data);
 
-    // Start with too little data (just the SOI marker)
-    let mut decoder = JpegDecoder::new(ZCursor::new(&data[..2]));
+    // Step 1: feed only a small prefix — not enough for headers.
+    let truncated = &data[..64];
+    let mut decoder = JpegDecoder::new(ZCursor::new(truncated));
     let err = decoder.decode_headers().unwrap_err();
-    assert!(err.is_recoverable_eof());
+    assert!(err.is_recoverable_eof(), "expected recoverable EOF on truncated data");
 
-    // Create a new decoder with all data
+    // Step 2: "fill the stream" — create a new decoder with the full data
+    // (ZCursor<&[u8]> is immutable, so we simulate refill by recreating).
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
-    decoder.decode_headers().unwrap();
-
-    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
-    decoder.decode_into(&mut out).unwrap();
-    assert_eq!(out, expected);
+    let result = decoder.decode().unwrap();
+    assert_eq!(result, expected, "full decode after EOF must match one-shot");
 }
 
-/// Calling `decode_headers` repeatedly on the same decoder after
-/// recoverable EOF must not panic or corrupt state — each attempt
-/// resets cleanly and re-parses from position 0.
+/// Calling decode_headers repeatedly on the same decoder with insufficient
+/// data must not panic or corrupt state — each attempt resets cleanly.
 #[test]
-fn repeated_eof_on_same_decoder_does_not_corrupt() {
+fn repeated_eof_does_not_corrupt_state() {
     let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
 
-    // Create decoder with very little data (just SOI + a few bytes)
     let mut decoder = JpegDecoder::new(ZCursor::new(&data[..10]));
 
-    // Multiple retries on the same decoder must all return recoverable EOF
-    // without panicking — proves reset_header_state works correctly.
     for _ in 0..5 {
         let err = decoder.decode_headers().unwrap_err();
-        assert!(
-            err.is_recoverable_eof(),
-            "expected recoverable EOF on retry, got: {err:?}"
-        );
-        // info() must return None since headers were never fully parsed
-        assert!(decoder.info().is_none());
+        assert!(err.is_recoverable_eof(), "expected recoverable EOF on retry, got: {err:?}");
+        assert!(decoder.info().is_none(), "info() must be None after failed headers");
+    }
+}
+
+/// Byte-by-byte header feeding: grow the visible window one byte at a time,
+/// creating a new decoder each time, until headers succeed. The final decoded
+/// output must match one-shot.
+#[test]
+fn chunked_header_feeding_byte_by_byte() {
+    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let expected = decode_oneshot(data);
+
+    let mut available = 1;
+    loop {
+        let mut decoder = JpegDecoder::new(ZCursor::new(&data[..available]));
+        match decoder.decode_headers() {
+            Ok(()) => {
+                // Headers succeeded — now decode with full data.
+                let mut decoder = JpegDecoder::new(ZCursor::new(data));
+                decoder.decode_headers().unwrap();
+                let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+                decoder.decode_into(&mut out).unwrap();
+                assert_eq!(out, expected);
+                return;
+            }
+            Err(ref e) if e.is_recoverable_eof() => {
+                available += 1;
+                assert!(available <= data.len(), "EOF with all bytes available");
+            }
+            Err(e) => panic!("unexpected error at byte {available}: {e:?}"),
+        }
     }
 }

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+//! Tests for incremental (resumable) JPEG decoding.
+//!
+//! Verifies that `is_recoverable_eof()` is reported on truncated input
+//! and that retrying with more data produces correct output.
+
+use zune_core::bytestream::ZCursor;
+use zune_jpeg::JpegDecoder;
+
+/// Find the smallest prefix of `data` for which `decode_headers` succeeds.
+/// Returns the length of that prefix.
+fn find_header_boundary(data: &[u8]) -> usize {
+    for n in 1..=data.len() {
+        let mut dec = JpegDecoder::new(ZCursor::new(&data[..n]));
+        if dec.decode_headers().is_ok() {
+            return n;
+        }
+    }
+    panic!("decode_headers never succeeded");
+}
+
+/// Feed `data` to the decoder in chunks of `chunk_size` bytes for the
+/// header phase, growing the visible window one chunk at a time.
+/// Each time `decode_headers` returns a recoverable EOF, a **new decoder**
+/// is created with a larger slice (since `ZCursor<&[u8]>` is immutable).
+/// Once headers are decoded, the scan is run with the full data.
+///
+/// Returns the decoded pixels.
+fn decode_chunked_headers(data: &[u8], chunk_size: usize) -> Vec<u8> {
+    assert!(chunk_size > 0);
+
+    let mut available = chunk_size.min(data.len());
+
+    // Phase 1: decode headers, growing the window until success
+    let mut decoder;
+    loop {
+        decoder = JpegDecoder::new(ZCursor::new(&data[..available]));
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(ref e) if e.is_recoverable_eof() => {
+                if available >= data.len() {
+                    panic!(
+                        "decode_headers: EOF with all {} bytes available",
+                        data.len()
+                    );
+                }
+                available = (available + chunk_size).min(data.len());
+                // Create a new decoder with the larger slice on next iteration
+            }
+            Err(e) => panic!("decode_headers error at available={available}: {e:?}"),
+        }
+    }
+
+    // Phase 2: headers succeeded; if the decoder doesn't have the full
+    // data yet, create a final decoder with everything.
+    if available < data.len() {
+        decoder = JpegDecoder::new(ZCursor::new(data));
+        decoder.decode_headers().unwrap();
+    }
+
+    let size = decoder.output_buffer_size().unwrap();
+    let mut out = vec![0u8; size];
+    decoder.decode_into(&mut out).unwrap();
+    out
+}
+
+fn decode_oneshot(data: &[u8]) -> Vec<u8> {
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode().expect("one-shot decode failed")
+}
+
+/// Feeding the entire file at once must still work — no regressions.
+#[test]
+fn full_decode_unchanged() {
+    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+    let expected = decode_oneshot(data);
+    // Use decode_headers + decode_into explicitly.
+    let mut decoder = JpegDecoder::new(ZCursor::new(&data[..]));
+    decoder.decode_headers().unwrap();
+    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut out).unwrap();
+    assert_eq!(out, expected);
+}
+
+/// Chunked header decode with 100-byte pieces must produce byte-identical output.
+#[test]
+fn chunked_headers_100_bytes() {
+    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+    let expected = decode_oneshot(data);
+    let actual = decode_chunked_headers(data, 100);
+    assert_eq!(actual, expected);
+}
+
+/// Chunked header decode with 1-byte pieces (stress test on a tiny image).
+#[test]
+fn chunked_headers_1_byte() {
+    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let expected = decode_oneshot(data);
+    let actual = decode_chunked_headers(data, 1);
+    assert_eq!(actual, expected);
+}
+
+/// Chunk larger than the file — never triggers a recoverable EOF.
+#[test]
+fn chunked_headers_larger_than_file() {
+    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+    let expected = decode_oneshot(data);
+    let actual = decode_chunked_headers(data, data.len() + 1);
+    assert_eq!(actual, expected);
+}
+
+/// Progressive JPEG: chunked header decode must produce the same output.
+#[test]
+fn chunked_headers_progressive() {
+    let data =
+        include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
+    let expected = decode_oneshot(data);
+    let actual = decode_chunked_headers(data, 512);
+    assert_eq!(actual, expected);
+}
+
+/// JPEG with restart markers: chunked header decode.
+#[test]
+fn chunked_headers_restart_markers() {
+    let data = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let expected = decode_oneshot(data);
+    let actual = decode_chunked_headers(data, 256);
+    assert_eq!(actual, expected);
+}
+
+/// Empty input must return a recoverable EOF error from decode_headers.
+#[test]
+fn empty_input_is_recoverable_eof() {
+    let mut decoder = JpegDecoder::new(ZCursor::new(&[] as &[u8]));
+    let err = decoder.decode_headers().unwrap_err();
+    assert!(
+        err.is_recoverable_eof(),
+        "expected recoverable EOF, got: {err:?}"
+    );
+}
+
+/// Non-interleaved JPEG: chunked header decode.
+#[test]
+fn chunked_headers_non_interleaved() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let expected = decode_oneshot(data);
+    let actual = decode_chunked_headers(data, 200);
+    assert_eq!(actual, expected);
+}
+
+/// Down-sampled image (4:2:0): chunked header decode.
+#[test]
+fn chunked_headers_420_subsampled() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
+    let expected = decode_oneshot(data);
+    let actual = decode_chunked_headers(data, 300);
+    assert_eq!(actual, expected);
+}
+
+/// `is_recoverable_eof` returns false for non-EOF errors.
+#[test]
+fn non_eof_errors_are_not_recoverable() {
+    use zune_jpeg::errors::DecodeErrors;
+    assert!(!DecodeErrors::ZeroError.is_recoverable_eof());
+    assert!(!DecodeErrors::IllegalMagicBytes(0x1234).is_recoverable_eof());
+    assert!(!DecodeErrors::FormatStatic("bad").is_recoverable_eof());
+}
+
+/// After decode_headers recovers from EOF, the header boundary is correct:
+/// we can get the exact same position where scan data starts.
+#[test]
+fn header_boundary_is_consistent() {
+    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+
+    // Find the minimal amount of data needed for headers to succeed.
+    let boundary = find_header_boundary(data);
+    assert!(boundary > 2, "header boundary should be past SOI");
+    assert!(boundary < data.len(), "header boundary should be before EOF");
+
+    // Verify that feeding exactly `boundary` bytes works via chunked headers.
+    let expected = decode_oneshot(data);
+    let actual = decode_chunked_headers(data, boundary);
+    assert_eq!(actual, expected);
+}
+
+/// After a recoverable EOF, creating a new decoder with more data
+/// and decoding from scratch must produce the correct result.
+#[test]
+fn retry_with_new_decoder() {
+    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+    let expected = decode_oneshot(data);
+
+    // Start with too little data (just the SOI marker)
+    let mut decoder = JpegDecoder::new(ZCursor::new(&data[..2]));
+    let err = decoder.decode_headers().unwrap_err();
+    assert!(err.is_recoverable_eof());
+
+    // Create a new decoder with all data
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+
+    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut out).unwrap();
+    assert_eq!(out, expected);
+}
+
+/// Calling `decode_headers` repeatedly on the same decoder after
+/// recoverable EOF must not panic or corrupt state — each attempt
+/// resets cleanly and re-parses from position 0.
+#[test]
+fn repeated_eof_on_same_decoder_does_not_corrupt() {
+    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+
+    // Create decoder with very little data (just SOI + a few bytes)
+    let mut decoder = JpegDecoder::new(ZCursor::new(&data[..10]));
+
+    // Multiple retries on the same decoder must all return recoverable EOF
+    // without panicking — proves reset_header_state works correctly.
+    for _ in 0..5 {
+        let err = decoder.decode_headers().unwrap_err();
+        assert!(
+            err.is_recoverable_eof(),
+            "expected recoverable EOF on retry, got: {err:?}"
+        );
+        // info() must return None since headers were never fully parsed
+        assert!(decoder.info().is_none());
+    }
+}


### PR DESCRIPTION
Add minimal state machine towards incremental/resumable decoding support in zune-jpeg. This minimal state machine will track header vs scan states and resume from start of the state in case of recoverable error. Subsequent PRs will add granularity on the resumable capability to allow a fine-grained status tracking to allow resuming from more acurate possition.

When decoding from a stream that doesn't have all bytes available yet (e.g. network download), decode_headers() can now be retried after feeding more data. If it fails because the input ran out, the decoder resets cleanly so the caller can try again.

Changes:

- Add DecodingState enum to track whether the decoder is parsing headers or ready to decode scan data
- Add is_recoverable_eof() on DecodeErrors to distinguish "need more data" from real format errors
- Add reset_header_state() to cleanly reset all decoder fields on recoverable EOF
- Refactor decode_into() to delegate header parsing to decode_headers() instead of duplicating its logic
- Add incremental decoding tests (full decode, chunked headers, byte-at-a-time feeding)
- No breaking API changes. Existing callers are unaffected.

This work is part of #375 