### PR TITLE
JpegDecoder: Add fine-grained resumable header parsing

### DIFF
--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -77,10 +77,45 @@ pub type IDCTPtr = fn(&mut [i32; 64], &mut [i16], usize);
 /// Tracks the current decoding phase for incremental decoding.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DecodingState {
-    /// Headers not yet fully decoded.
-    DecodeHeaders,
+    /// Headers not yet fully decoded. `resume_position == 0` means start from SOI.
+    DecodeHeaders { resume_position: usize },
     /// Headers decoded; scan data starts at `scan_start_position`.
     DecodeScan { scan_start_position: usize },
+}
+
+// Snapshot of append-only buffers populated across multi-segment markers
+// (ICC chunks, extended XMP, gain map). All other parsers either overwrite
+// fixed slots (qt/huffman/components) or fail before mutating, so only
+// these three need to be rolled back when a marker parser errors out.
+#[derive(Clone, Copy)]
+struct HeaderAppendStateSnapshot {
+    icc:  usize,
+    xmp:  usize,
+    gain: usize
+}
+
+impl HeaderAppendStateSnapshot {
+    fn capture<T: ZByteReaderTrait>(decoder: &JpegDecoder<T>) -> Self {
+        Self {
+            icc:  decoder.icc_data.len(),
+            xmp:  decoder.extended_xmp_segments.len(),
+            gain: decoder.info.gain_map_info.len()
+        }
+    }
+
+    fn rollback<T: ZByteReaderTrait>(self, decoder: &mut JpegDecoder<T>) {
+        decoder.icc_data.truncate(self.icc);
+        decoder.extended_xmp_segments.truncate(self.xmp);
+        decoder.info.gain_map_info.truncate(self.gain);
+    }
+}
+
+/// Result of handling a single marker inside the header loop.
+enum MarkerStep {
+    /// Continue reading further markers.
+    Continue,
+    /// Reached SOS; headers are done and scan starts at the current position.
+    EnteredScan
 }
 
 /// An encapsulation of an ICC chunk
@@ -192,6 +227,44 @@ impl<T> JpegDecoder<T>
 where
     T: ZByteReaderTrait
 {
+    // Mark the current stream position as a safe resume point at a marker
+    // boundary; on a future retry decode_headers_internal will seek here
+    // instead of restarting from SOI.
+    fn stream_position(&mut self) -> Result<usize, DecodeErrors> {
+        let position = self.stream.position()?;
+        usize::try_from(position).map_err(|_| {
+            DecodeErrors::FormatStatic("Stream position does not fit in usize")
+        })
+    }
+
+    fn checkpoint_headers(&mut self) -> Result<(), DecodeErrors> {
+        let resume_position = self.stream_position()?;
+        self.state = DecodingState::DecodeHeaders { resume_position };
+        Ok(())
+    }
+
+    fn enter_scan_state(&mut self) -> Result<(), DecodeErrors> {
+        let scan_start_position = self.stream_position()?;
+        self.state = DecodingState::DecodeScan { scan_start_position };
+        Ok(())
+    }
+
+    // Match output colorspace; we only care for ycbcr to rgb/rgba here, in
+    // case one is using another colorspace may god help you.
+    fn set_color_convert_from_options(&mut self) {
+        let out_colorspace = self.options.jpeg_get_out_colorspace();
+        if matches!(
+            out_colorspace,
+            ColorSpace::BGR | ColorSpace::BGRA | ColorSpace::RGB | ColorSpace::RGBA
+        ) {
+            self.color_convert_16 = choose_ycbcr_to_rgb_convert_func(
+                self.options.jpeg_get_out_colorspace(),
+                &self.options
+            )
+            .unwrap();
+        }
+    }
+
     #[allow(clippy::redundant_field_names)]
     fn default(options: DecoderOptions, buffer: T) -> Self {
         let color_convert = choose_ycbcr_to_rgb_convert_func(ColorSpace::RGB, &options).unwrap();
@@ -249,7 +322,7 @@ where
             is_mjpeg:          false,
             coeff:             1,
             extended_xmp_segments: vec![],
-            state:             DecodingState::DecodeHeaders,
+            state:             DecodingState::DecodeHeaders { resume_position: 0 },
         }
     }
     /// Decode a buffer already in memory
@@ -452,39 +525,29 @@ where
             DecodingState::DecodeScan { .. } => {
                 return Ok(());
             }
-            DecodingState::DecodeHeaders => {
-                // Reset any partial state from a prior incomplete attempt.
-                self.reset_header_state();
+            DecodingState::DecodeHeaders { resume_position } => {
+                if resume_position == 0 {
+                    self.reset_header_state();
+
+                    // First two bytes should be jpeg soi marker
+                    let magic_bytes = self.stream.get_u16_be_err()?;
+
+                    if magic_bytes != 0xffd8 {
+                        return Err(DecodeErrors::IllegalMagicBytes(magic_bytes));
+                    }
+
+                    // Color convert depends only on options, so pick it once
+                    // on a fresh decode rather than on every resume.
+                    self.set_color_convert_from_options();
+                    self.checkpoint_headers()?;
+                } else {
+                    self.stream.set_position(resume_position)?;
+                }
             }
         }
 
