### PR TITLE
JpegDecoder: Add libjpeg-turbo-style scanline output API

### DIFF
--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -34,6 +34,7 @@ use crate::huffman::HuffmanTable;
 use crate::idct::{choose_idct_func, choose_idct_1x1_func, choose_idct_4x4_func};
 use crate::marker::Marker;
 use crate::misc::SOFMarkers;
+use crate::scanline::ScanlineState;
 use crate::upsampler::{
     choose_horizontal_samp_function, choose_hv_samp_function, choose_v_samp_function,
     generic_sampler, upsample_no_op
@@ -232,6 +233,10 @@ pub struct JpegDecoder<T> {
     pub(crate) extended_xmp_segments: Vec<ExtendedXmpSegment>,
     /// Current decoding phase for incremental decoding.
     state: DecodingState,
+    /// Per-call state for the libjpeg-turbo-style scanline output API.
+    /// `None` until `start_decompress` is called; back to `None` after
+    /// `finish_decompress`.
+    pub(crate) scanline_state: Option<ScanlineState>
 }
 
 impl<T> JpegDecoder<T>
@@ -338,6 +343,7 @@ where
             coeff:             1,
             extended_xmp_segments: vec![],
             state:             DecodingState::DecodeHeaders { resume_position: 0 },
+            scanline_state:    None,
         }
     }
     /// Decode a buffer already in memory
@@ -986,6 +992,53 @@ where
         };
     }
 
+    /// Total number of scanlines this image will produce. Returns `None`
+    /// if headers have not been decoded.
+    #[must_use]
+    pub fn output_height(&self) -> Option<usize> {
+        return if self.headers_decoded {
+            Some(usize::from(self.info.height))
+        } else {
+            None
+        };
+    }
+
+    /// Output width in pixels. Returns `None` if headers have not been
+    /// decoded.
+    #[must_use]
+    pub fn output_width(&self) -> Option<usize> {
+        return if self.headers_decoded {
+            Some(usize::from(self.info.width))
+        } else {
+            None
+        };
+    }
+
+    /// Number of components per output pixel after any colorspace
+    /// transform configured in [`DecoderOptions`]. Returns `None` if
+    /// headers have not been decoded.
+    #[must_use]
+    pub fn output_components(&self) -> Option<usize> {
+        return if self.headers_decoded {
+            Some(self.options.jpeg_get_out_colorspace().num_components())
+        } else {
+            None
+        };
+    }
+
+    /// Bytes per output scanline = `output_width * output_components`.
+    /// Returns `None` if headers have not been decoded or the value
+    /// would overflow `usize`.
+    #[must_use]
+    pub fn output_row_stride(&self) -> Option<usize> {
+        return if self.headers_decoded {
+            usize::from(self.info.width)
+                .checked_mul(self.options.jpeg_get_out_colorspace().num_components())
+        } else {
+            None
+        };
+    }
+
     /// Decode into a pre-allocated buffer
     ///
     /// It is an error if the buffer size is smaller than
@@ -1082,7 +1135,135 @@ where
         Ok(())
     }
 
