### PR TITLE
JpegDecoder: Add restart-boundary resumability for JPEG scan decoding

### DIFF
--- a/benchmarks/benches/decode_jpeg.rs
+++ b/benchmarks/benches/decode_jpeg.rs
@@ -243,6 +243,142 @@ fn decode_no_samp_opts(c: &mut Criterion) {
     });
 }
 
+// ---------------------------------------------------------------------------
+// Restart-marker / resumability path
+//
+// The benchmarks above all use JPEGs without restart markers (DRI), so the
+// per-RST checkpoint code added for incremental decoding is never exercised
+// by them. The benchmarks below close that gap with a DRI-bearing input
+// (four_components.jpg, restart interval = 7 MCUs, 4-component baseline).
+// They cover:
+//   * one-shot decode of a DRI image (steady-state RST checkpoint cost),
+//   * an incremental decode that triggers a recoverable-EOF retry, so the
+//     RST checkpoint capture + resume seek path is measured end-to-end.
+// ---------------------------------------------------------------------------
+
+use std::cell::Cell;
+use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::rc::Rc;
+
+/// Byte-slice cursor with an externally-adjustable visibility limit.
+///
+/// Reads/seeks beyond `limit` behave as if the data ended there (EOF). The
+/// bench grows `limit` via the shared `Rc<Cell<usize>>` to simulate more
+/// data arriving on the same decoder.
+struct GrowableCursor<'a> {
+    data:     &'a [u8],
+    position: usize,
+    limit:    Rc<Cell<usize>>
+}
+
+impl<'a> GrowableCursor<'a> {
+    fn new(data: &'a [u8], limit: Rc<Cell<usize>>) -> Self {
+        Self { data, position: 0, limit }
+    }
+
+    fn visible(&self) -> usize {
+        self.limit.get().min(self.data.len())
+    }
+}
+
+impl Read for GrowableCursor<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let visible = self.visible();
+        if self.position >= visible {
+            return Ok(0);
+        }
+        let available = &self.data[self.position..visible];
+        let n = available.len().min(buf.len());
+        buf[..n].copy_from_slice(&available[..n]);
+        self.position += n;
+        Ok(n)
+    }
+}
+
+impl BufRead for GrowableCursor<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        let visible = self.visible();
+        if self.position >= visible {
+            return Ok(&[]);
+        }
+        Ok(&self.data[self.position..visible])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.position += amt;
+    }
+}
+
+impl Seek for GrowableCursor<'_> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let new_pos = match pos {
+            SeekFrom::Start(p) => p as i64,
+            SeekFrom::Current(p) => self.position as i64 + p,
+            SeekFrom::End(p) => self.visible() as i64 + p
+        };
+        if new_pos < 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "seek before start"
+            ));
+        }
+        self.position = new_pos as usize;
+        Ok(self.position as u64)
+    }
+}
+
+/// One-shot decode of a DRI-bearing JPEG. Exercises the per-RST checkpoint
+/// capture code path on every restart-interval boundary in steady state.
+fn decode_restart_full(c: &mut Criterion) {
+    let data =
+        read(sample_path().join("test-images/jpeg/four_components.jpg")).unwrap();
+    let mut group = c.benchmark_group("jpeg: DRI / Restart markers");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+
+    group.bench_function("one-shot", |b| {
+        b.iter(|| black_box(decode_jpeg(data.as_slice())));
+    });
+}
+
+/// Incremental decode of a DRI-bearing JPEG that triggers a recoverable EOF
+/// and then resumes. The decoder is freshly constructed each iteration, so
+/// the measurement reflects: one full header parse, one truncated scan that
+/// returns ExhaustedData near the end, then a final scan that resumes from
+/// the latest RST checkpoint and finishes the decode.
+fn decode_restart_resume(c: &mut Criterion) {
+    let data =
+        read(sample_path().join("test-images/jpeg/four_components.jpg")).unwrap();
+    let mut group = c.benchmark_group("jpeg: DRI / Restart markers");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+
+    // Expose ~80% of the file on the first attempt so the scan loop hits
+    // recoverable EOF after several RST checkpoints have been recorded.
+    let partial = data.len() * 80 / 100;
+
+    group.bench_function("incremental resume", |b| {
+        b.iter(|| {
+            let limit = Rc::new(Cell::new(partial));
+            let cursor = GrowableCursor::new(data.as_slice(), Rc::clone(&limit));
+            let mut decoder = JpegDecoder::new(cursor);
+            decoder.decode_headers().expect("headers should fit in 80%");
+            let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+
+            // First scan attempt: expect recoverable EOF.
+            match decoder.decode_into(&mut out) {
+                Ok(()) => panic!("scan should not complete at 80% visibility"),
+                Err(e) => assert!(e.is_recoverable_eof(), "got: {e:?}")
+            }
+
+            // Expose remaining bytes and resume from the latest checkpoint.
+            limit.set(data.len());
+            decoder
+                .decode_into(&mut out)
+                .expect("scan should complete with full data");
+            black_box(out);
+        });
+    });
+}
+
 criterion_group!(name=benches;
       config={
       let c = Criterion::default();
@@ -251,6 +387,7 @@ criterion_group!(name=benches;
     targets=decode_no_samp,decode_h_samp,decode_v_samp,
     decode_hv_samp,criterion_benchmark_grayscale,
     decode_hv_samp_prog,decode_h_samp_prog,decode_no_samp_prog,decode_v_samp_prog,
-    decode_no_samp_opts);
+    decode_no_samp_opts,
+    decode_restart_full,decode_restart_resume);
 
 criterion_main!(benches);

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -9,6 +9,7 @@
 //! Main image logic.
 #![allow(clippy::doc_markdown)]
 
+use alloc::boxed::Box;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 use alloc::{format, vec};
@@ -18,6 +19,8 @@ use zune_core::colorspace::ColorSpace;
 use zune_core::log::{error, trace, warn};
 use zune_core::options::DecoderOptions;
 
+#[cfg(feature = "arith")]
+use crate::bitstream::BitStream;
 use crate::bitstream::BitStreamHuffman;
 #[cfg(feature = "arith")]
 use crate::bitstream_arith::{ArithACTables, ArithDCTables, BitStreamArithmetic};
@@ -75,29 +78,61 @@ pub type ColorConvert16Ptr = fn(&[i16; 16], &[i16; 16], &[i16; 16], &mut [u8], &
 pub type IDCTPtr = fn(&mut [i32; 64], &mut [i16], usize);
 
 /// Tracks the current decoding phase for incremental decoding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Clone)]
 pub(crate) enum DecodingState {
     /// Headers not yet fully decoded. `resume_position == 0` means start from SOI.
     DecodeHeaders { resume_position: usize },
     /// Headers decoded; scan data starts at `scan_start_position`.
     ///
-    /// `append_snapshot` records the lengths of the append-only metadata
-    /// buffers (ICC, extended XMP, gain map) at the moment we entered the
-    /// scan. On every scan retry we roll those buffers back to this snapshot
-    /// before re-seeking, so inline markers re-encountered during replay
-    /// (see `mcu.rs::check_stream_marker_after_mcu_width`) do not duplicate
-    /// metadata entries.
+    /// `append_snapshot` rolls back inline metadata on scan replay.
+    /// `sos_snapshot` restores scan parameters before replay.
+    /// `rst_checkpoint` resumes from the latest restart boundary when present.
     DecodeScan {
         scan_start_position: usize,
-        append_snapshot:     HeaderAppendStateSnapshot
-    },
+        append_snapshot:     HeaderAppendStateSnapshot,
+        sos_snapshot:        SosParamsSnapshot,
+        rst_checkpoint:      Option<Box<ScanCheckpoint>>
+    }
 }
 
-// Snapshot of append-only buffers populated across multi-segment markers
-// (ICC chunks, extended XMP, gain map). All other parsers either overwrite
-// fixed slots (qt/huffman/components) or fail before mutating, so only
-// these three need to be rolled back when a marker parser errors out
-// or when scan-phase replay re-seeks past markers it already consumed.
+/// SOS fields restored before replaying scan data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SosParamsSnapshot {
+    pub(crate) z_order:         [usize; MAX_COMPONENTS],
+    pub(crate) num_scans:       u8,
+    pub(crate) scan_subsampled: bool,
+    pub(crate) spec_start:      u8,
+    pub(crate) spec_end:        u8,
+    pub(crate) succ_high:       u8,
+    pub(crate) succ_low:        u8,
+    pub(crate) dc_huff_tables:  [usize; MAX_COMPONENTS],
+    pub(crate) ac_huff_tables:  [usize; MAX_COMPONENTS]
+}
+
+/// Saved state at a restart-interval boundary during scan decoding.
+#[derive(Clone)]
+pub(crate) struct ScanCheckpoint {
+    /// Stream position immediately after the RST marker.
+    pub(crate) stream_position:   usize,
+    /// Next MCU row to decode.
+    pub(crate) mcu_row:           usize,
+    /// Next MCU column to decode in `mcu_row`.
+    pub(crate) mcu_col:           usize,
+    /// Number of output bytes stable at this checkpoint.
+    pub(crate) pixels_written:    usize,
+    /// SOS/component table state at this checkpoint.
+    pub(crate) sos_snapshot:      SosParamsSnapshot,
+    /// Append-only metadata state at this checkpoint.
+    pub(crate) append_snapshot:   HeaderAppendStateSnapshot,
+    /// Decoded coefficient/sample buffers.
+    pub(crate) component_buffers: [Vec<i16>; MAX_COMPONENTS],
+    /// Component decoder state, including upsampling row history.
+    pub(crate) component_state:   Vec<Components>,
+    /// Output bytes to restore before continuing.
+    pub(crate) output_prefix:     Vec<u8>
+}
+
+// Snapshot append-only metadata so marker or scan replay can roll it back.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct HeaderAppendStateSnapshot {
     icc:  usize,
@@ -254,13 +289,74 @@ where
         Ok(())
     }
 
+    fn capture_sos_params(&self) -> SosParamsSnapshot {
+        SosParamsSnapshot {
+            z_order:         self.z_order,
+            num_scans:       self.num_scans,
+            scan_subsampled: self.scan_subsampled,
+            spec_start:      self.spec_start,
+            spec_end:        self.spec_end,
+            succ_high:       self.succ_high,
+            succ_low:        self.succ_low,
+            dc_huff_tables:  core::array::from_fn(|i| {
+                self.components
+                    .get(i)
+                    .map_or(0, |component| component.dc_huff_table)
+            }),
+            ac_huff_tables:  core::array::from_fn(|i| {
+                self.components
+                    .get(i)
+                    .map_or(0, |component| component.ac_huff_table)
+            })
+        }
+    }
+
     fn enter_scan_state(&mut self) -> Result<(), DecodeErrors> {
         let scan_start_position = self.stream_position()?;
         let append_snapshot = HeaderAppendStateSnapshot::capture(self);
+        let sos_snapshot = self.capture_sos_params();
         self.state = DecodingState::DecodeScan {
             scan_start_position,
-            append_snapshot
+            append_snapshot,
+            sos_snapshot,
+            rst_checkpoint: None
         };
+        Ok(())
+    }
+
+    pub(crate) fn scan_checkpoint(&self) -> Option<&ScanCheckpoint> {
+        match &self.state {
+            DecodingState::DecodeScan { rst_checkpoint, .. } => rst_checkpoint.as_deref(),
+            DecodingState::DecodeHeaders { .. } => None
+        }
+    }
+
+    // Save a restart-boundary checkpoint. `pixels_written` remains row-based:
+    // if an RST lands mid-row, resume replays the row from restored buffers.
+    pub(crate) fn checkpoint_scan(
+        &mut self, mcu_row: usize, mcu_col: usize, pixels_written: usize,
+        component_buffers: [Vec<i16>; MAX_COMPONENTS], pixels: &[u8]
+    ) -> Result<(), DecodeErrors> {
+        let stream_position = self.stream_position()?;
+        let sos_snapshot = self.capture_sos_params();
+        let append_snapshot = HeaderAppendStateSnapshot::capture(self);
+        let output_prefix_len = pixels_written.min(pixels.len());
+        let output_prefix = pixels[..output_prefix_len].to_vec();
+        let component_state = self.components.clone();
+
+        if let DecodingState::DecodeScan { rst_checkpoint, .. } = &mut self.state {
+            *rst_checkpoint = Some(Box::new(ScanCheckpoint {
+                stream_position,
+                mcu_row,
+                mcu_col,
+                pixels_written: output_prefix_len,
+                sos_snapshot,
+                append_snapshot,
+                component_buffers,
+                component_state,
+                output_prefix
+            }));
+        }
         Ok(())
     }
 