-        // match output colorspace here
-        // we know this will only be called once per image
-        // so makes sense
-        // We only care for ycbcr to rgb/rgba here
-        // in case one is using another colorspace.
-        // May god help you
-        let out_colorspace = self.options.jpeg_get_out_colorspace();
-
-        if matches!(
-            out_colorspace,
-            ColorSpace::BGR | ColorSpace::BGRA | ColorSpace::RGB | ColorSpace::RGBA
-        ) {
-            self.color_convert_16 = choose_ycbcr_to_rgb_convert_func(
-                self.options.jpeg_get_out_colorspace(),
-                &self.options
-            )
-            .unwrap();
-        }
-        // First two bytes should be jpeg soi marker
-        let magic_bytes = self.stream.get_u16_be_err()?;
-
         let mut last_byte = 0;
         let mut bytes_before_marker = 0;
-
-        if magic_bytes != 0xffd8 {
-            return Err(DecodeErrors::IllegalMagicBytes(magic_bytes));
-        }
 
         loop {
             // read a byte
@@ -533,73 +596,95 @@ where
 
                     bytes_before_marker = 0;
 
-                    self.parse_marker_inner(n)?;
-
-                    if !self.extended_xmp_segments.is_empty() {
-                        self.reassemble_extended_xmp();
-                    }
-
-                    // break after reading the start of scan.
-                    // what follows is the image data
-                    if n == Marker::SOS {
-                        self.headers_decoded = true;
-                        trace!("Input colorspace {:?}", self.input_colorspace);
-
-                        // Check if image is RGB
-                        // The check is weird, we need to check if ID
-                        // represents R, G and B in ascii,
-                        //
-                        // I am not sure if this is even specified in any standard,
-                        // but jpegli https://github.com/google/jpegli does encode
-                        // its images that way, so this will check for that. and handle it appropriately
-                        // It is spefified here so that on a successful header decode,we can at least
-                        // try to attribute image colorspace  correctly.
-                        //
-                        // It was first the issue in https://github.com/etemesi254/zune-image/issues/291
-                        // that brought it to light
-                        //
-                        let mut is_rgb = self.components.len() == 3;
-                        let chars = ['R', 'G', 'B'];
-                        for (comp, single_char) in self.components.iter().zip(chars.iter()) {
-                            is_rgb &= comp.id == (*single_char) as u8;
-                        }
-                        // Image is RGB, change colorspace
-                        if is_rgb {
-                            self.input_colorspace = ColorSpace::RGB;
-                        }
-
-                        // Transition to scan phase, remembering where scan data starts.
-                        if self.state == DecodingState::DecodeHeaders {
-                            #[allow(clippy::cast_possible_truncation)]
-                            let pos = self.stream.position()? as usize;
-                            self.state = DecodingState::DecodeScan {
-                                scan_start_position: pos,
-                            };
-                        }
-
+                    if let MarkerStep::EnteredScan = self.handle_known_marker(n)? {
                         return Ok(());
                     }
                 } else {
                     bytes_before_marker = 0;
-
                     warn!("Marker 0xFF{m:X} not known");
-
-                    let length = self.stream.get_u16_be_err()?;
-
-                    if length < 2 {
-                        return Err(DecodeErrors::Format(format!(
-                            "Found a marker with invalid length : {length}"
-                        )));
-                    }
-
-                    warn!("Skipping {} bytes", length - 2);
-                    self.stream.skip((length - 2) as usize)?;
+                    self.skip_unknown_marker()?;
                 }
             }
             last_byte = m;
             bytes_before_marker += 1;
         }
