### PR TITLE
Fix failing CI workflows in PR from fork repos

### DIFF
--- a/.github/workflows/criterion_benchmarks.yml
+++ b/.github/workflows/criterion_benchmarks.yml
@@ -3,7 +3,7 @@ name: Benchmark Regression
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches: [ "dev" ]
   workflow_dispatch:
 
 permissions:
@@ -42,7 +42,7 @@ jobs:
           name: bench-${{ github.sha }}
           path: bench.json
   compare:
-    name: Benchmark Diff (PR vs main)
+    name: Benchmark Diff (PR vs dev)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
 
@@ -64,11 +64,11 @@ jobs:
       # ----------------------------
       # Fetch base branch benchmark
       # ----------------------------
-      - name: Fetch main branch benchmark
+      - name: Fetch dev branch benchmark
         run: |
-          git fetch origin main
-          git checkout origin/main
-          cargo criterion --message-format=json > main.json
+          git fetch origin dev
+          git checkout origin/dev
+          cargo criterion --message-format=json > dev.json
           git checkout ${{ github.sha }}
 
       # ----------------------------
@@ -79,12 +79,13 @@ jobs:
 
       - name: Compare benchmarks
         run: |
-          critcmp main.json pr.json | tee diff.txt
+          critcmp dev.json pr.json | tee diff.txt
 
       # ----------------------------
       # Comment PR
       # ----------------------------
       - name: Comment PR with benchmark diff
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -45,6 +45,7 @@ jobs:
           cat clippy.json | clippy-sarif > clippy.sarif
 
       - name: Upload SARIF to GitHub Security
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: clippy.sarif
@@ -64,7 +65,7 @@ jobs:
             ' | tee clippy-comments.txt
 
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
- criterion_benchmarks.yml: The compare job referenced 'main' branch which doesn't exist; changed to 'dev'.
- rust-clippy.yml: SARIF upload and PR comment steps fail on fork PRs due to missing write permissions; skip them for external contributors.