+    /// Begin scanline-by-scanline decompression.
+    ///
+    /// This is the libjpeg-turbo-style entry point for streaming output:
+    /// after calling [`decode_headers`](Self::decode_headers) the caller
+    /// invokes `start_decompress` once, then drives output with repeated
+    /// calls to [`read_scanlines`](Self::read_scanlines) until
+    /// [`next_scanline`](Self::next_scanline) reaches
+    /// [`output_height`](Self::output_height), then calls
+    /// [`finish_decompress`](Self::finish_decompress).
+    ///
+    /// # Errors
+    /// - If `decode_headers` has not yet been called, this method will
+    ///   call it; any error from header parsing propagates.
+    /// - Returns an error if `start_decompress` was already called and
+    ///   `finish_decompress` has not yet been invoked.
+    /// - If the input is truncated and the underlying decode returns a
+    ///   recoverable EOF, that error propagates and no scanline state is
+    ///   installed; the caller may supply more input and call
+    ///   `start_decompress` again on the same decoder.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let img = std::fs::read("a.jpg").unwrap();
+    /// let mut dec = JpegDecoder::new(ZCursor::new(&img));
+    /// dec.decode_headers().unwrap();
+    /// dec.start_decompress().unwrap();
+    ///
+    /// let row_stride = dec.output_row_stride().unwrap();
+    /// let height = dec.output_height().unwrap();
+    /// let mut row = vec![0_u8; row_stride];
+    /// while dec.next_scanline() < height {
+    ///     dec.read_scanlines(&mut row, 1).unwrap();
+    ///     // emit `row` somewhere
+    /// }
+    /// dec.finish_decompress().unwrap();
+    /// ```
+    pub fn start_decompress(&mut self) -> Result<(), DecodeErrors> {
+        if self.scanline_state.is_some() {
+            return Err(DecodeErrors::FormatStatic(
+                "start_decompress called twice without finish_decompress"
+            ));
+        }
 
+        let pre_decoded = self.decode()?;
+
+        let out_width = usize::from(self.info.width);
+        let out_height = usize::from(self.info.height);
+        let out_components = self.options.jpeg_get_out_colorspace().num_components();
+        let row_stride = out_width
+            .checked_mul(out_components)
+            .ok_or(DecodeErrors::FormatStatic("Output row stride overflow"))?;
+
+        self.scanline_state = Some(ScanlineState {
+            next_scanline: 0,
+            out_height,
+            row_stride,
+            pre_decoded
+        });
+        Ok(())
+    }
+
+    /// Read up to `num_lines` scanlines into `buf`.
+    ///
+    /// The return value is the number of scanlines actually written, which
+    /// may be less than `num_lines` if the image has fewer remaining rows.
+    /// Once the image is exhausted subsequent calls return `Ok(0)`.
+    ///
+    /// `buf` need only be large enough to hold the lines that will actually
+    /// be written on this call (i.e. at least
+    /// `min(num_lines, output_height() - next_scanline()) * output_row_stride()`
+    /// bytes). Passing a larger `num_lines` than rows remaining is not an
+    /// error — this matches libjpeg-turbo's `jpeg_read_scanlines`, which
+    /// documents an oversize `max_lines` as legal.
+    ///
+    /// # Errors
+    /// - Returns an error if `start_decompress` has not been called.
+    /// - Returns [`DecodeErrors::TooSmallOutput`] if `buf` is too short to
+    ///   hold the lines that would be written.
+    pub fn read_scanlines(
+        &mut self, buf: &mut [u8], num_lines: usize
+    ) -> Result<usize, DecodeErrors> {
+        let state = self.scanline_state.as_mut().ok_or(
+            DecodeErrors::FormatStatic("read_scanlines called before start_decompress")
+        )?;
+
+        if num_lines == 0 {
+            return Ok(0);
+        }
+
+        let take = (state.out_height - state.next_scanline).min(num_lines);
+        if take == 0 {
+            return Ok(0);
+        }
+
+        // take <= out_height; out_height * row_stride == pre_decoded.len(), so no overflow.
+        let bytes = take * state.row_stride;
+        if buf.len() < bytes {
+            return Err(DecodeErrors::TooSmallOutput(bytes, buf.len()));
+        }
+
+        let src = state.next_scanline * state.row_stride;
+        buf[..bytes].copy_from_slice(&state.pre_decoded[src..src + bytes]);
+        state.next_scanline += take;
+        Ok(take)
+    }
+
+    /// Finalize scanline decoding and free associated resources.
+    ///
+    /// Mirrors libjpeg-turbo's `jpeg_finish_decompress`. Tolerates being
+    /// called when `start_decompress` was never called or when
+    /// `finish_decompress` has already been invoked; both cases are
+    /// no-ops that return `Ok(())`.
+    pub fn finish_decompress(&mut self) -> Result<(), DecodeErrors> {
+        self.scanline_state = None;
+        Ok(())
+    }
+
+    /// Index of the next scanline that will be returned by
+    /// [`read_scanlines`](Self::read_scanlines).
+    ///
+    /// Mirrors libjpeg's `cinfo.output_scanline`. Returns 0 before
+    /// `start_decompress` is called.
+    #[must_use]
+    pub fn next_scanline(&self) -> usize {
+        self.scanline_state.as_ref().map_or(0, |s| s.next_scanline)
+    }
 
     /// Create a new decoder with the specified options to be used for decoding
     /// an image

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -188,6 +188,7 @@ mod marker;
 mod mcu;
 mod mcu_prog;
 mod misc;