-        // Check if image is RGB
+    }
+
+    // Parse a recognised marker and update the resume checkpoint. On a parser
+    // error, append-only metadata accumulated during this marker is rolled
+    // back so a future retry sees a clean state.
+    fn handle_known_marker(&mut self, n: Marker) -> Result<MarkerStep, DecodeErrors> {
+        let snapshot = HeaderAppendStateSnapshot::capture(self);
+
+        if let Err(e) = self.parse_marker_inner(n) {
+            snapshot.rollback(self);
+            return Err(e);
+        }
+
+        if !self.extended_xmp_segments.is_empty() {
+            self.reassemble_extended_xmp();
+        }
+
+        // break after reading the start of scan.
+        // what follows is the image data
+        if n == Marker::SOS {
+            self.headers_decoded = true;
+            trace!("Input colorspace {:?}", self.input_colorspace);
+
+            // Check if image is RGB
+            // The check is weird, we need to check if ID
+            // represents R, G and B in ascii,
+            //
+            // I am not sure if this is even specified in any standard,
+            // but jpegli https://github.com/google/jpegli does encode
+            // its images that way, so this will check for that. and handle it appropriately
+            // It is spefified here so that on a successful header decode,we can at least
+            // try to attribute image colorspace  correctly.
+            //
+            // It was first the issue in https://github.com/etemesi254/zune-image/issues/291
+            // that brought it to light
+            //
+            let mut is_rgb = self.components.len() == 3;
+            let chars = ['R', 'G', 'B'];
+            for (comp, single_char) in self.components.iter().zip(chars.iter()) {
+                is_rgb &= comp.id == (*single_char) as u8;
+            }
+            // Image is RGB, change colorspace
+            if is_rgb {
+                self.input_colorspace = ColorSpace::RGB;
+            }
+
+            self.enter_scan_state()?;
+            return Ok(MarkerStep::EnteredScan);
+        }
+
+        self.checkpoint_headers()?;
+        Ok(MarkerStep::Continue)
+    }
+
+    // Read a length-prefixed marker payload and skip past it. Shared by the
+    // unknown-marker path in `decode_headers_internal` and the catch-all arm
+    // in `parse_marker_inner` so the length validation lives in one place.
+    fn skip_marker_payload(&mut self) -> Result<(), DecodeErrors> {
+        let length = self.stream.get_u16_be_err()?;
+
+        if length < 2 {
+            return Err(DecodeErrors::Format(format!(
+                "Found a marker with invalid length : {length}"
+            )));
+        }
+
+        warn!("Skipping {} bytes", length - 2);
+        self.stream.skip((length - 2) as usize)?;
+        Ok(())
+    }
+
+    // Skip a marker we don't recognise, then checkpoint past it so we don't
+    // need to re-skip on retry.
+    fn skip_unknown_marker(&mut self) -> Result<(), DecodeErrors> {
+        self.skip_marker_payload()?;
+        self.checkpoint_headers()?;
+        Ok(())
     }
     #[allow(clippy::too_many_lines)]
     pub(crate) fn parse_marker_inner(&mut self, m: Marker) -> Result<(), DecodeErrors> {
@@ -728,20 +813,12 @@ where
                 warn!(
                     "Capabilities for processing marker \"{m:?}\" not implemented"
                 );
-
-                let length = self.stream.get_u16_be_err()?;
-
-                if length < 2 {
-                    return Err(DecodeErrors::Format(format!(
-                        "Found a marker with invalid length:{length}\n"
-                    )));
-                }
-                warn!("Skipping {} bytes", length - 2);
-                self.stream.skip((length - 2) as usize)?;
+                self.skip_marker_payload()?;
             }
         }
         Ok(())
     }
+
     /// Get the embedded ICC profile if it exists
     /// and is correct
     ///
