### PR TITLE
AVX2+NEON private API soundness fix

### DIFF
--- a/crates/zune-jpeg/src/color_convert/avx.rs
+++ b/crates/zune-jpeg/src/color_convert/avx.rs
@@ -299,7 +299,7 @@ const fn shuffle(z: i32, y: i32, x: i32, w: i32) -> i32 {
     (z << 6) | (y << 4) | (x << 2) | w
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod safety_tests {
     use super::*;
 

--- a/crates/zune-jpeg/src/color_convert/avx.rs
+++ b/crates/zune-jpeg/src/color_convert/avx.rs
@@ -295,3 +295,69 @@ unsafe fn ycbcr_to_rgba_unsafe(
 const fn shuffle(z: i32, y: i32, x: i32, w: i32) -> i32 {
     (z << 6) | (y << 4) | (x << 2) | w
 }
+
+#[cfg(test)]
+mod safety_tests {
+    use super::*;
+
+    /// Demonstrates buffer overflow in `ycbcr_to_rgb_avx2`.
+    ///
+    /// The function takes a `&mut [u8]` output slice but performs no bounds
+    /// check. It writes 48 bytes via raw pointer stores
+    /// (`_mm256_storeu_si256` and `_mm_storeu_si128`) starting at
+    /// `out.as_mut_ptr()` regardless of the output's length.
+    ///
+    /// Note: although `ycbcr_to_rgb_avx2` is `pub`, the containing
+    /// `color_convert` module is private (`mod color_convert;` in lib.rs),
+    /// so this is NOT a soundness hole in the crate's public API. It is a
+    /// crate-internal footgun: a `safe`-callable function that performs
+    /// unchecked OOB writes when misused. AddressSanitizer detects the
+    /// overflow when the function is called with a too-small slice.
+    #[test]
+    fn ycbcr_to_rgb_avx2_oob_write() {
+        if !is_x86_feature_detected!("avx2") {
+            eprintln!("AVX2 not available, skipping");
+            return;
+        }
+        let y = [128i16; 16];
+        let cb = [128i16; 16];
+        let cr = [128i16; 16];
+        // Output buffer of 32 bytes - smaller than the 48 bytes the function writes.
+        // We use a Vec to ensure ASan can detect the overflow.
+        let mut out: Vec<u8> = vec![0u8; 32];
+        let mut offset = 0usize;
+        ycbcr_to_rgb_avx2(&y, &cb, &cr, &mut out, &mut offset);
+    }
+
+    /// `ycbcr_to_rgb_avx2` ignores the `offset` argument when computing the
+    /// write address. It always writes to the *start* of `out` rather than
+    /// at `out[*offset..]`, even though it then increments `*offset` by 48.
+    /// The sibling `ycbcr_to_rgba_avx2` function does the right thing
+    /// (writes at `out[*offset..*offset+64]`).
+    ///
+    /// This is a logic bug rather than direct UB. It does not bite the
+    /// in-tree callers in `worker.rs` because they all pass a fresh
+    /// `&mut 0`, but it is a latent footgun for any new caller that
+    /// follows the implied API contract.
+    #[test]
+    fn ycbcr_to_rgb_avx2_ignores_offset() {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let y = [128i16; 16];
+        let cb = [128i16; 16];
+        let cr = [128i16; 16];
+        let mut out = vec![0xAAu8; 100];
+        let mut offset = 50usize;
+        ycbcr_to_rgb_avx2(&y, &cb, &cr, &mut out, &mut offset);
+        // Function writes at out.as_mut_ptr() (offset 0) regardless of `offset`.
+        // The first 48 bytes of `out` are now overwritten; bytes 50..98 are still 0xAA.
+        // This demonstrates the function ignores its `offset` argument.
+        assert_ne!(out[0], 0xAA, "function wrote at start of buffer (offset 0)");
+        assert_eq!(
+            out[50], 0xAA,
+            "function did NOT write at offset=50 as the API implies"
+        );
+    }
+
+}

--- a/crates/zune-jpeg/src/color_convert/avx.rs
+++ b/crates/zune-jpeg/src/color_convert/avx.rs
@@ -98,6 +98,9 @@ pub fn ycbcr_to_rgb_avx2(
 unsafe fn ycbcr_to_rgb_avx2_1(
     y: &[i16; 16], cb: &[i16; 16], cr: &[i16; 16], out: &mut [u8], offset: &mut usize
 ) {
+    // check if we have enough space to write.
+    let out: &mut [u8; 48] = out.get_mut(*offset..*offset + 48).expect("Slice to small cannot write").try_into().unwrap();
+
     let (mut r, mut g, mut b) = ycbcr_to_rgb_baseline_no_clamp(y, cb, cr);
 
     r = _mm256_packus_epi16(r, _mm256_setzero_si256());
@@ -314,10 +317,10 @@ mod safety_tests {
     /// unchecked OOB writes when misused. AddressSanitizer detects the
     /// overflow when the function is called with a too-small slice.
     #[test]
+    #[should_panic]
     fn ycbcr_to_rgb_avx2_oob_write() {
         if !is_x86_feature_detected!("avx2") {
-            eprintln!("AVX2 not available, skipping");
-            return;
+            panic!("AVX2 not available, skipping");
         }
         let y = [128i16; 16];
         let cb = [128i16; 16];
@@ -329,16 +332,11 @@ mod safety_tests {
         ycbcr_to_rgb_avx2(&y, &cb, &cr, &mut out, &mut offset);
     }
 
-    /// `ycbcr_to_rgb_avx2` ignores the `offset` argument when computing the
-    /// write address. It always writes to the *start* of `out` rather than
+    /// `ycbcr_to_rgb_avx2` used to ignore the `offset` argument when computing the
+    /// write address. It always wrote to the *start* of `out` rather than
     /// at `out[*offset..]`, even though it then increments `*offset` by 48.
     /// The sibling `ycbcr_to_rgba_avx2` function does the right thing
     /// (writes at `out[*offset..*offset+64]`).
-    ///
-    /// This is a logic bug rather than direct UB. It does not bite the
-    /// in-tree callers in `worker.rs` because they all pass a fresh
-    /// `&mut 0`, but it is a latent footgun for any new caller that
-    /// follows the implied API contract.
     #[test]
     fn ycbcr_to_rgb_avx2_ignores_offset() {
         if !is_x86_feature_detected!("avx2") {
@@ -353,8 +351,8 @@ mod safety_tests {
         // Function writes at out.as_mut_ptr() (offset 0) regardless of `offset`.
         // The first 48 bytes of `out` are now overwritten; bytes 50..98 are still 0xAA.
         // This demonstrates the function ignores its `offset` argument.
-        assert_ne!(out[0], 0xAA, "function wrote at start of buffer (offset 0)");
-        assert_eq!(
+        assert_eq!(out[0], 0xAA, "function wrote at start of buffer (offset 0)");
+        assert_ne!(
             out[50], 0xAA,
             "function did NOT write at offset=50 as the API implies"
         );

--- a/crates/zune-jpeg/src/color_convert/neon64.rs
+++ b/crates/zune-jpeg/src/color_convert/neon64.rs
@@ -125,22 +125,26 @@ unsafe fn ycbcr_to_rgb_baseline_no_clamp(
 pub fn ycbcr_to_rgb_neon(
     y: &[i16; 16], cb: &[i16; 16], cr: &[i16; 16], out: &mut [u8], offset: &mut usize
 ) {
-    // call this in another function to tell RUST to vectorize this
-    // storing
+    // check if we have enough space to write.
+    let out: &mut [u8; 48] = out.get_mut(*offset..*offset + 48).expect("Slice to small cannot write").try_into().unwrap();
+
     unsafe {
         let (r, g, b) = ycbcr_to_rgb_baseline_no_clamp(y, cb, cr);
         vst3q_u8(out.as_mut_ptr(), uint8x16x3_t(r, g, b));
-        *offset += 48;
     }
+    *offset += 48;
 }
 
 #[inline(always)]
 pub fn ycbcr_to_rgba_neon(
     y: &[i16; 16], cb: &[i16; 16], cr: &[i16; 16], out: &mut [u8], offset: &mut usize
 ) {
+    // check if we have enough space to write.
+    let out: &mut [u8; 64] = out.get_mut(*offset..*offset + 64).expect("Slice to small cannot write").try_into().unwrap();
+
     unsafe {
         let (r, g, b) = ycbcr_to_rgb_baseline_no_clamp(y, cb, cr);
         vst4q_u8(out.as_mut_ptr(), uint8x16x4_t(r, g, b, vdupq_n_u8(255)));
-        *offset += 64;
     }
+    *offset += 64;
 }


### PR DESCRIPTION
`ycbcr_to_rgb_avx2` function is safe to call, but does not perform a bounds check on the output buffer. The _rgba variant performs this check, as do all the scalar variants, but it was missed here.

`ycbcr_to_rgb_neon` and `ycbcr_to_rgba_neon` are both missing the check.

Due to the missed checks the  affected functions also do not honor the `offset` parameter, but since it's always 0 in practice that didn't matter either.

This is **not** a security issue in practice because the API is private and is always called with the appropriate buffer size and offset 0.

I have not benchmarked how this affects performance. If this is at all noticeable, we might want to make a larger refactoring by turning `out` into a `&mut [u8]` and removing the `offset` argument instead of the change proposed here.