+mod scanline;
 mod unsafe_utils;
 mod unsafe_utils_avx2;
 mod unsafe_utils_neon;

--- a/crates/zune-jpeg/src/scanline.rs
+++ b/crates/zune-jpeg/src/scanline.rs
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+//! Scanline-by-scanline output API, modelled on libjpeg-turbo's
+//! `jpeg_start_decompress` / `jpeg_read_scanlines` / `jpeg_finish_decompress`.
+
+use alloc::vec::Vec;
+
+/// Per-call state for the scanline output API.
+///
+/// Stored on `JpegDecoder` as `Option<ScanlineState>` and populated
+/// by `start_decompress`. Cleared by `finish_decompress`.
+pub(crate) struct ScanlineState {
+    /// Index of the next scanline that will be returned to the caller
+    /// (mirrors libjpeg's `cinfo.output_scanline`).
+    pub(crate) next_scanline: usize,
+
+    /// Total scanlines this image will produce.
+    pub(crate) out_height: usize,
+
+    /// Bytes per output scanline = `output_width * output_components`.
+    pub(crate) row_stride: usize,
+
+    /// The fully-decoded image. Scanlines are sliced out of this on each
+    /// `read_scanlines` call.
+    pub(crate) pre_decoded: Vec<u8>
+}

--- a/crates/zune-jpeg/tests/scanlines.rs
+++ b/crates/zune-jpeg/tests/scanlines.rs
@@ -142,7 +142,8 @@ fn scanlines_baseline_luma_output_from_color() {
 
 #[test]
 fn scanlines_progressive_420() {
-    let data = include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
+    let data =
+        include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
     let opts = DecoderOptions::default();
     assert_matches_one_shot(data, opts, 1);
     assert_matches_one_shot(data, opts, 8);
@@ -205,7 +206,9 @@ fn scanlines_read_past_end_returns_zero() {
     let mut out = vec![0_u8; row_stride * height];
     let mut total = 0;
     while dec.next_scanline() < height {
-        let n = dec.read_scanlines(&mut out[total * row_stride..], 1).unwrap();
+        let n = dec
+            .read_scanlines(&mut out[total * row_stride..], 1)
+            .unwrap();
         if n == 0 {
             break;
         }
@@ -277,3 +280,26 @@ fn scanlines_oversize_num_lines_ok() {
     assert_eq!(dec.read_scanlines(&mut tmp, usize::MAX).unwrap(), 0);
 }
 
+#[test]
+fn scanlines_partial_mcu_height() {
+    // 65x65: height is not a multiple of an MCU row. Exercises the
+    // last-partial-row path that the streaming follow-up will care
+    // about. Match against decode() so we pin both halves.
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 8);
+    assert_matches_one_shot(data, opts, 65);
+}
+
+#[test]
+fn scanlines_baseline_with_restart_markers() {
+    // four_components.jpg is baseline with a non-zero DRI: the scan is
+    // broken up by RST markers. Pin byte-for-byte equivalence with
+    // decode() so the streaming follow-up has a regression net for the
+    // restart path.
+    let data = include_bytes!("../../../test-images/jpeg/four_components.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 16);
+}

--- a/crates/zune-jpeg/tests/scanlines.rs
+++ b/crates/zune-jpeg/tests/scanlines.rs
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+//! Tests for the libjpeg-turbo-style scanline output API
+//! (`start_decompress` / `read_scanlines` / `finish_decompress`).
+//!
+//! Every test decodes the same image twice — once via the one-shot
+//! `decode_into` and once via the scanline API — and checks the byte
+//! streams match. That covers the various subsampling, output-colorspace,
+//! progressive, and restart-interval permutations without us having to
+//! hand-bake reference pixels.
+
+use zune_core::bytestream::ZCursor;
+use zune_core::colorspace::ColorSpace;
+use zune_core::options::DecoderOptions;
+use zune_jpeg::JpegDecoder;
+
+/// Decode `data` via the scanline API with the given options, pulling
+/// `chunk` scanlines per call. Returns the assembled buffer and the
+/// number of scanlines actually written (which should equal output_height).
+fn decode_via_scanlines(data: &[u8], options: DecoderOptions, chunk: usize) -> (Vec<u8>, usize) {
+    let mut dec = JpegDecoder::new_with_options(ZCursor::new(data), options);
+    dec.decode_headers().unwrap();
+    dec.start_decompress().unwrap();
+
+    let row_stride = dec.output_row_stride().unwrap();
+    let height = dec.output_height().unwrap();
+
+    let mut out = vec![0_u8; row_stride * height];
+    let mut total = 0;
+    while dec.next_scanline() < height {
+        let buf = &mut out[total * row_stride..];
+        let want = chunk.min(height - total);
+        let got = dec.read_scanlines(buf, want).unwrap();
+        if got == 0 {
+            break;
+        }
+        total += got;
+    }
+    dec.finish_decompress().unwrap();
+    (out, total)
+}
+
+fn decode_one_shot(data: &[u8], options: DecoderOptions) -> Vec<u8> {
+    let mut dec = JpegDecoder::new_with_options(ZCursor::new(data), options);
+    dec.decode().unwrap()
+}
+
+fn assert_matches_one_shot(data: &[u8], options: DecoderOptions, chunk: usize) {
+    let baseline = decode_one_shot(data, options);
+    let (scanlines, total) = decode_via_scanlines(data, options, chunk);
+    let height = {
+        let mut dec = JpegDecoder::new_with_options(ZCursor::new(data), options);
+        dec.decode_headers().unwrap();
+        dec.output_height().unwrap()
+    };
+    assert_eq!(total, height, "scanline count mismatch (chunk={chunk})");
+    assert_eq!(
+        scanlines.len(),
+        baseline.len(),
+        "buffer size mismatch (chunk={chunk})"
+    );
+    if scanlines != baseline {
+        let mismatched = scanlines
+            .iter()
+            .zip(baseline.iter())
+            .position(|(a, b)| a != b);
+        panic!(
+            "scanline output diverges from one-shot decode at byte {:?} (chunk={chunk})",
+            mismatched
+        );
+    }
+}
+
+#[test]
+fn scanlines_baseline_420_default_rgb() {
+    let data = include_bytes!("../../../test-images/jpeg/medium_no_samp_2500x1786.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 8);
+    assert_matches_one_shot(data, opts, 16);
+    assert_matches_one_shot(data, opts, usize::MAX / 2);
+}
+
+#[test]
+fn scanlines_baseline_444() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 7);
+    assert_matches_one_shot(data, opts, 64);
+}
+
+#[test]
+fn scanlines_baseline_422() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 16);
+}
+
+#[test]
+fn scanlines_baseline_horiz_sampled() {
+    let data = include_bytes!("../../../test-images/jpeg/medium_horiz_samp_2500x1786.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 17);
+}
+
+#[test]
+fn scanlines_baseline_vertical_sampled() {
+    // Vertical sampling exercises the post_process path that holds over
+    // the last row of an MCU for the next call's upsample.
+    let data = include_bytes!("../../../test-images/jpeg/medium_vertical_samp_2500x1786.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 16);
+    assert_matches_one_shot(data, opts, 64);
+}
+
+#[test]
+fn scanlines_baseline_rgba_output() {
+    let data = include_bytes!("../../../test-images/jpeg/medium_no_samp_2500x1786.jpg");
+    let opts = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::RGBA);
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 64);
+}
+
+#[test]
+fn scanlines_baseline_luma_output_from_color() {
+    // YCbCr -> Luma exercises the coeff=2 path.
+    let data = include_bytes!("../../../test-images/jpeg/medium_vertical_samp_2500x1786.jpg");
+    let opts = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::Luma);
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 32);
+}
+
+#[test]
+fn scanlines_progressive_420() {
+    let data = include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 8);
+    assert_matches_one_shot(data, opts, 100);
+}
+
+#[test]
+fn scanlines_progressive_grayscale() {
+    let data = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 8);
+}
+
+#[test]
+fn scanlines_multi_sos_baseline() {
+    // sos_news.jpeg interleaves SOS markers with MCU data — historically a
+    // tricky case for streaming. Pin its byte-for-byte output here so it
+    // stays covered when later PRs swap in per-MCU-row decoding.
+    let data = include_bytes!("../../../test-images/jpeg/sos_news.jpeg");
+    let opts = DecoderOptions::default();
+    assert_matches_one_shot(data, opts, 1);
+    assert_matches_one_shot(data, opts, 32);
+}
+
+#[test]
+fn scanlines_zero_lines_is_noop() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let mut dec = JpegDecoder::new(ZCursor::new(data));
+    dec.decode_headers().unwrap();
+    dec.start_decompress().unwrap();
+    let n = dec.read_scanlines(&mut [], 0).unwrap();
+    assert_eq!(n, 0);
+    assert_eq!(dec.next_scanline(), 0);
+}
+
+#[test]
+fn scanlines_short_buffer_errors() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let mut dec = JpegDecoder::new(ZCursor::new(data));
+    dec.decode_headers().unwrap();
+    dec.start_decompress().unwrap();
+    let row_stride = dec.output_row_stride().unwrap();
+    // Ask for 4 lines but only supply room for 2.
+    let mut buf = vec![0_u8; row_stride * 2];
+    let err = dec.read_scanlines(&mut buf, 4);
+    assert!(err.is_err(), "short buffer should produce an error");
+}
+
+#[test]
+fn scanlines_read_past_end_returns_zero() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let mut dec = JpegDecoder::new(ZCursor::new(data));
+    dec.decode_headers().unwrap();
+    dec.start_decompress().unwrap();
+    let row_stride = dec.output_row_stride().unwrap();
+    let height = dec.output_height().unwrap();
+
+    // Drain the whole image.
+    let mut out = vec![0_u8; row_stride * height];
+    let mut total = 0;
+    while dec.next_scanline() < height {
+        let n = dec.read_scanlines(&mut out[total * row_stride..], 1).unwrap();
+        if n == 0 {
+            break;
+        }
+        total += n;
+    }
+    assert_eq!(total, height);
+
+    // Subsequent reads should return 0, never error.
+    let mut tmp = vec![0_u8; row_stride];
+    assert_eq!(dec.read_scanlines(&mut tmp, 1).unwrap(), 0);
+}
+
+#[test]
+fn scanlines_double_start_errors() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let mut dec = JpegDecoder::new(ZCursor::new(data));
+    dec.decode_headers().unwrap();
+    dec.start_decompress().unwrap();
+    assert!(
+        dec.start_decompress().is_err(),
+        "second start_decompress without finish must error"
+    );
+    dec.finish_decompress().unwrap();
+}
+
+#[test]
+fn scanlines_finish_decompress_idempotent() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let mut dec = JpegDecoder::new(ZCursor::new(data));
+    dec.decode_headers().unwrap();
+    dec.start_decompress().unwrap();
+    dec.finish_decompress().unwrap();
+    // A second finish without an intervening start should also be a no-op.
+    dec.finish_decompress().unwrap();
+}
+
+#[test]
+fn scanlines_read_before_start_errors() {
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let mut dec = JpegDecoder::new(ZCursor::new(data));
+    dec.decode_headers().unwrap();
+    let mut buf = vec![0_u8; 64 * 3];
+    // No start_decompress yet — every form of read_scanlines must error,
+    // including the num_lines == 0 case (precondition is checked first).
+    assert!(dec.read_scanlines(&mut buf, 1).is_err());
+    assert!(dec.read_scanlines(&mut buf, 0).is_err());
+    assert!(dec.read_scanlines(&mut [], 0).is_err());
+}
+
+#[test]
+fn scanlines_oversize_num_lines_ok() {
+    // libjpeg-turbo documents that an oversize max_lines is not an error;
+    // the call should just cap to whatever is left. Verify that here with
+    // a buffer sized only for the actual remaining rows.
+    let data = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let mut dec = JpegDecoder::new(ZCursor::new(data));
+    dec.decode_headers().unwrap();
+    dec.start_decompress().unwrap();
+    let row_stride = dec.output_row_stride().unwrap();
+    let height = dec.output_height().unwrap();
+
+    // Buffer is exactly height rows — passing usize::MAX as num_lines
+    // must succeed and write `height` rows.
+    let mut buf = vec![0_u8; row_stride * height];
+    let n = dec.read_scanlines(&mut buf, usize::MAX).unwrap();
+    assert_eq!(n, height);
+    // Past the end, oversize num_lines stays a no-op rather than erroring.
+    let mut tmp = [0_u8; 0];
+    assert_eq!(dec.read_scanlines(&mut tmp, usize::MAX).unwrap(), 0);
+}
+