@@ -536,12 +632,12 @@ where
     ///  - DAC -> Images using Arithmetic tables
     ///  - JPG(n)
     fn decode_headers_internal(&mut self) -> Result<(), DecodeErrors> {
-        match self.state {
+        match &self.state {
             DecodingState::DecodeScan { .. } => {
                 return Ok(());
             }
             DecodingState::DecodeHeaders { resume_position } => {
-                if resume_position == 0 {
+                if *resume_position == 0 {
                     // First two bytes should be jpeg soi marker
                     let magic_bytes = self.stream.get_u16_be_err()?;
 
@@ -554,7 +650,7 @@ where
                     self.set_color_convert_from_options();
                     self.checkpoint_headers()?;
                 } else {
-                    self.stream.set_position(resume_position)?;
+                    self.stream.set_position(*resume_position)?;
                 }
             }
         }
@@ -1012,16 +1108,60 @@ where
     ///
     ///
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
-        match self.state {
+        match self.state.clone() {
             DecodingState::DecodeHeaders { .. } => {
                 self.decode_headers_internal()?;
             }
-            DecodingState::DecodeScan { scan_start_position, append_snapshot } => {
-                // Roll back any metadata that an inline marker pushed during
-                // a previous scan attempt, then seek back to the start of the
-                // scan so MCU decoding can be retried from the same anchor.
-                append_snapshot.rollback(self);
-                self.stream.set_position(scan_start_position)?;
+            DecodingState::DecodeScan {
+                scan_start_position,
+                append_snapshot,
+                sos_snapshot,
+                rst_checkpoint
+            } => {
+                // Roll back inline metadata from a previous scan attempt.
+                let resume_append_snapshot = rst_checkpoint
+                    .as_ref()
+                    .map_or(append_snapshot, |checkpoint| checkpoint.append_snapshot);
+                resume_append_snapshot.rollback(self);
+
+                // Restore the SOS state for the chosen resume point.
+                let resume_sos_snapshot = rst_checkpoint
+                    .as_ref()
+                    .map_or(sos_snapshot, |checkpoint| checkpoint.sos_snapshot);
+                self.z_order = resume_sos_snapshot.z_order;
+                self.num_scans = resume_sos_snapshot.num_scans;
+                self.scan_subsampled = resume_sos_snapshot.scan_subsampled;
+                self.spec_start = resume_sos_snapshot.spec_start;
+                self.spec_end = resume_sos_snapshot.spec_end;
+                self.succ_high = resume_sos_snapshot.succ_high;
+                self.succ_low = resume_sos_snapshot.succ_low;
+                debug_assert!(
+                    self.components.len() <= MAX_COMPONENTS,
+                    "components vector exceeds MAX_COMPONENTS; SOS restore would index out of bounds"
+                );
+                for (i, component) in self.components.iter_mut().take(MAX_COMPONENTS).enumerate() {
+                    component.dc_huff_table = resume_sos_snapshot.dc_huff_tables[i];
+                    component.ac_huff_table = resume_sos_snapshot.ac_huff_tables[i];
+                }
+
+                if let Some(checkpoint) = rst_checkpoint {
+                    self.stream.set_position(checkpoint.stream_position)?;
+                } else {
+                    self.stream.set_position(scan_start_position)?;
+                }
+
+                // DC predictions restart at scan start and RST boundaries.
+                for comp in &mut self.components {
+                    comp.dc_pred = 0;
+                    comp.dc_diff = 0;
+                }
+                self.todo =
+                    if self.restart_interval == 0 { 0x7fff_ffff } else { self.restart_interval };
+
+                if self.is_arithmetic {
+                    #[cfg(feature = "arith")]
+                    BitStreamArithmetic::reset_arith_tables(&mut self.entropy_tables);
+                }
             }
         }
 

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -77,22 +77,23 @@ pub type ColorConvert16Ptr = fn(&[i16; 16], &[i16; 16], &[i16; 16], &mut [u8], &
 /// Carry out IDCT (type 3 dct) on ach block of 64 i16's
 pub type IDCTPtr = fn(&mut [i32; 64], &mut [i16], usize);
 
-/// Tracks the current decoding phase for incremental decoding.
+/// State recorded once headers complete, used for scan-phase replay/resume.
+///
+/// Stored on the decoder behind an `Option<Box<...>>` so that one-shot
+/// decoding (the path that never resumes) carries only a null pointer's
+/// worth of overhead. The box is created on the SOS marker and either
+/// dropped when the scan completes successfully or kept alive across a
+/// recoverable EOF so the next `decode_into` call can resume.
+///
+/// `append_snapshot` rolls back inline metadata on scan replay.
+/// `sos_snapshot` restores scan parameters before replay.
+/// `rst_checkpoint` resumes from the latest restart boundary when present.
 #[derive(Clone)]
-pub(crate) enum DecodingState {
-    /// Headers not yet fully decoded. `resume_position == 0` means start from SOI.
-    DecodeHeaders { resume_position: usize },
-    /// Headers decoded; scan data starts at `scan_start_position`.
-    ///
-    /// `append_snapshot` rolls back inline metadata on scan replay.
-    /// `sos_snapshot` restores scan parameters before replay.
-    /// `rst_checkpoint` resumes from the latest restart boundary when present.
-    DecodeScan {
-        scan_start_position: usize,
-        append_snapshot:     HeaderAppendStateSnapshot,
-        sos_snapshot:        SosParamsSnapshot,
-        rst_checkpoint:      Option<Box<ScanCheckpoint>>
-    }
+pub(crate) struct ScanDecodeState {
+    pub(crate) scan_start_position: usize,
+    pub(crate) append_snapshot:     HeaderAppendStateSnapshot,
+    pub(crate) sos_snapshot:        SosParamsSnapshot,
+    pub(crate) rst_checkpoint:      Option<Box<ScanCheckpoint>>
 }
 
 /// SOS fields restored before replaying scan data.
@@ -110,26 +111,33 @@ pub(crate) struct SosParamsSnapshot {
 }
 
 /// Saved state at a restart-interval boundary during scan decoding.
-#[derive(Clone)]
+///
+/// Allocation-free by construction: this struct only carries `Copy` scalars
+/// and fixed-size arrays, so per-RST checkpoint capture performs no heap
+/// work. The coefficient and component buffers themselves are *not* snapshotted
+/// here — they persist on [`JpegDecoder`] (`Components::raw_coeff`,
+/// `progressive_mcus_buffer`, `progressive_block_buffer`) across
+/// `decode_into` calls. Resume just needs to know where in the bitstream to
+/// pick up and what the DC predictor state was at that boundary.
+///
+/// Resume contract: the caller must pass the same output buffer to
+/// `decode_into` on retry so previously-written pixels are preserved.
+#[derive(Clone, Copy)]
 pub(crate) struct ScanCheckpoint {
     /// Stream position immediately after the RST marker.
-    pub(crate) stream_position:   usize,
+    pub(crate) stream_position: usize,
     /// Next MCU row to decode.
-    pub(crate) mcu_row:           usize,
+    pub(crate) mcu_row:         usize,
     /// Next MCU column to decode in `mcu_row`.
-    pub(crate) mcu_col:           usize,
+    pub(crate) mcu_col:         usize,
     /// Number of output bytes stable at this checkpoint.
-    pub(crate) pixels_written:    usize,
+    pub(crate) pixels_written:  usize,
     /// SOS/component table state at this checkpoint.
-    pub(crate) sos_snapshot:      SosParamsSnapshot,
+    pub(crate) sos_snapshot:    SosParamsSnapshot,
     /// Append-only metadata state at this checkpoint.
-    pub(crate) append_snapshot:   HeaderAppendStateSnapshot,
-    /// Decoded coefficient/sample buffers.
-    pub(crate) component_buffers: [Vec<i16>; MAX_COMPONENTS],
-    /// Component decoder state, including upsampling row history.
-    pub(crate) component_state:   Vec<Components>,
-    /// Output bytes to restore before continuing.
-    pub(crate) output_prefix:     Vec<u8>
+    pub(crate) append_snapshot: HeaderAppendStateSnapshot,
+    /// Per-component DC predictor state at the checkpoint: `(dc_pred, dc_diff)`.
+    pub(crate) dc_predictions:  [(i32, i32); MAX_COMPONENTS]
 }
 
 // Snapshot append-only metadata so marker or scan replay can roll it back.
@@ -265,8 +273,23 @@ pub struct JpegDecoder<T> {
     pub(crate) coeff:    usize, // Solves some weird bug :)
     /// Extended XMP segments
     pub(crate) extended_xmp_segments: Vec<ExtendedXmpSegment>,
-    /// Current decoding phase for incremental decoding.
-    state: DecodingState,
+    /// Stream position where the header parser should resume on a future
+    /// call after a recoverable EOF. Zero means "start from SOI".
+    ///
+    /// This is intentionally a plain scalar (not an enum variant or boxed
+    /// payload) so that one-shot decoding pays no per-call match cost.
+    header_resume_position: usize,
+    /// Scan-phase resume state. `Some` from SOS until the scan completes;
+    /// `None` during header parsing and after a successful decode. Boxed
+    /// so the decoder struct stays compact for the common one-shot path.
+    scan_state: Option<Box<ScanDecodeState>>,
+    /// Persistent coefficient buffers for multi-SOS baseline decoding.
+    ///
+    /// Owned by the decoder so contents survive a recoverable EOF and the
+    /// next `decode_into` retry can resume from where it stopped without
+    /// copying anything. The inner `Vec`s are reused across `decode_into`
+    /// calls; capacity is reclaimed only when the decoder is dropped.
+    pub(crate) progressive_mcus_buffer: [Vec<i16>; MAX_COMPONENTS]
 }
 
 impl<T> JpegDecoder<T>
@@ -285,7 +308,7 @@ where
 
     fn checkpoint_headers(&mut self) -> Result<(), DecodeErrors> {
         let resume_position = self.stream_position()?;
-        self.state = DecodingState::DecodeHeaders { resume_position };
+        self.header_resume_position = resume_position;
         Ok(())
     }
 
@@ -315,49 +338,66 @@ where
         let scan_start_position = self.stream_position()?;
         let append_snapshot = HeaderAppendStateSnapshot::capture(self);
         let sos_snapshot = self.capture_sos_params();
-        self.state = DecodingState::DecodeScan {
+        self.scan_state = Some(Box::new(ScanDecodeState {
             scan_start_position,
             append_snapshot,
             sos_snapshot,
             rst_checkpoint: None
-        };
+        }));
         Ok(())
     }
 
     pub(crate) fn scan_checkpoint(&self) -> Option<&ScanCheckpoint> {
-        match &self.state {
-            DecodingState::DecodeScan { rst_checkpoint, .. } => rst_checkpoint.as_deref(),
-            DecodingState::DecodeHeaders { .. } => None
-        }
+        self.scan_state
+            .as_deref()
+            .and_then(|state| state.rst_checkpoint.as_deref())
     }
 
-    // Save a restart-boundary checkpoint. `pixels_written` remains row-based:
-    // if an RST lands mid-row, resume replays the row from restored buffers.
+    // Save a restart-boundary checkpoint at the most recently consumed RST
+    // marker. Allocation-free: this only writes `Copy` scalars and fixed-size
+    // arrays into the existing `Box<ScanCheckpoint>` (or allocates the box
+    // exactly once at the first RST in a scan). The decoded coefficient and
+    // component buffers themselves are *not* copied here — they live on the
+    // decoder (`Components::raw_coeff`, `progressive_mcus_buffer`,
+    // `progressive_block_buffer`) and persist across `decode_into` retries.
     pub(crate) fn checkpoint_scan(
         &mut self, mcu_row: usize, mcu_col: usize, pixels_written: usize,
-        component_buffers: [Vec<i16>; MAX_COMPONENTS], pixels: &[u8]
+        dc_predictions: [(i32, i32); MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         let stream_position = self.stream_position()?;
         let sos_snapshot = self.capture_sos_params();
         let append_snapshot = HeaderAppendStateSnapshot::capture(self);
-        let output_prefix_len = pixels_written.min(pixels.len());
-        let output_prefix = pixels[..output_prefix_len].to_vec();
-        let component_state = self.components.clone();
 
-        if let DecodingState::DecodeScan { rst_checkpoint, .. } = &mut self.state {
-            *rst_checkpoint = Some(Box::new(ScanCheckpoint {
+        if let Some(state) = self.scan_state.as_mut() {
+            let snapshot = ScanCheckpoint {
                 stream_position,
                 mcu_row,
                 mcu_col,
-                pixels_written: output_prefix_len,
+                pixels_written,
                 sos_snapshot,
                 append_snapshot,
-                component_buffers,
-                component_state,
-                output_prefix
-            }));
+                dc_predictions
+            };
+            match &mut state.rst_checkpoint {
+                Some(existing) => **existing = snapshot,
+                None => state.rst_checkpoint = Some(Box::new(snapshot))
+            }
         }
         Ok(())
+    }
+
+    /// Drop the active RST checkpoint, if any.
+    ///
+    /// Called from the single-SOS baseline path after each row's
+    /// `post_process` succeeds. The next iteration of the outer loop will
+    /// overwrite `Components::raw_coeff`, so any checkpoint that pointed at
+    /// the just-processed row is no longer safe to resume to. New checkpoints
+    /// get recorded as RSTs fire in the next row; if EOF happens before the
+    /// next row's first RST, the scan falls back to replaying from scan start.
+    pub(crate) fn invalidate_scan_checkpoint(&mut self) {
+        if let Some(state) = self.scan_state.as_mut() {
+            state.rst_checkpoint = None;
+        }
     }
 
     // Match output colorspace; we only care for ycbcr to rgb/rgba here, in
@@ -433,7 +473,9 @@ where
             is_mjpeg:          false,
             coeff:             1,
             extended_xmp_segments: vec![],
-            state:             DecodingState::DecodeHeaders { resume_position: 0 },
+            header_resume_position: 0,
+            scan_state: None,
+            progressive_mcus_buffer: core::array::from_fn(|_| Vec::new())
         }
     }
     /// Decode a buffer already in memory
@@ -632,27 +674,25 @@ where
     ///  - DAC -> Images using Arithmetic tables
     ///  - JPG(n)
     fn decode_headers_internal(&mut self) -> Result<(), DecodeErrors> {
-        match &self.state {
-            DecodingState::DecodeScan { .. } => {
-                return Ok(());
-            }
-            DecodingState::DecodeHeaders { resume_position } => {
-                if *resume_position == 0 {
-                    // First two bytes should be jpeg soi marker
-                    let magic_bytes = self.stream.get_u16_be_err()?;
+        // If we already entered the scan phase nothing to do.
+        if self.scan_state.is_some() {
+            return Ok(());
+        }
+        let resume_position = self.header_resume_position;
+        if resume_position == 0 {
+            // First two bytes should be jpeg soi marker
+            let magic_bytes = self.stream.get_u16_be_err()?;
 
-                    if magic_bytes != 0xffd8 {
-                        return Err(DecodeErrors::IllegalMagicBytes(magic_bytes));
-                    }
-
-                    // Color convert depends only on options, so pick it once
-                    // on a fresh decode rather than on every resume.
-                    self.set_color_convert_from_options();
-                    self.checkpoint_headers()?;
-                } else {
-                    self.stream.set_position(*resume_position)?;
-                }
+            if magic_bytes != 0xffd8 {
+                return Err(DecodeErrors::IllegalMagicBytes(magic_bytes));
             }
+
+            // Color convert depends only on options, so pick it once
+            // on a fresh decode rather than on every resume.
+            self.set_color_convert_from_options();
+            self.checkpoint_headers()?;
+        } else {
+            self.stream.set_position(resume_position)?;
         }
 
         let mut last_byte = 0;
@@ -1108,61 +1148,100 @@ where
     ///
     ///
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
-        match self.state.clone() {
-            DecodingState::DecodeHeaders { .. } => {
-                self.decode_headers_internal()?;
-            }
-            DecodingState::DecodeScan {
+        // Read the scan-resume state without cloning it. We pull out the
+        // cheap, `Copy` snapshot fields; the boxed `rst_checkpoint` stays
+        // in place so the inner decoder can pick it up directly. When
+        // headers haven't completed yet, `scan_plan` is `None` and we
+        // just run header decoding below.
+        struct ScanPlan {
+            scan_start_position:   usize,
+            outer_append_snapshot: HeaderAppendStateSnapshot,
+            outer_sos_snapshot:    SosParamsSnapshot,
+            /// Snapshots taken from the checkpoint (if any) so the seek and
+            /// SOS-restore steps below do not need to touch `scan_state`.
+            checkpoint_view:       Option<CheckpointView>
+        }
+        #[derive(Clone, Copy)]
+        struct CheckpointView {
+            append_snapshot: HeaderAppendStateSnapshot,
+            sos_snapshot:    SosParamsSnapshot,
+            stream_position: usize,
+            dc_predictions:  [(i32, i32); MAX_COMPONENTS]
+        }
+        let scan_plan = self.scan_state.as_deref().map(|state| ScanPlan {
+            scan_start_position:   state.scan_start_position,
+            outer_append_snapshot: state.append_snapshot,
+            outer_sos_snapshot:    state.sos_snapshot,
+            checkpoint_view:       state.rst_checkpoint.as_deref().map(|checkpoint| {
+                CheckpointView {
+                    append_snapshot: checkpoint.append_snapshot,
+                    sos_snapshot:    checkpoint.sos_snapshot,
+                    stream_position: checkpoint.stream_position,
+                    dc_predictions:  checkpoint.dc_predictions
+                }
+            })
+        });
+        if let Some(plan) = scan_plan {
+            let ScanPlan {
                 scan_start_position,
-                append_snapshot,
-                sos_snapshot,
-                rst_checkpoint
-            } => {
-                // Roll back inline metadata from a previous scan attempt.
-                let resume_append_snapshot = rst_checkpoint
-                    .as_ref()
-                    .map_or(append_snapshot, |checkpoint| checkpoint.append_snapshot);
-                resume_append_snapshot.rollback(self);
+                outer_append_snapshot,
+                outer_sos_snapshot,
+                checkpoint_view
+            } = plan;
+            // Roll back inline metadata from a previous scan attempt.
+            let resume_append_snapshot =
+                checkpoint_view.map_or(outer_append_snapshot, |view| view.append_snapshot);
+            resume_append_snapshot.rollback(self);
 
-                // Restore the SOS state for the chosen resume point.
-                let resume_sos_snapshot = rst_checkpoint
-                    .as_ref()
-                    .map_or(sos_snapshot, |checkpoint| checkpoint.sos_snapshot);
-                self.z_order = resume_sos_snapshot.z_order;
-                self.num_scans = resume_sos_snapshot.num_scans;
-                self.scan_subsampled = resume_sos_snapshot.scan_subsampled;
-                self.spec_start = resume_sos_snapshot.spec_start;
-                self.spec_end = resume_sos_snapshot.spec_end;
-                self.succ_high = resume_sos_snapshot.succ_high;
-                self.succ_low = resume_sos_snapshot.succ_low;
-                debug_assert!(
-                    self.components.len() <= MAX_COMPONENTS,
-                    "components vector exceeds MAX_COMPONENTS; SOS restore would index out of bounds"
-                );
-                for (i, component) in self.components.iter_mut().take(MAX_COMPONENTS).enumerate() {
-                    component.dc_huff_table = resume_sos_snapshot.dc_huff_tables[i];
-                    component.ac_huff_table = resume_sos_snapshot.ac_huff_tables[i];
+            // Restore the SOS state for the chosen resume point.
+            let resume_sos_snapshot =
+                checkpoint_view.map_or(outer_sos_snapshot, |view| view.sos_snapshot);
+            self.z_order = resume_sos_snapshot.z_order;
+            self.num_scans = resume_sos_snapshot.num_scans;
+            self.scan_subsampled = resume_sos_snapshot.scan_subsampled;
+            self.spec_start = resume_sos_snapshot.spec_start;
+            self.spec_end = resume_sos_snapshot.spec_end;
+            self.succ_high = resume_sos_snapshot.succ_high;
+            self.succ_low = resume_sos_snapshot.succ_low;
+            debug_assert!(
+                self.components.len() <= MAX_COMPONENTS,
+                "components vector exceeds MAX_COMPONENTS; SOS restore would index out of bounds"
+            );
+            for (i, component) in self.components.iter_mut().take(MAX_COMPONENTS).enumerate() {
+                component.dc_huff_table = resume_sos_snapshot.dc_huff_tables[i];
+                component.ac_huff_table = resume_sos_snapshot.ac_huff_tables[i];
+            }
+
+            if let Some(view) = checkpoint_view {
+                self.stream.set_position(view.stream_position)?;
+                // Restore per-component DC predictor state from the checkpoint.
+                // At an RST boundary these are zero (handle_rst resets them),
+                // but we keep the values self-describing rather than relying
+                // on that invariant from another module.
+                for (i, comp) in
+                    self.components.iter_mut().enumerate().take(MAX_COMPONENTS)
+                {
+                    let (dc_pred, dc_diff) = view.dc_predictions[i];
+                    comp.dc_pred = dc_pred;
+                    comp.dc_diff = dc_diff;
                 }
-
-                if let Some(checkpoint) = rst_checkpoint {
-                    self.stream.set_position(checkpoint.stream_position)?;
-                } else {
-                    self.stream.set_position(scan_start_position)?;
-                }
-
-                // DC predictions restart at scan start and RST boundaries.
+            } else {
+                self.stream.set_position(scan_start_position)?;
+                // Fresh scan replay: DC predictors restart at zero.
                 for comp in &mut self.components {
                     comp.dc_pred = 0;
                     comp.dc_diff = 0;
                 }
-                self.todo =
-                    if self.restart_interval == 0 { 0x7fff_ffff } else { self.restart_interval };
-
-                if self.is_arithmetic {
-                    #[cfg(feature = "arith")]
-                    BitStreamArithmetic::reset_arith_tables(&mut self.entropy_tables);
-                }
             }
+            self.todo =
+                if self.restart_interval == 0 { 0x7fff_ffff } else { self.restart_interval };
+
+            if self.is_arithmetic {
+                #[cfg(feature = "arith")]
+                BitStreamArithmetic::reset_arith_tables(&mut self.entropy_tables);
+            }
+        } else {
+            self.decode_headers_internal()?;
         }
 
         let expected_size = self.output_buffer_size().unwrap();

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -28,6 +28,24 @@ use crate::JpegDecoder;
 /// The size of a DC block for a MCU.
 pub const DCT_BLOCK: usize = 64;
 
+struct McuWidthContext<'a, B: BitStream> {
+    mcu_width:      usize,
+    // Current MCU row, used when indexing progressive scratch buffers and checkpoints.
+    mcu_row:        usize,
+    // First MCU column to decode in this row; non-zero when resuming from a restart checkpoint.
+    start_col:      usize,
+    // Number of output bytes already committed before this MCU row.
+    pixels_written: usize,
+    // Output buffer snapshot source used when capturing a restart checkpoint.
+    pixels:         &'a [u8],
+    // Shared coefficient scratch block reused for each decoded data unit.
+    tmp:            &'a mut [i32; 64],
+    // Entropy decoder state for the current scan.
+    stream:         &'a mut B,
+    // Full-image coefficient buffers for multi-SOS baseline scans.
+    progressive:    &'a mut [Vec<i16>; MAX_COMPONENTS]
+}
+
 impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// Check for existence of DC and AC Huffman Tables
     pub(crate) fn check_tables<B: BitStream>(&mut self) -> Result<(), DecodeErrors> {
@@ -154,7 +172,40 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
         }
 
+        let checkpoint = self.scan_checkpoint().cloned();
+        let mut resume_row = 0;
+        let mut resume_col = 0;
         let mut pixels_written = 0;
+
+        if let Some(checkpoint) = checkpoint.as_ref() {
+            resume_row = checkpoint.mcu_row;
+            resume_col = checkpoint.mcu_col;
+            pixels_written = checkpoint.pixels_written;
+            let prefix_len = checkpoint.output_prefix.len().min(pixels.len());
+            pixels[..prefix_len].copy_from_slice(&checkpoint.output_prefix[..prefix_len]);
+            self.components = checkpoint.component_state.clone();
+
+            if !all_components_in_first_scan {
+                for (dst, src) in progressive_mcus
+                    .iter_mut()
+                    .zip(&checkpoint.component_buffers)
+                {
+                    if !src.is_empty() {
+                        *dst = src.clone();
+                    }
+                }
+            } else {
+                for (component, src) in self
+                    .components
+                    .iter_mut()
+                    .zip(&checkpoint.component_buffers)
+                {
+                    if !src.is_empty() {
+                        component.raw_coeff = src.clone();
+                    }
+                }
+            }
+        }
 
         let is_hv = usize::from(self.is_interleaved);
         let upsampler_scratch_size = is_hv
@@ -175,29 +226,29 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
             trace!("Decoding MCU width: {mcu_width}, height: {mcu_height}");
 
-            for i in 0..mcu_height {
+            for i in resume_row..mcu_height {
+                let start_col = if i == resume_row { resume_col } else { 0 };
                 if stream.overread_by() > 0 {
-                    if let Some(v) = pixels.get_mut(pixels_written..) {
-                        v.fill(128);
-                    }
-                    if self.options.strict_mode() {
-                        return Err(DecodeErrors::FormatStatic("Premature end of buffer"));
-                    }
-
-                    error!("Premature end of buffer");
-                    break;
+                    // The bitstream reader has exhausted available data.
+                    // Return a recoverable error so the caller can feed more
+                    // bytes and retry (incremental decoding).
+                    return Err(DecodeErrors::ExhaustedData);
                 }
 
                 // decode a whole MCU width,
                 // this takes into account interleaved components.
+                let mut mcu_width_context = McuWidthContext {
+                    mcu_width,
+                    mcu_row: i,
+                    start_col,
+                    pixels_written,
+                    pixels,
+                    tmp: &mut tmp,
+                    stream: &mut stream,
+                    progressive: &mut progressive_mcus
+                };
                 let terminate = if all_components_in_first_scan {
-                    self.decode_mcu_width::<false, B>(
-                        mcu_width,
-                        i,
-                        &mut tmp,
-                        &mut stream,
-                        &mut progressive_mcus,
-                    )?
+                    self.decode_mcu_width::<false, B>(&mut mcu_width_context)?
                 } else {
                     /* NB: (cae). This code was added due to the issue at https://github.com/etemesi254/zune-image/issues/277
                     *
@@ -216,13 +267,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     *
                     */
 
-                    self.decode_mcu_width::<true, B>(
-                        mcu_width,
-                        i,
-                        &mut tmp,
-                        &mut stream,
-                        &mut progressive_mcus,
-                    )?
+                    self.decode_mcu_width::<true, B>(&mut mcu_width_context)?
                 };
 
                 // process that width up until it's impossible. This is faster than allocation the
@@ -265,9 +310,52 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 }
             }
 
+            // A non-interleaved baseline image may place the next SOS right
+            // after the final MCU row of the current scan. If the bitstream
+            // did not discover that marker while decoding coefficients, look
+            // for it before treating the image as complete.
+            if !all_components_in_first_scan && !*stream.seen_eoi() {
+                match get_marker(&mut self.stream, &mut stream) {
+                    Ok(Marker::EOI) => {
+                        *stream.seen_eoi() = true;
+                        break;
+                    }
+                    Ok(Marker::SOS) => {
+                        self.parse_marker_inner(Marker::SOS)?;
+                        stream.reset();
+                        B::reset_arith_tables(&mut self.entropy_tables);
+                        continue 'sos;
+                    }
+                    Ok(marker) => {
+                        if self.advance_to_next_sos(marker, &mut stream)? {
+                            continue 'sos;
+                        }
+                        break;
+                    }
+                    Err(e) if e.is_recoverable_eof() => {
+                        return Err(e);
+                    }
+                    Err(e) => {
+                        if self.options.strict_mode() {
+                            return Err(e);
+                        }
+                        error!("{e}");
+                        break;
+                    }
+                }
+            }
+
             // Breaks if we get here, looping only if we have restarted, i.e. found another SOS and
             // continued at `'sos'.
             break;
+        }
+
+        // After the scan loop completes, check if the bitstream was over-read.
+        // This catches the case where the final MCU row consumed data past EOF
+        // (e.g. a 0xFF at the boundary was misinterpreted as byte-stuffing)
+        // without a subsequent row to detect it.
+        if stream.overread_by() > 0 {
+            return Err(DecodeErrors::ExhaustedData);
         }
 
         if !all_components_in_first_scan {
@@ -284,10 +372,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // Ensure we read EOI
         if !*stream.seen_eoi() {
             let marker = get_marker(&mut self.stream, &mut stream);
-            if let Ok(_m) = marker {
-                trace!("Found marker {_m:?}");
-            } else {
-                // ignore error
+            match marker {
+                Ok(_m) => {
+                    trace!("Found marker {_m:?}");
+                }
+                Err(e) if e.is_recoverable_eof() => {
+                    return Err(e);
+                }
+                Err(e) => {
+                    if self.options.strict_mode() {
+                        return Err(e);
+                    }
+                    error!("{e}");
+                }
             }
         }
 
@@ -374,8 +471,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn decode_mcu_width<const PROGRESSIVE: bool, B: BitStream>(
-        &mut self, mcu_width: usize, mcu_height: usize, tmp: &mut [i32; 64], stream: &mut B,
-        progressive: &mut [Vec<i16>; 4],
+        &mut self, context: &mut McuWidthContext<'_, B>
     ) -> Result<McuContinuation, DecodeErrors> {
         let is_one_by_one = !self.scan_subsampled;
 
@@ -389,21 +485,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // We statically specialize on this to improve code generation of the common case a little
         // bit. We could also special case common sub-sampling cases but be mindful of code bloat.
         if is_one_by_one {
-            self.inner_decode_mcu_width::<PROGRESSIVE, false, B>(
-                mcu_width,
-                mcu_height,
-                tmp,
-                stream,
-                progressive,
-            )
+            self.inner_decode_mcu_width::<PROGRESSIVE, false, B>(context)
         } else {
-            self.inner_decode_mcu_width::<PROGRESSIVE, true, B>(
-                mcu_width,
-                mcu_height,
-                tmp,
-                stream,
-                progressive,
-            )
+            self.inner_decode_mcu_width::<PROGRESSIVE, true, B>(context)
         }
     }
 
@@ -414,8 +498,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     // the scan. The difference was ~1% or a bit more.
     #[allow(clippy::too_many_lines)]
     fn inner_decode_mcu_width<const PROGRESSIVE: bool, const SAMPLED: bool, B: BitStream>(
-        &mut self, mcu_width: usize, mcu_height: usize, tmp: &mut [i32; 64], stream: &mut B,
-        progressive: &mut [Vec<i16>; 4],
+        &mut self, context: &mut McuWidthContext<'_, B>
     ) -> Result<McuContinuation, DecodeErrors> {
         let z_order = self.z_order;
         let z_scans = &z_order[..usize::from(self.num_scans)];
@@ -436,7 +519,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // Calculate actual data units for this component: ceil(width / (8 * subsampling_ratio))
             (self.info.width as usize * comp.horizontal_sample).div_ceil(self.h_max * 8)
         } else {
-            mcu_width
+            context.mcu_width
         };
         // In malformed scans that list multiple components, clamp to the smallest row capacity
         // to avoid writing past the row buffer.
@@ -449,7 +532,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             scan_du_width = scan_du_width.min(min_du);
         }
 
-        for j in 0..scan_du_width {
+        for j in context.start_col..scan_du_width {
             // iterate over components
             for &k in z_scans {
                 // we made this loop body massive due to several different paths that depend on
@@ -468,12 +551,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 let qt_table = &component.quantization_table;
                 let channel = if PROGRESSIVE {
                     let offset =
-                        mcu_height * component.width_stride * 8 * component.vertical_sample;
+                        context.mcu_row * component.width_stride * 8 * component.vertical_sample;
                     // Small stopgap for https://github.com/etemesi254/zune-image/issues/362
-                    if offset >= progressive[k].len() {
+                    if offset >= context.progressive[k].len() {
                         return Err(DecodeErrors::FormatStatic("Would panic on slice iteration"));
                     }
-                    &mut progressive[k][offset..]
+                    &mut context.progressive[k][offset..]
                 } else {
                     &mut component.raw_coeff
                 };
@@ -508,20 +591,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             // we attempt to overwrite exactly one coefficient.
                             let clobber_len = if clobber_more_than_4x4 { 64 } else { 32 };
 
-                            tmp[..clobber_len].fill(0);
+                            context.tmp[..clobber_len].fill(0);
 
-                            stream.decode_mcu_block(
+                            context.stream.decode_mcu_block(
                                 &mut self.stream,
                                 dc_table,
                                 ac_table,
                                 qt_table,
-                                tmp,
+                                context.tmp,
                                 &mut component.dc_pred,
                                 &mut component.dc_diff,
                             )
                         } else {
                             // We do not touch tmp so there is no need to reset it.
-                            stream.discard_mcu_block(
+                            context.stream.discard_mcu_block(
                                 &mut self.stream,
                                 dc_table,
                                 ac_table,
@@ -537,11 +620,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         //
                         // See example in https://github.com/etemesi254/zune-image/issues/293
                         let Ok(len) = result else {
-                            // result.is_err()
+                            let err = result.err().unwrap();
+                            // Always propagate ExhaustedData for incremental
+                            // decoding support — the caller can retry with more
+                            // data.
+                            if err.is_recoverable_eof() {
+                                return Err(err);
+                            }
+                            if self.stream.eof()? {
+                                return Err(DecodeErrors::ExhaustedData);
+                            }
                             return if self.options.strict_mode() {
-                                Err(result.err().unwrap())
+                                Err(err)
                             } else {
-                                error!("{}", result.err().unwrap());
+                                error!("{}", err);
                                 Ok(McuContinuation::Terminate)
                             };
                         };
@@ -564,12 +656,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             let idct_pos = channel.get_mut(idct_position..).unwrap();
 
                             if len <= 1 {
-                                (self.idct_1x1_func)(tmp, idct_pos, component.width_stride);
+                                (self.idct_1x1_func)(context.tmp, idct_pos, component.width_stride);
                             } else if len <= 10 {
-                                (self.idct_4x4_func)(tmp, idct_pos, component.width_stride);
+                                (self.idct_4x4_func)(context.tmp, idct_pos, component.width_stride);
                             } else {
                                 //  call idct.
-                                (self.idct_func)(tmp, idct_pos, component.width_stride);
+                                (self.idct_func)(context.tmp, idct_pos, component.width_stride);
                             }
                         }
                     }
@@ -579,16 +671,33 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             self.todo = self.todo.wrapping_sub(1);
 
             if self.todo == 0 {
-                self.handle_rst_main(stream)?;
+                if self.handle_rst_main(context.stream)? {
+                    let component_buffers = if PROGRESSIVE {
+                        core::array::from_fn(|idx| context.progressive[idx].clone())
+                    } else {
+                        core::array::from_fn(|idx| {
+                            self.components
+                                .get(idx)
+                                .map_or_else(Vec::new, |component| component.raw_coeff.clone())
+                        })
+                    };
+                    self.checkpoint_scan(
+                        context.mcu_row,
+                        j + 1,
+                        context.pixels_written,
+                        component_buffers,
+                        context.pixels
+                    )?;
+                }
                 continue;
             }
 
-            if stream.marker().is_some() && stream.bits_left() == 0 {
+            if context.stream.marker().is_some() && context.stream.bits_left() == 0 {
                 break;
             }
         }
 
-        self.check_stream_marker_after_mcu_width(stream)
+        self.check_stream_marker_after_mcu_width(context.stream)
     }
 
     fn check_stream_marker_after_mcu_width<B: BitStream>(
@@ -617,10 +726,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // https://github.com/google/libultrahdr
                 *stream.seen_eoi() = true;
             } else if let Marker::RST(_) = m {
-                //debug_assert_eq!(self.todo, 0);
-                if self.todo == 0 {
-                    self.handle_rst(stream)?;
-                }
+                // A latched RST means the entropy segment is already exhausted.
+                self.handle_rst(stream)?;
             } else if let Marker::SOS = m {
                 self.parse_marker_inner(Marker::SOS)?;
                 stream.marker().take();

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -36,8 +36,6 @@ struct McuWidthContext<'a, B: BitStream> {
     start_col:      usize,
     // Number of output bytes already committed before this MCU row.
     pixels_written: usize,
-    // Output buffer snapshot source used when capturing a restart checkpoint.
-    pixels:         &'a [u8],
     // Shared coefficient scratch block reused for each decoded data unit.
     tmp:            &'a mut [i32; 64],
     // Entropy decoder state for the current scan.
@@ -63,6 +61,26 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// Decode MCUs and carry out post processing.
     ///
     /// This is the main decoder loop for the library, the hot path.
+    pub(crate) fn decode_mcu_ycbcr_baseline<B: BitStream>(
+        &mut self, pixels: &mut [u8]
+    ) -> Result<(), DecodeErrors> {
+        // Move the persistent multi-SOS coefficient buffer out of `self` so
+        // the inner decoder can borrow it mutably while still calling methods
+        // on `self`. The buffer is put back on return and survives across
+        // `decode_into` retries, which is what lets per-RST checkpoints stay
+        // allocation-free.
+        let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
+        let result =
+            self.decode_mcu_ycbcr_baseline_inner::<B>(pixels, &mut progressive_mcus);
+        self.progressive_mcus_buffer = progressive_mcus;
+        result
+    }
+
+    /// Inner implementation of [`Self::decode_mcu_ycbcr_baseline`].
+    ///
+    /// `progressive_mcus` is owned by the decoder across calls so its
+    /// contents survive recoverable EOFs and don't need to be copied into a
+    /// `ScanCheckpoint` at restart boundaries.
     ///
     /// Because of this, we pull in some very crazy optimization tricks hence readability is a pinch
     /// here.
@@ -73,8 +91,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         clippy::used_underscore_binding
     )]
     #[inline(never)]
-    pub(crate) fn decode_mcu_ycbcr_baseline<B: BitStream>(
+    fn decode_mcu_ycbcr_baseline_inner<B: BitStream>(
         &mut self, pixels: &mut [u8],
+        progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
 
@@ -130,6 +149,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut tmp = [0_i32; DCT_BLOCK];
 
         let comp_len = self.components.len();
+        // True when we are resuming from a previously-saved RST checkpoint;
+        // in that case the per-component `raw_coeff` and `progressive_mcus`
+        // buffers still hold the data from the prior `decode_into` call and
+        // must not be re-zeroed. On a fresh decode they are (re-)allocated.
+        let resuming = self.scan_checkpoint().is_some();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
@@ -149,7 +173,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 let len = comp.width_stride * comp.vertical_sample * 8;
 
                 comp.needed = true;
-                comp.raw_coeff = vec![0; len];
+                if !resuming || comp.raw_coeff.len() != len {
+                    // Reuse capacity across decodes; zero contents.
+                    comp.raw_coeff.clear();
+                    comp.raw_coeff.resize(len, 0);
+                }
             } else {
                 comp.needed = false;
             }
@@ -159,52 +187,42 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // (upsampled) pixels immediately after each MCU, for convenience we use each row of MCUS.
         // Otherwise, we must first wait until following SOS provide the remaining components.
         let all_components_in_first_scan = usize::from(self.num_scans) == self.components.len();
-        let mut progressive_mcus: [Vec<i16>; 4] = core::array::from_fn(|_| vec![]);
 
-        if !all_components_in_first_scan {
-            for (component, mcu) in self.components.iter().zip(&mut progressive_mcus) {
+        if all_components_in_first_scan {
+            // No multi-SOS scratch is needed for this call; release any
+            // retained `progressive_mcus_buffer` capacity so it doesn't pin
+            // memory between decodes.
+            for mcu in progressive_mcus.iter_mut() {
+                *mcu = Vec::new();
+            }
+        } else {
+            for (component, mcu) in self.components.iter().zip(progressive_mcus.iter_mut()) {
                 let len = mcu_width
                     * component.vertical_sample
                     * component.horizontal_sample
                     * mcu_height
                     * 64;
-                *mcu = vec![0; len];
+                if !resuming || mcu.len() != len {
+                    mcu.clear();
+                    mcu.resize(len, 0);
+                }
             }
         }
 
-        let checkpoint = self.scan_checkpoint().cloned();
+        let checkpoint = self.scan_checkpoint().copied();
         let mut resume_row = 0;
         let mut resume_col = 0;
         let mut pixels_written = 0;
 
-        if let Some(checkpoint) = checkpoint.as_ref() {
+        if let Some(checkpoint) = checkpoint {
             resume_row = checkpoint.mcu_row;
             resume_col = checkpoint.mcu_col;
             pixels_written = checkpoint.pixels_written;
-            let prefix_len = checkpoint.output_prefix.len().min(pixels.len());
-            pixels[..prefix_len].copy_from_slice(&checkpoint.output_prefix[..prefix_len]);
-            self.components = checkpoint.component_state.clone();
-
-            if !all_components_in_first_scan {
-                for (dst, src) in progressive_mcus
-                    .iter_mut()
-                    .zip(&checkpoint.component_buffers)
-                {
-                    if !src.is_empty() {
-                        *dst = src.clone();
-                    }
-                }
-            } else {
-                for (component, src) in self
-                    .components
-                    .iter_mut()
-                    .zip(&checkpoint.component_buffers)
-                {
-                    if !src.is_empty() {
-                        component.raw_coeff = src.clone();
-                    }
-                }
-            }
+            // Coefficient and progressive buffers are persistent across
+            // `decode_into` calls and already contain the data from the
+            // prior attempt; we don't need to copy anything back. Only the
+            // per-component DC predictor state needs to be restored, which
+            // is already handled in `decode_into` from the checkpoint.
         }
 
         let is_hv = usize::from(self.is_interleaved);
@@ -242,10 +260,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     mcu_row: i,
                     start_col,
                     pixels_written,
-                    pixels,
                     tmp: &mut tmp,
                     stream: &mut stream,
-                    progressive: &mut progressive_mcus
+                    progressive: &mut *progressive_mcus
                 };
                 let terminate = if all_components_in_first_scan {
                     self.decode_mcu_width::<false, B>(&mut mcu_width_context)?
@@ -282,6 +299,13 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         &mut pixels_written,
                         &mut upsampler_scratch_space,
                     )?;
+                    // The just-completed row's `raw_coeff` will be overwritten
+                    // by the next row's decode. Any RST checkpoint recorded
+                    // mid-row-`i` would now point at coefficient data that is
+                    // about to be clobbered, so drop it. The next row's first
+                    // RST will record a fresh, valid checkpoint; if EOF hits
+                    // before that, resume falls back to scan-start replay.
+                    self.invalidate_scan_checkpoint();
                 }
 
                 match terminate {
@@ -500,6 +524,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     fn inner_decode_mcu_width<const PROGRESSIVE: bool, const SAMPLED: bool, B: BitStream>(
         &mut self, context: &mut McuWidthContext<'_, B>
     ) -> Result<McuContinuation, DecodeErrors> {
+        // Destructure the context into local bindings up front. Reading the
+        // hot loop through `context.<field>` keeps the optimizer from
+        // treating the per-field mutable borrows as `noalias` and was
+        // observed to cost ~1-2% on sub-sampled baseline benchmarks; pulling
+        // them out here restores parity with the pre-refactor signature.
+        let mcu_width = context.mcu_width;
+        let mcu_row = context.mcu_row;
+        let start_col = context.start_col;
+        let ctx_pixels_written = context.pixels_written;
+        let tmp: &mut [i32; 64] = &mut *context.tmp;
+        let stream: &mut B = &mut *context.stream;
+        let progressive: &mut [Vec<i16>; MAX_COMPONENTS] = &mut *context.progressive;
+
         let z_order = self.z_order;
         let z_scans = &z_order[..usize::from(self.num_scans)];
 
@@ -519,7 +556,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // Calculate actual data units for this component: ceil(width / (8 * subsampling_ratio))
             (self.info.width as usize * comp.horizontal_sample).div_ceil(self.h_max * 8)
         } else {
-            context.mcu_width
+            mcu_width
         };
         // In malformed scans that list multiple components, clamp to the smallest row capacity
         // to avoid writing past the row buffer.
@@ -532,7 +569,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             scan_du_width = scan_du_width.min(min_du);
         }
 
-        for j in context.start_col..scan_du_width {
+        for j in start_col..scan_du_width {
             // iterate over components
             for &k in z_scans {
                 // we made this loop body massive due to several different paths that depend on
@@ -551,12 +588,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 let qt_table = &component.quantization_table;
                 let channel = if PROGRESSIVE {
                     let offset =
-                        context.mcu_row * component.width_stride * 8 * component.vertical_sample;
+                        mcu_row * component.width_stride * 8 * component.vertical_sample;
                     // Small stopgap for https://github.com/etemesi254/zune-image/issues/362
-                    if offset >= context.progressive[k].len() {
+                    if offset >= progressive[k].len() {
                         return Err(DecodeErrors::FormatStatic("Would panic on slice iteration"));
                     }
-                    &mut context.progressive[k][offset..]
+                    &mut progressive[k][offset..]
                 } else {
                     &mut component.raw_coeff
                 };
@@ -591,20 +628,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             // we attempt to overwrite exactly one coefficient.
                             let clobber_len = if clobber_more_than_4x4 { 64 } else { 32 };
 
-                            context.tmp[..clobber_len].fill(0);
+                            tmp[..clobber_len].fill(0);
 
-                            context.stream.decode_mcu_block(
+                            stream.decode_mcu_block(
                                 &mut self.stream,
                                 dc_table,
                                 ac_table,
                                 qt_table,
-                                context.tmp,
+                                tmp,
                                 &mut component.dc_pred,
                                 &mut component.dc_diff,
                             )
                         } else {
                             // We do not touch tmp so there is no need to reset it.
-                            context.stream.discard_mcu_block(
+                            stream.discard_mcu_block(
                                 &mut self.stream,
                                 dc_table,
                                 ac_table,
@@ -656,12 +693,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             let idct_pos = channel.get_mut(idct_position..).unwrap();
 
                             if len <= 1 {
-                                (self.idct_1x1_func)(context.tmp, idct_pos, component.width_stride);
+                                (self.idct_1x1_func)(tmp, idct_pos, component.width_stride);
                             } else if len <= 10 {
-                                (self.idct_4x4_func)(context.tmp, idct_pos, component.width_stride);
+                                (self.idct_4x4_func)(tmp, idct_pos, component.width_stride);
                             } else {
                                 //  call idct.
-                                (self.idct_func)(context.tmp, idct_pos, component.width_stride);
+                                (self.idct_func)(tmp, idct_pos, component.width_stride);
                             }
                         }
                     }
@@ -671,33 +708,33 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             self.todo = self.todo.wrapping_sub(1);
 
             if self.todo == 0 {
-                if self.handle_rst_main(context.stream)? {
-                    let component_buffers = if PROGRESSIVE {
-                        core::array::from_fn(|idx| context.progressive[idx].clone())
-                    } else {
-                        core::array::from_fn(|idx| {
-                            self.components
-                                .get(idx)
-                                .map_or_else(Vec::new, |component| component.raw_coeff.clone())
-                        })
-                    };
+                if self.handle_rst_main_with_status(stream)? {
+                    // Coefficient buffers (`raw_coeff` and `progressive`)
+                    // live on the decoder across `decode_into` calls, so
+                    // they don't need to be snapshotted here. We only
+                    // capture the per-component DC predictor state, which is
+                    // zero immediately after `handle_rst` resets it.
+                    let dc_predictions = core::array::from_fn(|idx| {
+                        self.components
+                            .get(idx)
+                            .map_or((0, 0), |component| (component.dc_pred, component.dc_diff))
+                    });
                     self.checkpoint_scan(
-                        context.mcu_row,
+                        mcu_row,
                         j + 1,
-                        context.pixels_written,
-                        component_buffers,
-                        context.pixels
+                        ctx_pixels_written,
+                        dc_predictions
                     )?;
                 }
                 continue;
             }
 
-            if context.stream.marker().is_some() && context.stream.bits_left() == 0 {
+            if stream.marker().is_some() && stream.bits_left() == 0 {
                 break;
             }
         }
 
-        self.check_stream_marker_after_mcu_width(context.stream)
+        self.check_stream_marker_after_mcu_width(stream)
     }
 
     fn check_stream_marker_after_mcu_width<B: BitStream>(

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -103,12 +103,34 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             block[i] = vec![0; len];
         }
 
+        let checkpoint = self.scan_checkpoint().cloned();
+        let mut resume_position = checkpoint
+            .as_ref()
+            .map(|checkpoint| (checkpoint.mcu_row, checkpoint.mcu_col));
+
+        if let Some(checkpoint) = checkpoint.as_ref() {
+            self.components = checkpoint.component_state.clone();
+            for (dst, src) in block.iter_mut().zip(&checkpoint.component_buffers) {
+                if !src.is_empty() {
+                    *dst = src.clone();
+                }
+            }
+        }
+
         let mut stream = B::new_progressive(self.succ_low, self.spec_start, self.spec_end);
 
         // there are multiple scans in the stream, this should resolve the first scan
-        let result = self.parse_entropy_coded_data(&mut stream, &mut block);
+        let result =
+            self.parse_entropy_coded_data(&mut stream, &mut block, resume_position.take());
 
-        if result.is_err() {
+        if let Err(ref e) = result {
+            // Always propagate ExhaustedData for incremental decoding support.
+            if e.is_recoverable_eof() {
+                return Err(result.err().unwrap());
+            }
+            if self.stream.eof()? {
+                return Err(DecodeErrors::ExhaustedData);
+            }
             return if self.options.strict_mode() {
                 Err(result.err().unwrap())
             } else {
@@ -117,12 +139,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 return self.finish_progressive_decoding(&block, pixels);
             };
         }
+        if stream.overread_by() > 0 {
+            return Err(DecodeErrors::ExhaustedData);
+        }
 
         // extract marker
-        let mut marker = stream
-            .marker()
-            .take()
-            .ok_or(DecodeErrors::FormatStatic("Marker missing where expected"))?;
+        let mut marker = get_marker(&mut self.stream, &mut stream)?;
 
         // if marker is EOI, we are done, otherwise continue scanning.
         //
@@ -141,17 +163,26 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         self.spec_end
                     );
                     // after every SOS, marker, parse data for that scan.
-                    let result = self.parse_entropy_coded_data(&mut stream, &mut block);
+                    let result = self.parse_entropy_coded_data(&mut stream, &mut block, None);
 
                     // Do not error out too fast, allows the decoder to continue as much as possible
-                    // even after errors
-                    if result.is_err() {
+                    // even after errors — but always propagate ExhaustedData.
+                    if let Err(ref e) = result {
+                        if e.is_recoverable_eof() {
+                            return Err(result.err().unwrap());
+                        }
+                        if self.stream.eof()? {
+                            return Err(DecodeErrors::ExhaustedData);
+                        }
                         return if self.options.strict_mode() {
                             Err(result.err().unwrap())
                         } else {
                             error!("{}", result.err().unwrap());
                             break 'eoi;
                         };
+                    }
+                    if stream.overread_by() > 0 {
+                        return Err(DecodeErrors::ExhaustedData);
                     }
                     // extract marker, might either indicate end of image or we continue
                     // scanning(hence the continue statement to determine).
@@ -171,6 +202,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             continue 'eoi;
                         }
                         Err(msg) => {
+                            if msg.is_recoverable_eof() {
+                                return Err(msg);
+                            }
                             if self.options.strict_mode() {
                                 return Err(msg);
                             }
@@ -192,6 +226,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     marker = marker_n;
                 }
                 Err(e) => {
+                    if e.is_recoverable_eof() {
+                        return Err(e);
+                    }
                     if self.options.strict_mode() {
                         return Err(e);
                     }
@@ -220,11 +257,18 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         self.todo = if self.restart_interval != 0 { self.restart_interval } else { usize::MAX };
     }
 
+    /// Parse a progressive scan's entropy-coded data into `buffer`.
+    ///
+    /// `resume_position` is `Some((mcu_row, mcu_col))` when resuming from a
+    /// restart-interval checkpoint; the loop will restart from that MCU
+    /// coordinate. `None` starts decoding from `(0, 0)`.
     #[allow(clippy::too_many_lines, clippy::cast_sign_loss)]
     fn parse_entropy_coded_data<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS]
+        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        resume_position: Option<(usize, usize)>
     ) -> Result<(), DecodeErrors> {
         self.reset_prog_params(stream);
+        let (resume_row, resume_col) = resume_position.unwrap_or((0, 0));
 
         if usize::from(self.num_scans) > self.input_colorspace.num_components() {
             return Err(DecodeErrors::Format(format!(
@@ -255,8 +299,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             let mcu_width = (self.info.width as usize * component.horizontal_sample).div_ceil(self.h_max * 8);
             let mcu_height = (self.info.height as usize * component.vertical_sample).div_ceil(self.v_max * 8);
 
-            for i in 0..mcu_height {
-                for j in 0..mcu_width {
+            for i in resume_row..mcu_height {
+                let start_col = if i == resume_row { resume_col } else { 0 };
+                for j in start_col..mcu_width {
                     if self.spec_start != 0 && self.succ_high == 0 && *stream.eob_run() > 0 {
                         // handle EOB runs here.
                         *stream.eob_run() -= 1;
@@ -316,7 +361,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     // + EOB and investigate effect.
                     self.todo -= 1;
 
-                    self.handle_rst_main(stream)?;
+                    if self.handle_rst_main(stream)? {
+                        let component_buffers = core::array::from_fn(|idx| buffer[idx].clone());
+                        self.checkpoint_scan(i, j + 1, 0, component_buffers, &[])?;
+                    }
                 }
             }
         } else {
@@ -345,8 +393,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
             // Components shall not be interleaved in progressive mode, except for
             // the DC coefficients in the first scan for each component of a progressive frame.
-            for i in 0..self.mcu_y {
-                for j in 0..self.mcu_x {
+            for i in resume_row..self.mcu_y {
+                let start_col = if i == resume_row { resume_col } else { 0 };
+                for j in start_col..self.mcu_x {
                     // process scan n elements in order
                     for k in 0..self.num_scans {
                         let n = self.z_order[k as usize];
@@ -385,7 +434,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     // we get a higher number in the case this underflows
                     self.todo -= 1;
                     // after every scan that's a mcu, count down restart markers.
-                    self.handle_rst_main(stream)?;
+                    if self.handle_rst_main(stream)? {
+                        let component_buffers = core::array::from_fn(|idx| buffer[idx].clone());
+                        self.checkpoint_scan(i, j + 1, 0, component_buffers, &[])?;
+                    }
                 }
             }
         }
@@ -395,7 +447,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::used_underscore_binding)]
     pub(crate) fn handle_rst_main<B: BitStream>(
         &mut self, stream: &mut B
-    ) -> Result<(), DecodeErrors> {
+    ) -> Result<bool, DecodeErrors> {
         if self.todo == 0 {
             stream.refill(&mut self.stream)?;
         }
@@ -418,23 +470,31 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // in the image and this would return an error, so for now
             // translate it to a warning, but return the image decoded up
             // until that point
-            if let Ok(marker) = marker {
-                let _end = self.stream.position()?;
-                *stream.marker() = Some(marker);
-                // NB some warnings may be false positives.
-                warn!(
-                    "{} Extraneous bytes before marker {:?}",
-                    _end - _start,
-                    marker
-                );
-            } else {
-                warn!("RST marker was not found, where expected, image may be garbled");
+            match marker {
+                Ok(marker) => {
+                    let _end = self.stream.position()?;
+                    *stream.marker() = Some(marker);
+                    // NB some warnings may be false positives.
+                    warn!(
+                        "{} Extraneous bytes before marker {:?}",
+                        _end - _start,
+                        marker
+                    );
+                }
+                Err(ref e) if e.is_recoverable_eof() => {
+                    return Err(DecodeErrors::ExhaustedData);
+                }
+                Err(_) => {
+                    warn!("RST marker was not found, where expected, image may be garbled");
+                }
             }
         }
         if self.todo == 0 {
+            let handled_restart = matches!(stream.marker(), Some(Marker::RST(_)));
             self.handle_rst(stream)?;
+            return Ok(handled_restart);
         }
-        Ok(())
+        Ok(false)
     }
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::needless_range_loop, clippy::cast_sign_loss)]

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -41,6 +41,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// Decode a progressive image
     ///
     /// This routine decodes a progressive image, stopping if it finds any error.
+    ///
+    /// Progressive decoding allocates its scan buffer per call. Unlike
+    /// baseline, it does not record per-RST checkpoints (refine passes do
+    /// read-modify-write on the buffer, making mid-scan resume unsafe), so
+    /// there is no benefit to persisting the buffer on the decoder across
+    /// calls — the buffer is always zeroed at the start of a fresh decode.
     #[allow(
         clippy::needless_range_loop,
         clippy::cast_sign_loss,
@@ -54,7 +60,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         setup_component_params(self)?;
         let mut mcu_height;
 
-        // memory location for decoded pixels for components
+        // Coefficient buffer is local: progressive can't reuse contents
+        // across `decode_into` retries (see RST handling note in this file
+        // for why).
         let mut block: [Vec<i16>; MAX_COMPONENTS] = [vec![], vec![], vec![], vec![]];
         let mut mcu_width;
 
@@ -97,34 +105,30 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         mcu_width *= 64;
 
+        // Progressive scans can be refine passes that read-modify-write
+        // existing `block` entries (`decode_prog_dc_refine`,
+        // `decode_prog_ac_refine`). Mid-scan resume into such a buffer is
+        // unsafe — the partial deltas from a failed attempt would be
+        // re-applied on retry. Progressive therefore does not capture
+        // per-RST checkpoints (see RST handling below); on a recoverable
+        // EOF the decoder falls back to `scan_start_position`, replaying
+        // from the first SOS with a freshly-zeroed `block`.
         for (i, comp) in self.components.iter().enumerate() {
             let len = mcu_width * comp.vertical_sample * comp.horizontal_sample * mcu_height;
-
             block[i] = vec![0; len];
         }
 
-        let checkpoint = self.scan_checkpoint().cloned();
-        let mut resume_position = checkpoint
-            .as_ref()
-            .map(|checkpoint| (checkpoint.mcu_row, checkpoint.mcu_col));
-
-        if let Some(checkpoint) = checkpoint.as_ref() {
-            self.components = checkpoint.component_state.clone();
-            for (dst, src) in block.iter_mut().zip(&checkpoint.component_buffers) {
-                if !src.is_empty() {
-                    *dst = src.clone();
-                }
-            }
-        }
-
+        // Per-RST checkpoints are not recorded for progressive (see comment
+        // above), so `parse_entropy_coded_data` always starts each scan from
+        // its beginning. This still benefits from header-level resume.
         let mut stream = B::new_progressive(self.succ_low, self.spec_start, self.spec_end);
 
         // there are multiple scans in the stream, this should resolve the first scan
-        let result =
-            self.parse_entropy_coded_data(&mut stream, &mut block, resume_position.take());
+        let result = self.parse_entropy_coded_data(&mut stream, &mut block);
 
         if let Err(ref e) = result {
-            // Always propagate ExhaustedData for incremental decoding support.
+            // Always propagate ExhaustedData for incremental decoding support
+            // — the caller can retry with more data.
             if e.is_recoverable_eof() {
                 return Err(result.err().unwrap());
             }
@@ -163,7 +167,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         self.spec_end
                     );
                     // after every SOS, marker, parse data for that scan.
-                    let result = self.parse_entropy_coded_data(&mut stream, &mut block, None);
+                    let result = self.parse_entropy_coded_data(&mut stream, &mut block);
 
                     // Do not error out too fast, allows the decoder to continue as much as possible
                     // even after errors — but always propagate ExhaustedData.
@@ -259,16 +263,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     /// Parse a progressive scan's entropy-coded data into `buffer`.
     ///
-    /// `resume_position` is `Some((mcu_row, mcu_col))` when resuming from a
-    /// restart-interval checkpoint; the loop will restart from that MCU
-    /// coordinate. `None` starts decoding from `(0, 0)`.
+    /// Progressive scans always start at MCU `(0, 0)` — per-RST checkpoints
+    /// are not recorded for progressive (refine passes do read-modify-write
+    /// on `buffer`, so mid-scan resume would re-apply partial deltas).
     #[allow(clippy::too_many_lines, clippy::cast_sign_loss)]
     fn parse_entropy_coded_data<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
-        resume_position: Option<(usize, usize)>
+        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         self.reset_prog_params(stream);
-        let (resume_row, resume_col) = resume_position.unwrap_or((0, 0));
 
         if usize::from(self.num_scans) > self.input_colorspace.num_components() {
             return Err(DecodeErrors::Format(format!(
@@ -299,9 +301,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             let mcu_width = (self.info.width as usize * component.horizontal_sample).div_ceil(self.h_max * 8);
             let mcu_height = (self.info.height as usize * component.vertical_sample).div_ceil(self.v_max * 8);
 
-            for i in resume_row..mcu_height {
-                let start_col = if i == resume_row { resume_col } else { 0 };
-                for j in start_col..mcu_width {
+            for i in 0..mcu_height {
+                for j in 0..mcu_width {
                     if self.spec_start != 0 && self.succ_high == 0 && *stream.eob_run() > 0 {
                         // handle EOB runs here.
                         *stream.eob_run() -= 1;
@@ -361,10 +362,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     // + EOB and investigate effect.
                     self.todo -= 1;
 
-                    if self.handle_rst_main(stream)? {
-                        let component_buffers = core::array::from_fn(|idx| buffer[idx].clone());
-                        self.checkpoint_scan(i, j + 1, 0, component_buffers, &[])?;
-                    }
+                    // Progressive does not record per-RST checkpoints —
+                    // refine scans do read-modify-write on `buffer` and
+                    // mid-scan resume would re-apply partial deltas. On
+                    // EOF the decoder falls back to scan-start replay.
+                    self.handle_rst_main(stream)?;
                 }
             }
         } else {
@@ -393,9 +395,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
             // Components shall not be interleaved in progressive mode, except for
             // the DC coefficients in the first scan for each component of a progressive frame.
-            for i in resume_row..self.mcu_y {
-                let start_col = if i == resume_row { resume_col } else { 0 };
-                for j in start_col..self.mcu_x {
+            for i in 0..self.mcu_y {
+                for j in 0..self.mcu_x {
                     // process scan n elements in order
                     for k in 0..self.num_scans {
                         let n = self.z_order[k as usize];
@@ -434,20 +435,25 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     // we get a higher number in the case this underflows
                     self.todo -= 1;
                     // after every scan that's a mcu, count down restart markers.
-                    if self.handle_rst_main(stream)? {
-                        let component_buffers = core::array::from_fn(|idx| buffer[idx].clone());
-                        self.checkpoint_scan(i, j + 1, 0, component_buffers, &[])?;
-                    }
+                    // Progressive does not record per-RST checkpoints;
+                    // see comment in the spectral branch above.
+                    self.handle_rst_main(stream)?;
                 }
             }
         }
         return Ok(());
     }
 
+    /// Handle an RST marker mid-scan, if one is due. Used by the progressive
+    /// scan decoder, which does not record per-RST checkpoints and therefore
+    /// does not need to know whether a marker was actually consumed.
+    ///
+    /// The baseline decoder, which does checkpoint, calls
+    /// [`Self::handle_rst_main_with_status`] instead.
     #[allow(clippy::used_underscore_binding)]
     pub(crate) fn handle_rst_main<B: BitStream>(
         &mut self, stream: &mut B
-    ) -> Result<bool, DecodeErrors> {
+    ) -> Result<(), DecodeErrors> {
         if self.todo == 0 {
             stream.refill(&mut self.stream)?;
         }
@@ -490,11 +496,34 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
         }
         if self.todo == 0 {
-            let handled_restart = matches!(stream.marker(), Some(Marker::RST(_)));
             self.handle_rst(stream)?;
-            return Ok(handled_restart);
         }
-        Ok(false)
+        Ok(())
+    }
+
+    /// Variant of [`Self::handle_rst_main`] used by the baseline scan decoder
+    /// to detect whether the consumed marker was actually an RST. Returns
+    /// `true` when `todo` had wrapped to 0 *and* a real RST marker was found
+    /// at the entropy-segment boundary, signalling a safe place to take a
+    /// resumability checkpoint. Returns `false` otherwise.
+    ///
+    /// Only baseline calls this; progressive uses the lighter
+    /// [`Self::handle_rst_main`] above so its per-MCU codegen stays
+    /// bit-identical to the pre-PR shape.
+    pub(crate) fn handle_rst_main_with_status<B: BitStream>(
+        &mut self, stream: &mut B
+    ) -> Result<bool, DecodeErrors> {
+        let was_due = self.todo == 0;
+        self.handle_rst_main(stream)?;
+        if !was_due {
+            return Ok(false);
+        }
+        // After `handle_rst_main`, the marker (if any) has been latched into
+        // the stream's marker slot. A successful restart consumes the latched
+        // RST marker and clears it, but the marker may also be SOS/EOI/DHT/…
+        // for which we don't want to record a checkpoint.
+        let handled_restart = matches!(stream.marker(), None | Some(Marker::RST(_)));
+        Ok(handled_restart)
     }
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::needless_range_loop, clippy::cast_sign_loss)]

--- a/crates/zune-jpeg/src/misc.rs
+++ b/crates/zune-jpeg/src/misc.rs
@@ -236,8 +236,8 @@ pub(crate) fn setup_component_params<T: ZByteReaderTrait>(
         // probably not needed. :)
         component.y = y;
         component.quantization_table = qt_table;
-        // initially stride contains its horizontal sub-sampling
-        component.width_stride *= img.mcu_x * 8;
+        // Use direct assignment (not *=) so this is idempotent on retry.
+        component.width_stride = component.horizontal_sample * img.mcu_x * 8;
     }
     {
         // Sampling factors are one thing that suck

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -14,7 +14,7 @@
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::JpegDecoder;
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::io::{BufRead, Read, Seek, SeekFrom};
 use std::rc::Rc;
 
@@ -27,11 +27,29 @@ struct GrowableCursor<'a> {
     data:     &'a [u8],
     position: usize,
     limit:    Rc<Cell<usize>>,
+    seek_log: Option<Rc<RefCell<Vec<usize>>>>
 }
 
 impl<'a> GrowableCursor<'a> {
     fn new(data: &'a [u8], limit: Rc<Cell<usize>>) -> Self {
-        Self { data, position: 0, limit }
+        Self {
+            data,
+            position: 0,
+            limit,
+            seek_log: None
+        }
+    }
+
+    #[cfg(feature = "arith")]
+    fn with_seek_log(
+        data: &'a [u8], limit: Rc<Cell<usize>>, seek_log: Rc<RefCell<Vec<usize>>>
+    ) -> Self {
+        Self {
+            data,
+            position: 0,
+            limit,
+            seek_log: Some(seek_log)
+        }
     }
 
     fn visible(&self) -> usize {
@@ -81,6 +99,9 @@ impl Seek for GrowableCursor<'_> {
             ));
         }
         self.position = new_pos as usize;
+        if let Some(seek_log) = &self.seek_log {
+            seek_log.borrow_mut().push(self.position);
+        }
         Ok(self.position as u64)
     }
 }
@@ -88,6 +109,86 @@ impl Seek for GrowableCursor<'_> {
 fn decode_oneshot(data: &[u8]) -> Vec<u8> {
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode().expect("one-shot decode failed")
+}
+
+fn assert_pixels_match(actual: &[u8], expected: &[u8], name: &str, available: usize) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{name}: incremental and one-shot output lengths differ"
+    );
+
+    if let Some(index) = actual
+        .iter()
+        .zip(expected)
+        .position(|(left, right)| left != right)
+    {
+        let start = index.saturating_sub(8);
+        let end = (index + 9).min(actual.len());
+        panic!(
+            "{name}: first pixel byte mismatch at {index} with {available} bytes visible: incremental={}, one-shot={}, incremental window={:?}, one-shot window={:?}",
+            actual[index],
+            expected[index],
+            &actual[start..end],
+            &expected[start..end]
+        );
+    }
+}
+
+fn assert_incremental_decode_matches_oneshot(name: &str, data: &[u8], step: usize) {
+    assert!(step > 0, "incremental step must be non-zero");
+
+    let expected = decode_oneshot(data);
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    let mut header_done = false;
+    let mut out: Vec<u8> = Vec::new();
+    let mut available = 0_usize;
+
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+
+        if !header_done {
+            match decoder.decode_headers() {
+                Ok(()) => header_done = true,
+                Err(ref e) if e.is_recoverable_eof() => {
+                    assert!(
+                        available < data.len(),
+                        "headers still need more data with the full input visible"
+                    );
+                    continue;
+                }
+                Err(e) => panic!("unexpected header error at byte {available}: {e:?}")
+            }
+        }
+
+        if out.is_empty() {
+            out = vec![0u8; decoder.output_buffer_size().unwrap()];
+        }
+
+        match decoder.decode_into(&mut out) {
+            Ok(()) => {
+                assert_pixels_match(&out, &expected, name, available);
+                return;
+            }
+            Err(ref e) if e.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "scan still needs more data with the full input visible"
+                );
+            }
+            Err(e) => panic!("unexpected scan error at byte {available}: {e:?}")
+        }
+    }
+}
+
+fn assert_incremental_decode_matrix(cases: &[(&str, &[u8], usize)]) {
+    for (name, data, step) in cases {
+        assert_incremental_decode_matches_oneshot(name, data, *step);
+    }
 }
 
 /// Feeding the entire file at once via decode_headers + decode_into must
@@ -389,12 +490,243 @@ fn header_app2_truncation_is_recoverable() {
     panic!("headers never completed even with all bytes visible");
 }
 
+/// Sanity check: give headers + partial scan, get EOF, then give
+/// full data and verify pixels match one-shot.
+#[test]
+fn scan_resume_two_step() {
+    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let expected = decode_oneshot(data);
+
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    // Expose 80% of data — headers should complete, scan should fail
+    let partial = data.len() * 80 / 100;
+    limit.set(partial);
+
+    decoder
+        .decode_headers()
+        .expect("headers should succeed at 80%");
+    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+
+    match decoder.decode_into(&mut out) {
+        Ok(()) => panic!("scan should not complete with only 80% data"),
+        Err(ref e) if e.is_recoverable_eof() => {} // expected
+        Err(e) => panic!("unexpected error: {e:?}")
+    }
+
+    // Now expose all data
+    limit.set(data.len());
+    decoder
+        .decode_into(&mut out)
+        .expect("scan should succeed with 100% data");
+    assert_eq!(out, expected, "pixels must match one-shot decode");
+}
+
+/// Same as two_step but with 10-byte chunks to stress-test many retries.
+#[test]
+fn scan_resume_small_chunks() {
+    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let expected = decode_oneshot(data);
+
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    let mut out: Vec<u8> = Vec::new();
+    let chunk = 10;
+    let mut header_done = false;
+    for avail in (chunk..=data.len()).step_by(chunk) {
+        limit.set(avail.min(data.len()));
+
+        if !header_done {
+            match decoder.decode_headers() {
+                Ok(()) => {
+                    header_done = true;
+                }
+                Err(ref e) if e.is_recoverable_eof() => continue,
+                Err(e) => panic!("header error at byte {avail}: {e:?}")
+            }
+        }
+
+        if out.is_empty() {
+            out = vec![0u8; decoder.output_buffer_size().unwrap()];
+        }
+
+        match decoder.decode_into(&mut out) {
+            Ok(()) => {
+                assert_eq!(out, expected, "pixels must match one-shot");
+                return;
+            }
+            Err(ref e) if e.is_recoverable_eof() => {
+                continue;
+            }
+            Err(e) => panic!("scan error at byte {avail}: {e:?}")
+        }
+    }
+    // One final try with all data
+    limit.set(data.len());
+    decoder
+        .decode_into(&mut out)
+        .expect("should succeed with all data");
+    assert_eq!(out, expected, "pixels must match one-shot (final)");
+}
+
+#[test]
+fn baseline_interleaved_incremental_parity() {
+    assert_incremental_decode_matrix(&[
+        (
+            "synthetic_image",
+            include_bytes!("../../../test-images/jpeg/synthetic_image.jpg"),
+            37
+        ),
+        (
+            "sampling_factors",
+            include_bytes!("../../../test-images/jpeg/sampling_factors.jpg"),
+            29
+        ),
+        (
+            "cymk",
+            include_bytes!("../../../test-images/jpeg/cymk.jpg"),
+            4096
+        )
+    ]);
+}
+
+#[test]
+fn concatenated_four_components_incremental_parity() {
+    assert_incremental_decode_matches_oneshot(
+        "four_components",
+        include_bytes!("../../../test-images/jpeg/four_components.jpg"),
+        4096
+    );
+}
+
+#[test]
+fn baseline_non_interleaved_incremental_parity() {
+    assert_incremental_decode_matrix(&[
+        (
+            "non_interleaved_444_64x64",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg"),
+            17
+        ),
+        (
+            "non_interleaved_420_64x64",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg"),
+            17
+        ),
+        (
+            "non_interleaved_422_64x64",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg"),
+            17
+        ),
+        (
+            "non_interleaved_440_64x64",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg"),
+            17
+        ),
+        (
+            "non_interleaved_422_65x65",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg"),
+            17
+        )
+    ]);
+}
+
+#[test]
+fn progressive_huffman_incremental_parity() {
+    assert_incremental_decode_matrix(&[
+        (
+            "down_sampled_grayscale_prog",
+            include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+            31
+        ),
+        (
+            "kiara_limited_progressive_four_components",
+            include_bytes!(
+                "../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg"
+            ),
+            8192
+        )
+    ]);
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_incremental_parity() {
+    assert_incremental_decode_matrix(&[
+        (
+            "arith_seq",
+            include_bytes!("../../../test-images/jpeg/arith/seq.jpg"),
+            23
+        ),
+        (
+            "arith_prog",
+            include_bytes!("../../../test-images/jpeg/arith/prog.jpg"),
+            23
+        )
+    ]);
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_restart_incremental_parity() {
+    assert_incremental_decode_matrix(&[
+        (
+            "arith_seq_restart",
+            include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg"),
+            23
+        ),
+        (
+            "arith_prog_restart",
+            include_bytes!("../../../test-images/jpeg/arith/prog-restart.jpg"),
+            23
+        )
+    ]);
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_restart_resume_uses_rst_checkpoint() {
+    let data = include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg");
+    let expected = decode_oneshot(data);
+    let limit = Rc::new(Cell::new(874_usize));
+    let seek_log = Rc::new(RefCell::new(Vec::new()));
+    let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    decoder
+        .decode_headers()
+        .expect("headers should be visible before first RST retry");
+    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+    let err = decoder
+        .decode_into(&mut out)
+        .expect_err("truncated scan after first RST should be recoverable");
+    assert!(
+        err.is_recoverable_eof(),
+        "expected recoverable EOF, got {err:?}"
+    );
+
+    seek_log.borrow_mut().clear();
+    limit.set(data.len());
+    decoder
+        .decode_into(&mut out)
+        .expect("full input should resume from RST checkpoint");
+
+    let seeks = seek_log.borrow();
+    assert!(
+        seeks.iter().any(|&position| position == 857),
+        "retry should seek to first RST checkpoint at 857, got {seeks:?}"
+    );
+    assert_pixels_match(&out, &expected, "arith_seq_restart_checkpoint", data.len());
+}
+
 /// Sanity check: byte-by-byte incremental decode of a normal image (no
 /// inline markers) must reproduce the one-shot pixel output. If this test
 /// fails, the bug is in the scan-retry mechanism itself rather than in
 /// the inline-marker path.
 #[test]
-#[ignore = "scan-phase resume not yet implemented: entropy decoder treats EOF as end-of-scan"]
 fn inplace_byte_by_byte_full_decode() {
     let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
     let expected = decode_oneshot(data);
@@ -442,7 +774,6 @@ fn inplace_byte_by_byte_full_decode() {
 ///   4. asserts the final ICC profile is byte-identical (not duplicated)
 ///      and pixels match.
 #[test]
-#[ignore = "scan-phase resume not yet implemented: entropy decoder treats EOF as end-of-scan"]
 fn inline_marker_in_scan_does_not_duplicate_icc() {
     let base = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
     let payload = b"INLINE-ICC-PAYLOAD-FOR-REGRESSION-TEST";


### PR DESCRIPTION
This PR adds the first stage of resumable JPEG decoding support. It makes scan decoding retryable after recoverable EOF by preserving decoder state at scan start and, when restart markers are available, at the latest restart-marker boundary.

The goal of this PR is to support a practical and bounded resumability step without trying to match the full suspension model of libjpeg-turbo in one change.

What This Includes

- Tracks decoder phase across header and scan decoding.
- Allows header parsing and scan decoding to return recoverable EOF and retry on the same decoder after more input arrives.
- Rolls back append-only metadata collected during scan replay, so inline APP/COM marker handling does not duplicate ICC/XMP/gain-map state.
- Captures SOS-related state before scan replay, including component table selections and scan parameters.
- Adds restart-boundary checkpoints that preserve:
  - stream position after RST
  - MCU row/column resume point
  - DC/arithmetic restart state expectations
  - coefficient/sample buffers
  - component state
  - already-written output prefix
- Restores baseline, progressive, and arithmetic scan state from the latest checkpoint when possible.
- Keeps output validity tied to successful completion of `decode_into`; partial output after recoverable EOF remains retry state, not final decoded output.
- Adds integration coverage for incremental decoding across baseline, progressive, and arithmetic JPEGs.


Follow-Up Plan

- Follow-up PR 1: Preserve partial marker parsing state more closely, especially for standard marker payloads.
Avoid reprocessing incomplete marker bodies where libjpeg-turbo would suspend and continue.
Improve parity around APP/COM marker save behavior and input-controller state transitions.
- Follow-up PR 2: Explore preserving entropy decoder and MCU controller state inside restart intervals.
Reduce replay work when EOF happens mid-MCU or mid-restart segment.
Move closer to libjpeg-turbo’s coefficient-controller suspension behavior.

This work is part of #375 