@@ -914,7 +991,7 @@ where
     ///
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
         match self.state {
-            DecodingState::DecodeHeaders => {
+            DecodingState::DecodeHeaders { .. } => {
                 self.decode_headers_internal()?;
             }
             DecodingState::DecodeScan { scan_start_position } => {
@@ -1013,7 +1090,7 @@ where
         self.is_mjpeg = false;
         self.coeff = 1;
         self.extended_xmp_segments.clear();
-        self.state = DecodingState::DecodeHeaders;
+        self.state = DecodingState::DecodeHeaders { resume_position: 0 };
         // Best-effort seek to start; may fail for non-seekable streams.
         let _ = self.stream.set_position(0);
     }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -99,7 +99,7 @@ pub(crate) enum DecodingState {
 // these three need to be rolled back when a marker parser errors out
 // or when scan-phase replay re-seeks past markers it already consumed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct HeaderAppendStateSnapshot {
+pub(crate) struct HeaderAppendStateSnapshot {
     icc:  usize,
     xmp:  usize,
     gain: usize

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -542,8 +542,6 @@ where
             }
             DecodingState::DecodeHeaders { resume_position } => {
                 if resume_position == 0 {
-                    self.reset_header_state();
-
                     // First two bytes should be jpeg soi marker
                     let magic_bytes = self.stream.get_u16_be_err()?;
 
@@ -1084,43 +1082,7 @@ where
         Ok(())
     }
 
-    /// Reset all state set during header parsing so that
-    /// `decode_headers_internal` can be called again from scratch.
-    // NB: fields here must stay in sync with `fn default()`.
-    fn reset_header_state(&mut self) {
-        self.info = ImageInfo::default();
-        self.qt_tables = [None, None, None, None];
-        self.entropy_tables.dc_huffman = [None, None, None, None];
-        self.entropy_tables.ac_huffman = [None, None, None, None];
-        self.components.clear();
-        self.h_max = 1;
-        self.v_max = 1;
-        self.mcu_height = 0;
-        self.mcu_width = 0;
-        self.mcu_x = 0;
-        self.mcu_y = 0;
-        self.is_interleaved = false;
-        self.is_progressive = false;
-        self.spec_start = 0;
-        self.spec_end = 0;
-        self.succ_high = 0;
-        self.succ_low = 0;
-        self.num_scans = 0;
-        self.scan_subsampled = false;
-        self.input_colorspace = ColorSpace::YCbCr;
-        self.z_order = [0; MAX_COMPONENTS];
-        self.restart_interval = 0;
-        self.todo = 0x7fff_ffff;
-        self.headers_decoded = false;
-        self.seen_sof = false;
-        self.icc_data.clear();
-        self.is_mjpeg = false;
-        self.coeff = 1;
-        self.extended_xmp_segments.clear();
-        self.state = DecodingState::DecodeHeaders { resume_position: 0 };
-        // Best-effort seek to start; may fail for non-seekable streams.
-        let _ = self.stream.set_position(0);
-    }
+
 
     /// Create a new decoder with the specified options to be used for decoding
     /// an image

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -80,14 +80,25 @@ pub(crate) enum DecodingState {
     /// Headers not yet fully decoded. `resume_position == 0` means start from SOI.
     DecodeHeaders { resume_position: usize },
     /// Headers decoded; scan data starts at `scan_start_position`.
-    DecodeScan { scan_start_position: usize },
+    ///
+    /// `append_snapshot` records the lengths of the append-only metadata
+    /// buffers (ICC, extended XMP, gain map) at the moment we entered the
+    /// scan. On every scan retry we roll those buffers back to this snapshot
+    /// before re-seeking, so inline markers re-encountered during replay
+    /// (see `mcu.rs::check_stream_marker_after_mcu_width`) do not duplicate
+    /// metadata entries.
+    DecodeScan {
+        scan_start_position: usize,
+        append_snapshot:     HeaderAppendStateSnapshot
+    },
 }
 
 // Snapshot of append-only buffers populated across multi-segment markers
 // (ICC chunks, extended XMP, gain map). All other parsers either overwrite
 // fixed slots (qt/huffman/components) or fail before mutating, so only
-// these three need to be rolled back when a marker parser errors out.
-#[derive(Clone, Copy)]
+// these three need to be rolled back when a marker parser errors out
+// or when scan-phase replay re-seeks past markers it already consumed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct HeaderAppendStateSnapshot {
     icc:  usize,
     xmp:  usize,
@@ -245,7 +256,11 @@ where
 
     fn enter_scan_state(&mut self) -> Result<(), DecodeErrors> {
         let scan_start_position = self.stream_position()?;
-        self.state = DecodingState::DecodeScan { scan_start_position };
+        let append_snapshot = HeaderAppendStateSnapshot::capture(self);
+        self.state = DecodingState::DecodeScan {
+            scan_start_position,
+            append_snapshot
+        };
         Ok(())
     }
 
@@ -610,16 +625,12 @@ where
         }
     }
 
-    // Parse a recognised marker and update the resume checkpoint. On a parser
-    // error, append-only metadata accumulated during this marker is rolled
-    // back so a future retry sees a clean state.
+    // Parse a recognised marker and update the resume checkpoint. Rollback of
+    // append-only metadata on parser error lives inside `parse_marker_inner`
+    // itself so every caller (including the inline-marker path in `mcu.rs`)
+    // is protected uniformly.
     fn handle_known_marker(&mut self, n: Marker) -> Result<MarkerStep, DecodeErrors> {
-        let snapshot = HeaderAppendStateSnapshot::capture(self);
-
-        if let Err(e) = self.parse_marker_inner(n) {
-            snapshot.rollback(self);
-            return Err(e);
-        }
+        self.parse_marker_inner(n)?;
 
         if !self.extended_xmp_segments.is_empty() {
             self.reassemble_extended_xmp();
@@ -686,8 +697,21 @@ where
         self.checkpoint_headers()?;
         Ok(())
     }
-    #[allow(clippy::too_many_lines)]
     pub(crate) fn parse_marker_inner(&mut self, m: Marker) -> Result<(), DecodeErrors> {
+        // Snapshot append-only metadata so any error path leaves the decoder
+        // in the same shape as before the marker started. Required for both
+        // header-phase resume and the non-strict inline-marker dispatch from
+        // `mcu.rs::check_stream_marker_after_mcu_width`.
+        let snapshot = HeaderAppendStateSnapshot::capture(self);
+        let result = self.parse_marker_dispatch(m);
+        if result.is_err() {
+            snapshot.rollback(self);
+        }
+        result
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn parse_marker_dispatch(&mut self, m: Marker) -> Result<(), DecodeErrors> {
         match m {
             Marker::SOF(0..=2) => {
                 // choose marker
@@ -994,8 +1018,11 @@ where
             DecodingState::DecodeHeaders { .. } => {
                 self.decode_headers_internal()?;
             }
-            DecodingState::DecodeScan { scan_start_position } => {
-                // Seek back to scan start (needed for retry after more data arrived).
+            DecodingState::DecodeScan { scan_start_position, append_snapshot } => {
+                // Roll back any metadata that an inline marker pushed during
+                // a previous scan attempt, then seek back to the start of the
+                // scan so MCU decoding can be retried from the same anchor.
+                append_snapshot.rollback(self);
                 self.stream.set_position(scan_start_position)?;
             }
         }

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -522,7 +522,7 @@ pub(crate) fn parse_app13<T: ZByteReaderTrait>(
 ) -> Result<(), DecodeErrors> {
     const IPTC_PREFIX: &[u8] = b"Photoshop 3.0\0";
     // skip length.
-    let mut length = usize::from(decoder.stream.get_u16_be());
+    let mut length = usize::from(decoder.stream.get_u16_be_err()?);
 
     if length < 2 {
         return Err(DecodeErrors::FormatStatic("Too small APP13 length"));
@@ -549,7 +549,7 @@ pub(crate) fn parse_app14<T: ZByteReaderTrait>(
     decoder: &mut JpegDecoder<T>
 ) -> Result<(), DecodeErrors> {
     // skip length
-    let mut length = usize::from(decoder.stream.get_u16_be());
+    let mut length = usize::from(decoder.stream.get_u16_be_err()?);
 
     if length < 2 {
         return Err(DecodeErrors::FormatStatic("Too small APP14 length"));
@@ -566,7 +566,7 @@ pub(crate) fn parse_app14<T: ZByteReaderTrait>(
         // skip version, flags0 and flags1
         decoder.stream.skip(5)?;
         // get color transform
-        let transform = decoder.stream.read_u8();
+        let transform = decoder.stream.read_u8_err()?;
         // https://exiftool.org/TagNames/JPEG.html#Adobe
         match transform {
             0 => decoder.input_colorspace = ColorSpace::CMYK,
@@ -609,7 +609,7 @@ pub(crate) fn parse_app1<T: ZByteReaderTrait>(
         EXTENDED_XMP_GUID_SIZE + EXTENDED_XMP_TOTAL_SIZE_SIZE + EXTENDED_XMP_OFFSET_SIZE;
 
     // contains exif data
-    let mut length = usize::from(decoder.stream.get_u16_be());
+    let mut length = usize::from(decoder.stream.get_u16_be_err()?);
 
     if length < 2 {
         return Err(DecodeErrors::FormatStatic("Too small app1 length"));
@@ -678,7 +678,7 @@ pub(crate) fn parse_app2<T: ZByteReaderTrait>(
     static HDR_META: &[u8] = b"urn:iso:std:iso:ts:21496:-1\0";
     static MPF_DATA: &[u8] = b"MPF\0";
 
-    let mut length = usize::from(decoder.stream.get_u16_be());
+    let mut length = usize::from(decoder.stream.get_u16_be_err()?);
 
     if length < 2 {
         return Err(DecodeErrors::FormatStatic("Too small app2 segment"));
@@ -691,8 +691,8 @@ pub(crate) fn parse_app2<T: ZByteReaderTrait>(
         // skip 12 bytes which indicate ICC profile
         length -= 12;
         decoder.stream.skip(12)?;
-        let seq_no = decoder.stream.read_u8();
-        let num_markers = decoder.stream.read_u8();
+        let seq_no = decoder.stream.read_u8_err()?;
+        let num_markers = decoder.stream.read_u8_err()?;
         // deduct the two bytes we read above
         length -= 2;
 
@@ -715,8 +715,8 @@ pub(crate) fn parse_app2<T: ZByteReaderTrait>(
                 // 2 bytes minimum_version: (00 00)
                 // 2 bytes writer_version: (00 00)
                 // Perhaps nothing to do with it ?
-                let _ = decoder.stream.get_u16_be();
-                let _ = decoder.stream.get_u16_be();
+                let _ = decoder.stream.get_u16_be_err()?;
+                let _ = decoder.stream.get_u16_be_err()?;
                 length -= 4;
                 decoder
                     .info

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -14,6 +14,77 @@
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::JpegDecoder;
 
+use std::cell::Cell;
+use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::rc::Rc;
+
+/// A cursor over a byte slice with an adjustable visibility limit.
+///
+/// Reads/seeks beyond `limit` behave as if the data ends there (EOF).
+/// The test can grow `limit` via the shared `Rc<Cell<usize>>` to
+/// simulate more data arriving, then retry on the **same** decoder.
+struct GrowableCursor<'a> {
+    data:     &'a [u8],
+    position: usize,
+    limit:    Rc<Cell<usize>>,
+}
+
+impl<'a> GrowableCursor<'a> {
+    fn new(data: &'a [u8], limit: Rc<Cell<usize>>) -> Self {
+        Self { data, position: 0, limit }
+    }
+
+    fn visible(&self) -> usize {
+        self.limit.get().min(self.data.len())
+    }
+}
+
+impl Read for GrowableCursor<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let visible = self.visible();
+        if self.position >= visible {
+            return Ok(0); // EOF
+        }
+        let available = &self.data[self.position..visible];
+        let n = available.len().min(buf.len());
+        buf[..n].copy_from_slice(&available[..n]);
+        self.position += n;
+        Ok(n)
+    }
+}
+
+impl BufRead for GrowableCursor<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        let visible = self.visible();
+        if self.position >= visible {
+            return Ok(&[]);
+        }
+        Ok(&self.data[self.position..visible])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.position += amt;
+    }
+}
+
+impl Seek for GrowableCursor<'_> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let new_pos = match pos {
+            SeekFrom::Start(p) => p as i64,
+            SeekFrom::Current(p) => self.position as i64 + p,
+            SeekFrom::End(p) => self.visible() as i64 + p,
+        };
+        if new_pos < 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "seek before start",
+            ));
+        }
+        self.position = new_pos as usize;
+        Ok(self.position as u64)
+    }
+}
+
 fn decode_oneshot(data: &[u8]) -> Vec<u8> {
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode().expect("one-shot decode failed")
@@ -95,11 +166,11 @@ fn repeated_eof_does_not_corrupt_state() {
     }
 }
 
-/// Byte-by-byte header feeding: grow the visible window one byte at a time,
-/// creating a new decoder each time, until headers succeed. The final decoded
-/// output must match one-shot.
+/// Byte-by-byte header feeding with a *fresh* decoder per attempt: this is
+/// a one-shot parity regression test, not a fine-grained resume test (each
+/// attempt restarts from SOI).
 #[test]
-fn chunked_header_feeding_byte_by_byte() {
+fn chunked_fresh_decoder_byte_by_byte() {
     let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
     let expected = decode_oneshot(data);
 
@@ -123,4 +194,119 @@ fn chunked_header_feeding_byte_by_byte() {
             Err(e) => panic!("unexpected error at byte {available}: {e:?}"),
         }
     }
+}
+
+/// In-place resumable header parsing on the *same* decoder instance.
+///
+/// Uses `GrowableCursor` to simulate a stream where more data becomes
+/// available over time.  The decoder must resume from where it left off
+/// (not restart from SOI) and eventually succeed, producing output that
+/// matches a one-shot decode.
+#[test]
+fn inplace_growable_header_resume() {
+    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+    let expected = decode_oneshot(data);
+
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    // Grow limit in chunks until headers succeed.
+    let step = 32;
+    loop {
+        let new_limit = (limit.get() + step).min(data.len());
+        limit.set(new_limit);
+
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(ref e) if e.is_recoverable_eof() => {
+                assert!(
+                    new_limit < data.len(),
+                    "EOF with all bytes visible — headers should have succeeded"
+                );
+            }
+            Err(e) => panic!("unexpected error at limit {new_limit}: {e:?}"),
+        }
+    }
+
+    // Headers decoded — make all data visible and decode the image.
+    limit.set(data.len());
+    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut out).unwrap();
+    assert_eq!(out, expected, "decoded pixels must match one-shot decode");
+}
+
+/// Byte-by-byte in-place resume: grow visibility one byte at a time on
+/// the *same* decoder instance, verifying that fine-grained checkpointing
+/// works for every possible truncation point in the headers.
+#[test]
+fn inplace_byte_by_byte_header_resume() {
+    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let expected = decode_oneshot(data);
+
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    for avail in 1..=data.len() {
+        limit.set(avail);
+
+        match decoder.decode_headers() {
+            Ok(()) => {
+                // Headers succeeded — make all data visible and decode.
+                limit.set(data.len());
+                let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+                decoder.decode_into(&mut out).unwrap();
+                assert_eq!(out, expected);
+                return;
+            }
+            Err(ref e) if e.is_recoverable_eof() => continue,
+            Err(e) => panic!("unexpected error at byte {avail}: {e:?}"),
+        }
+    }
+    panic!("headers never succeeded even with all bytes visible");
+}
+
+/// Verify that an EOF after a completed SOF marker is recoverable and that
+/// supplying the rest of the data lets the decoder finish parsing headers.
+///
+/// Note: this asserts the resume *succeeds*, not that markers parsed before
+/// the EOF were preserved across the retry. The byte-by-byte in-place tests
+/// above exercise true fine-grained checkpointing.
+#[test]
+fn resume_after_sof_eventually_succeeds() {
+    let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+
+    // Find roughly where SOF is by scanning for 0xFFC0 marker.
+    let sof_pos = data
+        .windows(2)
+        .position(|w| w == [0xFF, 0xC0] || w == [0xFF, 0xC2])
+        .expect("no SOF marker found in test image");
+
+    // Find roughly where SOS is by scanning for 0xFFDA marker.
+    let sos_pos = data
+        .windows(2)
+        .position(|w| w == [0xFF, 0xDA])
+        .expect("no SOS marker found in test image");
+
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    // Feed enough data to get past SOF but not past SOS.
+    // We pick a point between SOF and SOS.  The SOF marker segment
+    // is typically ~20 bytes, so SOF + 30 should be safely past it.
+    let mid = (sof_pos + 30).min(sos_pos);
+    limit.set(mid);
+    let err = decoder.decode_headers().unwrap_err();
+    assert!(err.is_recoverable_eof(), "expected EOF between SOF and SOS");
+    // Headers haven't completed yet, so info() must still be None.
+    assert!(decoder.info().is_none(), "info() must be None until headers complete");
+
+    // Now supply all data; the decoder should resume and finish.
+    limit.set(data.len());
+    decoder.decode_headers().unwrap();
+
+    let info = decoder.info().expect("info() must be Some after headers");
+    assert!(info.width > 0 && info.height > 0, "dimensions must be valid");
 }

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -310,3 +310,148 @@ fn resume_after_sof_eventually_succeeds() {
     let info = decoder.info().expect("info() must be Some after headers");
     assert!(info.width > 0 && info.height > 0, "dimensions must be valid");
 }
+
+/// Inject a synthetic APP2 ICC chunk just before the EOI marker of `base`.
+///
+/// The resulting JPEG places an APP marker at a position the entropy decoder
+/// encounters while reading scan data; in non-strict mode the scan loop
+/// dispatches such markers through `parse_marker_inner` from `mcu.rs`,
+/// which bypasses the header-side snapshot/rollback wrapping done in
+/// `handle_known_marker`.
+fn inject_inline_icc(base: &[u8], payload: &[u8]) -> Vec<u8> {
+    let eoi = base
+        .windows(2)
+        .rposition(|w| w == [0xFF, 0xD9])
+        .expect("base JPEG must end with EOI");
+
+    let body_len = 2 + 12 + 1 + 1 + payload.len();
+    assert!(body_len <= u16::MAX as usize, "payload too large for one APP2");
+
+    let mut chunk = Vec::with_capacity(2 + body_len);
+    chunk.extend_from_slice(&[0xFF, 0xE2]);
+    chunk.extend_from_slice(&(body_len as u16).to_be_bytes());
+    chunk.extend_from_slice(b"ICC_PROFILE\0");
+    chunk.push(1);
+    chunk.push(1);
+    chunk.extend_from_slice(payload);
+
+    let mut out = Vec::with_capacity(base.len() + chunk.len());
+    out.extend_from_slice(&base[..eoi]);
+    out.extend_from_slice(&chunk);
+    out.extend_from_slice(&base[eoi..]);
+    out
+}
+
+/// Sanity check: byte-by-byte incremental decode of a normal image (no
+/// inline markers) must reproduce the one-shot pixel output. If this test
+/// fails, the bug is in the scan-retry mechanism itself rather than in
+/// the inline-marker path.
+#[test]
+#[ignore = "scan-phase resume not yet implemented: entropy decoder treats EOF as end-of-scan"]
+fn inplace_byte_by_byte_full_decode() {
+    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let expected = decode_oneshot(data);
+
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    let mut out: Vec<u8> = Vec::new();
+    for avail in 1..=data.len() {
+        limit.set(avail);
+
+        match decoder.decode_headers() {
+            Ok(()) => {}
+            Err(ref e) if e.is_recoverable_eof() => continue,
+            Err(e) => panic!("unexpected header error at byte {avail}: {e:?}"),
+        }
+
+        if out.is_empty() {
+            out = vec![0u8; decoder.output_buffer_size().unwrap()];
+        }
+
+        match decoder.decode_into(&mut out) {
+            Ok(()) => {
+                assert_eq!(out, expected, "pixel output must match one-shot");
+                return;
+            }
+            Err(ref e) if e.is_recoverable_eof() => continue,
+            Err(e) => panic!("unexpected scan error at byte {avail}: {e:?}"),
+        }
+    }
+    panic!("decode never completed");
+}
+
+/// Regression test for the case when scan-phase resume re-seeks to 
+/// `scan_start_position` and replays the scan, any inline marker dispatched
+///  through `mcu.rs::parse_marker_inner` gets re-parsed on every retry. 
+/// For append-only metadata like ICC, this silently duplicates entries.
+///
+/// The test:
+///   1. builds a synthetic JPEG with one inline APP2 ICC chunk just before EOI,
+///   2. one-shot decodes it to record the expected ICC and pixel output,
+///   3. incrementally decodes it byte-by-byte through `GrowableCursor`,
+///      forcing many scan retries,
+///   4. asserts the final ICC profile is byte-identical (not duplicated)
+///      and pixels match.
+#[test]
+#[ignore = "scan-phase resume not yet implemented: entropy decoder treats EOF as end-of-scan"]
+fn inline_marker_in_scan_does_not_duplicate_icc() {
+    let base = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let payload = b"INLINE-ICC-PAYLOAD-FOR-REGRESSION-TEST";
+    let data = inject_inline_icc(base, payload);
+
+    // Sanity: one-shot decode must accept the synthetic image and surface
+    // exactly the payload we injected.
+    let mut oneshot = JpegDecoder::new(ZCursor::new(&data[..]));
+    let expected_pixels = oneshot.decode().expect("one-shot decode of synthetic image");
+    let expected_icc = oneshot
+        .icc_profile()
+        .expect("one-shot decode must expose injected ICC profile");
+    assert_eq!(
+        expected_icc, payload,
+        "injected payload not round-tripped by one-shot decoder; \
+         test image construction is wrong"
+    );
+
+    // Incremental decode on the *same* decoder, growing visibility one byte
+    // at a time so the scan path repeatedly hits recoverable EOF and retries.
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(&data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    let mut out: Vec<u8> = Vec::new();
+    for avail in 1..=data.len() {
+        limit.set(avail);
+
+        // Drive headers first; only attempt scan once headers complete.
+        match decoder.decode_headers() {
+            Ok(()) => {}
+            Err(ref e) if e.is_recoverable_eof() => continue,
+            Err(e) => panic!("unexpected header error at byte {avail}: {e:?}"),
+        }
+
+        if out.is_empty() {
+            out = vec![0u8; decoder.output_buffer_size().unwrap()];
+        }
+
+        match decoder.decode_into(&mut out) {
+            Ok(()) => {
+                assert_eq!(out, expected_pixels, "pixel output must match one-shot");
+                let got_icc = decoder
+                    .icc_profile()
+                    .expect("incremental decode must expose injected ICC profile");
+                assert_eq!(
+                    got_icc, expected_icc,
+                    "ICC profile after incremental decode must match one-shot \
+                     (duplicated entries indicate scan-retry re-parses an \
+                     inline marker without rolling back append-only state)"
+                );
+                return;
+            }
+            Err(ref e) if e.is_recoverable_eof() => continue,
+            Err(e) => panic!("unexpected scan error at byte {avail}: {e:?}"),
+        }
+    }
+    panic!("decode never completed even with all bytes visible");
+}

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -311,19 +311,8 @@ fn resume_after_sof_eventually_succeeds() {
     assert!(info.width > 0 && info.height > 0, "dimensions must be valid");
 }
 
-/// Inject a synthetic APP2 ICC chunk just before the EOI marker of `base`.
-///
-/// The resulting JPEG places an APP marker at a position the entropy decoder
-/// encounters while reading scan data; in non-strict mode the scan loop
-/// dispatches such markers through `parse_marker_inner` from `mcu.rs`,
-/// which bypasses the header-side snapshot/rollback wrapping done in
-/// `handle_known_marker`.
-fn inject_inline_icc(base: &[u8], payload: &[u8]) -> Vec<u8> {
-    let eoi = base
-        .windows(2)
-        .rposition(|w| w == [0xFF, 0xD9])
-        .expect("base JPEG must end with EOI");
-
+/// Build a synthetic APP2 ICC chunk with a single payload segment.
+fn icc_app2_chunk(payload: &[u8]) -> Vec<u8> {
     let body_len = 2 + 12 + 1 + 1 + payload.len();
     assert!(body_len <= u16::MAX as usize, "payload too large for one APP2");
 
@@ -334,12 +323,70 @@ fn inject_inline_icc(base: &[u8], payload: &[u8]) -> Vec<u8> {
     chunk.push(1);
     chunk.push(1);
     chunk.extend_from_slice(payload);
+    chunk
+}
+
+/// Inject a synthetic APP2 ICC chunk before SOS so header parsing sees it.
+fn inject_header_icc(base: &[u8], payload: &[u8]) -> Vec<u8> {
+    let sos = base
+        .windows(2)
+        .position(|w| w == [0xFF, 0xDA])
+        .expect("base JPEG must contain SOS");
+    let chunk = icc_app2_chunk(payload);
+
+    let mut out = Vec::with_capacity(base.len() + chunk.len());
+    out.extend_from_slice(&base[..sos]);
+    out.extend_from_slice(&chunk);
+    out.extend_from_slice(&base[sos..]);
+    out
+}
+
+/// Inject a synthetic APP2 ICC chunk just before the EOI marker of `base`.
+///
+/// The resulting JPEG places an APP marker at a position the entropy decoder
+/// encounters while reading scan data; in non-strict mode the scan loop
+/// dispatches such markers through `parse_marker_inner` from `mcu.rs`.
+fn inject_inline_icc(base: &[u8], payload: &[u8]) -> Vec<u8> {
+    let eoi = base
+        .windows(2)
+        .rposition(|w| w == [0xFF, 0xD9])
+        .expect("base JPEG must end with EOI");
+    let chunk = icc_app2_chunk(payload);
 
     let mut out = Vec::with_capacity(base.len() + chunk.len());
     out.extend_from_slice(&base[..eoi]);
     out.extend_from_slice(&chunk);
     out.extend_from_slice(&base[eoi..]);
     out
+}
+
+#[test]
+fn header_app2_truncation_is_recoverable() {
+    let base = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let payload = b"HEADER-ICC-PAYLOAD-FOR-RESUME-TEST";
+    let data = inject_header_icc(base, payload);
+
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(&data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    for avail in 1..=data.len() {
+        limit.set(avail);
+
+        match decoder.decode_headers() {
+            Ok(()) => {
+                let got_icc = decoder
+                    .icc_profile()
+                    .expect("incremental headers must expose injected ICC profile");
+                assert_eq!(got_icc, payload);
+                return;
+            }
+            Err(ref e) if e.is_recoverable_eof() => continue,
+            Err(e) => panic!("unexpected header error at byte {avail}: {e:?}"),
+        }
+    }
+
+    panic!("headers never completed even with all bytes visible");
 }
 
 /// Sanity check: byte-by-byte incremental decode of a normal image (no
@@ -382,9 +429,9 @@ fn inplace_byte_by_byte_full_decode() {
     panic!("decode never completed");
 }
 
-/// Regression test for the case when scan-phase resume re-seeks to 
+/// Regression test for the case when scan-phase resume re-seeks to
 /// `scan_start_position` and replays the scan, any inline marker dispatched
-///  through `mcu.rs::parse_marker_inner` gets re-parsed on every retry. 
+///  through `mcu.rs::parse_marker_inner` gets re-parsed on every retry.
 /// For append-only metadata like ICC, this silently duplicates entries.
 ///
 /// The test:


### PR DESCRIPTION
This PR adds fine-grained resumable JPEG header parsing. Instead of restarting header parsing from SOI after recoverable EOF, the decoder now checkpoints at the last fully consumed marker and resumes from that marker boundary when more input becomes available.

## Changes

- Add recoverable EOF classification for byte-stream errors.
- Track JPEG decode phase with `DecodingState::DecodeHeaders { resume_position }` and `DecodeScan { scan_start_position }`.
- Resume header parsing from the last fully consumed marker instead of reparsing previous markers.
- Roll back append-only metadata state when parsing an ICC, extended XMP, or gain-map marker fails partway through.
- Preserve scan retry behavior by seeking back to the recorded scan start position.
- Add incremental tests covering:
  - recoverable EOF on truncated input,
  - repeated EOF on the same decoder,
  - in-place growable stream header resume,
  - byte-by-byte fine-grained checkpointing,
  - decode parity with one-shot decoding.

This work is going towards completing #375