### PR DESCRIPTION
Hello, I'm tracking an issue with large images in Gnome Nautilus (https://github.com/image-rs/image/issues/1989).

The code path is Nautilus -> glycin -> image-rs -> zune-image

In order to reduce memory use (and do high-performance scaling) I would like if zune-image returned one scanline at a time.

This PR adds a libjpeg-turbo-style scanline output API to `JpegDecoder`. It mirrors `jpeg_start_decompress` / `jpeg_read_scanlines` / `jpeg_finish_decompress`, giving callers a row-at-a-time output.

This is a first stage to explore the API. The first cut runs `decode()` at `start_decompress` and serves rows from the resulting buffer. The public contract matches a true streaming implementation, so a follow-up can swap in per-MCU-row decoding for the streamable cases (single-SOS baseline, progressive post-process) without changing the API or breaking callers.

What This Includes

- `start_decompress()`
- `read_scanlines(buf, num_lines) -> Result<usize>` (returns rows written)
- `finish_decompress()`
- `next_scanline()` (mirrors libjpeg's `cinfo.output_scanline`)
- New header-gated accessors returning `Option<usize>`, matching the existing `output_buffer_size` style:
  - `output_height` / `output_width` / `output_components` / `output_row_stride`
- libjpeg-turbo-compatible `read_scanlines` semantics:
  - oversize `num_lines` is capped to rows remaining (not an error)
  - reads past end return `Ok(0)`
  - the `start_decompress` precondition is checked before the `num_lines == 0` short-circuit, so the error is consistent regardless of buffer size
- New `crates/zune-jpeg/src/scanline.rs` carrying the per-call `ScanlineState`, populated by `start_decompress` and cleared by `finish_decompress`.

Tests

`crates/zune-jpeg/tests/scanlines.rs` cross-checks the scanline API against `decode()` across:
- common subsampling (4:2:0, 4:2:2, 4:4:4, horizontally-sampled, vertically-sampled, partial-MCU height)
- progressive (grayscale, 4:2:0)
- output-colorspace permutations (RGBA, luma-from-color, default RGB)
- multi-SOS baseline and baseline with restart markers (DRI)
- error and edge paths (`read_scanlines` before `start_decompress`, double `start_decompress`, oversize `num_lines`, zero-line read, short buffer, idempotent
`finish_decompress`, read-past-end returns `Ok(0)`)

Possible Follow-up

- Switch the streamable cases (single-SOS baseline, progressive post-process) to per-MCU-row decoding so `start_decompress` no longer materialises the full image.
- The multi-SOS interleaved baseline edge case (one component per scan) requires all components before post-processing and would stay decode-then-slice in the streaming follow-up.
