### PR TITLE
JpegDecoder: Complete baseline incremental checkpoint coverage

### DIFF
--- a/crates/zune-jpeg/README.md
+++ b/crates/zune-jpeg/README.md
@@ -47,6 +47,11 @@ caller expects input to arrive incrementally; this records checkpoints during
 the first baseline Huffman scan attempt and can reduce replay work on the next
 retry.
 
+Fine-grained row checkpoints currently apply within baseline Huffman scan
+bodies, including baseline multi-SOS / non-interleaved images. Those images may
+still report no stable output rows until the later component scans have been
+decoded and final assembly has run.
+
 ```Rust
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::JpegDecoder;

--- a/crates/zune-jpeg/README.md
+++ b/crates/zune-jpeg/README.md
@@ -52,6 +52,13 @@ bodies, including baseline multi-SOS / non-interleaved images. Those images may
 still report no stable output rows until the later component scans have been
 decoded and final assembly has run.
 
+Scan checkpoints store only scalar resume state: stream position, next MCU
+row/column, restart countdown, SOS parameters, DC predictors, and bitstream
+state. Coefficients for already-decoded component scans stay on the decoder
+across retries. For multi-SOS images this means a retry can continue inside the
+current component scan, then decode later component scans, but output rows are
+not considered stable until final assembly has all component data.
+
 ```Rust
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::JpegDecoder;

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -79,7 +79,7 @@ pub type IDCTPtr = fn(&mut [i32; 64], &mut [i16], usize);
 
 /// Scan-phase state kept so `decode_into` can retry or replay after SOS.
 ///
-/// Full replay starts at the first SOS; `rst_checkpoint` can resume from a
+/// Full replay starts at the first SOS; `scan_checkpoint` can resume from a
 /// later restart or row boundary when one is still valid.
 #[derive(Clone)]
 pub(crate) struct ScanDecodeState {
@@ -87,7 +87,7 @@ pub(crate) struct ScanDecodeState {
     pub(crate) append_snapshot:     HeaderAppendStateSnapshot,
     pub(crate) sos_snapshot:        SosParamsSnapshot,
     pub(crate) header_snapshot:     ScanHeaderStateSnapshot,
-    pub(crate) rst_checkpoint:      Option<Box<ScanCheckpoint>>
+    pub(crate) scan_checkpoint:     Option<Box<ScanCheckpoint>>
 }
 
 /// SOS fields restored before replaying scan data.
@@ -402,7 +402,7 @@ where
             append_snapshot,
             sos_snapshot,
             header_snapshot,
-            rst_checkpoint: None
+            scan_checkpoint: None
         }));
         Ok(())
     }
@@ -410,7 +410,7 @@ where
     pub(crate) fn scan_checkpoint(&self) -> Option<&ScanCheckpoint> {
         self.scan_state
             .as_deref()
-            .and_then(|state| state.rst_checkpoint.as_deref())
+            .and_then(|state| state.scan_checkpoint.as_deref())
     }
 
     // Save a scan checkpoint at the current restart or MCU-row boundary.
@@ -456,9 +456,9 @@ where
                 dc_predictions,
                 bitstream_state
             };
-            match &mut state.rst_checkpoint {
+            match &mut state.scan_checkpoint {
                 Some(existing) => **existing = snapshot,
-                None => state.rst_checkpoint = Some(Box::new(snapshot))
+                None => state.scan_checkpoint = Some(Box::new(snapshot))
             }
         }
         Ok(())
@@ -476,7 +476,7 @@ where
     /// replaying from scan start.
     pub(crate) fn invalidate_scan_checkpoint(&mut self) {
         if let Some(state) = self.scan_state.as_mut() {
-            state.rst_checkpoint = None;
+            state.scan_checkpoint = None;
         }
     }
 
@@ -1339,7 +1339,7 @@ where
             outer_append_snapshot: state.append_snapshot,
             outer_sos_snapshot:    state.sos_snapshot,
             outer_header_snapshot: state.header_snapshot.clone(),
-            checkpoint_view:       state.rst_checkpoint.as_deref().map(|checkpoint| {
+            checkpoint_view:       state.scan_checkpoint.as_deref().map(|checkpoint| {
                 CheckpointView {
                     append_snapshot: checkpoint.append_snapshot,
                     sos_snapshot:    checkpoint.sos_snapshot,
@@ -1461,7 +1461,7 @@ where
 
         match result {
             Ok(()) => {
-                // Drop the RST checkpoint so a post-success replay starts
+                // Drop the scan checkpoint so a post-success replay starts
                 // from scan-start with zeroed DC predictors instead of
                 // pointing at stale entropy data.
                 debug_assert!(
@@ -1469,7 +1469,7 @@ where
                     "scan_state should be Some after a successful scan decode"
                 );
                 if let Some(state) = self.scan_state.as_deref_mut() {
-                    state.rst_checkpoint = None;
+                    state.scan_checkpoint = None;
                 }
                 self.pixels_decoded = expected_size;
                 Ok(())

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -80,7 +80,7 @@ pub type IDCTPtr = fn(&mut [i32; 64], &mut [i16], usize);
 /// Scan-phase state kept so `decode_into` can retry or replay after SOS.
 ///
 /// Full replay starts at the first SOS; `rst_checkpoint` can resume from a
-/// later restart boundary when one is still valid.
+/// later restart or row boundary when one is still valid.
 #[derive(Clone)]
 pub(crate) struct ScanDecodeState {
     pub(crate) scan_start_position: usize,
@@ -117,7 +117,7 @@ pub(crate) struct ScanHeaderStateSnapshot {
     pub(crate) is_mjpeg:         bool
 }
 
-/// Saved state at a restart-interval boundary during scan decoding.
+/// Saved state at a restart-interval or MCU-row boundary during scan decoding.
 ///
 /// Coefficient buffers stay on `JpegDecoder`; the checkpoint only stores the
 /// bitstream position, output position, scan state, and DC predictors.
@@ -155,7 +155,7 @@ pub(crate) struct HeaderAppendStateSnapshot {
 }
 
 impl HeaderAppendStateSnapshot {
-    fn capture<T: ZByteReaderTrait>(decoder: &JpegDecoder<T>) -> Self {
+    pub(crate) fn capture<T: ZByteReaderTrait>(decoder: &JpegDecoder<T>) -> Self {
         Self {
             icc:  decoder.icc_data.len(),
             xmp:  decoder.extended_xmp_segments.len(),
@@ -163,7 +163,7 @@ impl HeaderAppendStateSnapshot {
         }
     }
 
-    fn rollback<T: ZByteReaderTrait>(self, decoder: &mut JpegDecoder<T>) {
+    pub(crate) fn rollback<T: ZByteReaderTrait>(self, decoder: &mut JpegDecoder<T>) {
         decoder.icc_data.truncate(self.icc);
         decoder.extended_xmp_segments.truncate(self.xmp);
         decoder.info.gain_map_info.truncate(self.gain);
@@ -374,7 +374,7 @@ where
         }
     }
 
-    fn capture_scan_header_state(&self) -> ScanHeaderStateSnapshot {
+    pub(crate) fn capture_scan_header_state(&self) -> ScanHeaderStateSnapshot {
         ScanHeaderStateSnapshot {
             qt_tables:        self.qt_tables,
             entropy_tables:   self.entropy_tables.clone(),
@@ -384,7 +384,7 @@ where
         }
     }
 
-    fn restore_scan_header_state(&mut self, snapshot: &ScanHeaderStateSnapshot) {
+    pub(crate) fn restore_scan_header_state(&mut self, snapshot: &ScanHeaderStateSnapshot) {
         self.qt_tables = snapshot.qt_tables;
         self.entropy_tables = snapshot.entropy_tables.clone();
         self.restart_interval = snapshot.restart_interval;
@@ -413,8 +413,8 @@ where
             .and_then(|state| state.rst_checkpoint.as_deref())
     }
 
-    // Save a restart-boundary checkpoint at the most recently consumed RST
-    // marker. Allocation-free: this only writes `Copy` scalars and fixed-size
+    // Save a scan checkpoint at the current restart or MCU-row boundary.
+    // Allocation-free: this only writes `Copy` scalars and fixed-size
     // arrays into the existing `Box<ScanCheckpoint>` (or allocates the box
     // exactly once at the first RST in a scan). The decoded coefficient and
     // component buffers themselves are *not* copied here — they live on the
@@ -464,14 +464,16 @@ where
         Ok(())
     }
 
-    /// Drop the active RST checkpoint, if any.
+    /// Drop the active scan checkpoint, if any.
     ///
     /// Called from the single-SOS baseline path after each row's
-    /// `post_process` succeeds. The next iteration of the outer loop will
-    /// overwrite `Components::raw_coeff`, so any checkpoint that pointed at
-    /// the just-processed row is no longer safe to resume to. New checkpoints
-    /// get recorded as RSTs fire in the next row; if EOF happens before the
-    /// next row's first RST, the scan falls back to replaying from scan start.
+    /// `post_process` succeeds, and after a later SOS is fully parsed in the
+    /// multi-SOS path (`advance_to_next_sos`). In the single-SOS case the next
+    /// iteration of the outer loop will overwrite `Components::raw_coeff`, so
+    /// any checkpoint that pointed at the just-processed row is no longer safe
+    /// to resume to. New checkpoints get recorded as RSTs fire in the next row;
+    /// if EOF happens before the next row's first RST, the scan falls back to
+    /// replaying from scan start.
     pub(crate) fn invalidate_scan_checkpoint(&mut self) {
         if let Some(state) = self.scan_state.as_mut() {
             state.rst_checkpoint = None;

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -57,6 +57,11 @@
 //! the first baseline Huffman scan attempt and can reduce replay work on the next
 //! retry.
 //!
+//! Fine-grained row checkpoints currently apply within baseline Huffman scan
+//! bodies, including baseline multi-SOS / non-interleaved images. Those images may
+//! still report no stable output rows until the later component scans have been
+//! decoded and final assembly has run.
+//!
 //! ```no_run
 //! use zune_core::bytestream::ZCursor;
 //! use zune_jpeg::errors::DecodeErrors;

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -62,6 +62,13 @@
 //! still report no stable output rows until the later component scans have been
 //! decoded and final assembly has run.
 //!
+//! Scan checkpoints store only scalar resume state: stream position, next MCU
+//! row/column, restart countdown, SOS parameters, DC predictors, and bitstream
+//! state. Coefficients for already-decoded component scans stay on the decoder
+//! across retries. For multi-SOS images this means a retry can continue inside the
+//! current component scan, then decode later component scans, but output rows are
+//! not considered stable until final assembly has all component data.
+//!
 //! ```no_run
 //! use zune_core::bytestream::ZCursor;
 //! use zune_jpeg::errors::DecodeErrors;

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -17,7 +17,7 @@ use zune_core::log::{error, trace, warn};
 
 use crate::bitstream::BitStream;
 use crate::components::SampleRatios;
-use crate::decoder::MAX_COMPONENTS;
+use crate::decoder::{HeaderAppendStateSnapshot, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
 use crate::marker::Marker;
 use crate::mcu_prog::get_marker;
@@ -245,8 +245,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
             trace!("Decoding MCU width: {mcu_width}, height: {mcu_height}");
 
-            for i in resume_row..mcu_height {
-                let start_col = if i == resume_row { resume_col } else { 0 };
+            // Consume the resume position once into locals so later SOS scans
+            // start at row 0, and so we don't mutate the loop's range bound
+            // from inside the loop below.
+            let current_resume_row = resume_row;
+            let current_resume_col = resume_col;
+            resume_row = 0;
+            resume_col = 0;
+
+            for i in current_resume_row..mcu_height {
+                let start_col = if i == current_resume_row {
+                    current_resume_col
+                } else {
+                    0
+                };
                 if stream.overread_by() > 0 {
                     // The bitstream reader has exhausted available data.
                     // Return a recoverable error so the caller can feed more
@@ -261,11 +273,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // caller explicitly opted into incremental mode. Default
                 // one-shot decode keeps this disabled.
                 //
-                // Only for single-SOS baseline (all_components_in_first_scan):
-                // multi-SOS scans can't safely resume mid-scan because later
-                // SOS passes may overwrite coefficient bands.
+                // Multi-SOS baseline scans keep their full-image coefficient
+                // buffers on the decoder across retries, so row checkpoints
+                // are safe there too. They still report no stable output
+                // until final assembly has all component scans.
                 if self.mcu_checkpoints_enabled
-                    && all_components_in_first_scan
                     && !self.is_progressive
                     && B::supports_mcu_checkpoint()
                 {
@@ -373,8 +385,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         break;
                     }
                     Ok(Marker::SOS) => {
-                        self.invalidate_scan_checkpoint();
                         self.parse_marker_inner(Marker::SOS)?;
+                        self.invalidate_scan_checkpoint();
                         stream.reset();
                         B::reset_arith_tables(&mut self.entropy_tables);
                         continue 'sos;
@@ -795,8 +807,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // A latched RST means the entropy segment is already exhausted.
                 self.handle_rst(stream)?;
             } else if let Marker::SOS = m {
-                self.invalidate_scan_checkpoint();
                 self.parse_marker_inner(Marker::SOS)?;
+                self.invalidate_scan_checkpoint();
                 stream.marker().take();
                 stream.reset();
                 B::reset_arith_tables(&mut self.entropy_tables);
@@ -852,23 +864,47 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // Limit iterations to prevent DoS from malicious files.
         const MAX_INTER_SCAN_MARKERS: usize = 64;
 
-        // Once we leave the entropy segment, any RST checkpoint inside that
-        // segment is no longer safe: inter-scan setup markers may redefine
-        // DHT/DQT/DRI/DAC state before the next SOS. Falling back to the
-        // first-SOS replay path restores the scan-start snapshot instead.
-        self.invalidate_scan_checkpoint();
+        let inter_scan_snapshot = if self.scan_checkpoint().is_some() {
+            Some((
+                HeaderAppendStateSnapshot::capture(self),
+                self.capture_scan_header_state(),
+            ))
+        } else {
+            None
+        };
+
+        // Keep the previous scan checkpoint valid until the next SOS is fully
+        // parsed. If input ends between scans, rollback marker side effects so
+        // the retry can resume from that checkpoint and parse the markers again.
+        macro_rules! restore_inter_scan_on_eof {
+            ($result:expr) => {
+                match $result {
+                    Ok(value) => value,
+                    Err(e) => {
+                        if e.is_recoverable_eof() {
+                            if let Some((append_snapshot, header_snapshot)) = &inter_scan_snapshot {
+                                append_snapshot.rollback(self);
+                                self.restore_scan_header_state(header_snapshot);
+                            }
+                        }
+                        return Err(e);
+                    }
+                }
+            };
+        }
 
         // Parse the first marker that triggered this call
-        self.parse_marker_inner(first_marker)?;
+        restore_inter_scan_on_eof!(self.parse_marker_inner(first_marker));
         stream.reset();
         B::reset_arith_tables(&mut self.entropy_tables);
 
         for _ in 0..MAX_INTER_SCAN_MARKERS {
-            let marker = get_marker(&mut self.stream, stream)?;
+            let marker = restore_inter_scan_on_eof!(get_marker(&mut self.stream, stream));
 
             match marker {
                 Marker::SOS => {
-                    self.parse_marker_inner(Marker::SOS)?;
+                    restore_inter_scan_on_eof!(self.parse_marker_inner(Marker::SOS));
+                    self.invalidate_scan_checkpoint();
                     stream.reset();
                     B::reset_arith_tables(&mut self.entropy_tables);
                     trace!("Found SOS marker, continuing decode");
@@ -881,11 +917,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 }
                 Marker::DAC | Marker::DHT | Marker::DQT | Marker::DRI | Marker::COM => {
                     trace!("Parsing inter-scan marker {marker:?}");
-                    self.parse_marker_inner(marker)?;
+                    restore_inter_scan_on_eof!(self.parse_marker_inner(marker));
                 }
                 Marker::APP(_) => {
                     trace!("Parsing inter-scan APP marker {marker:?}");
-                    self.parse_marker_inner(marker)?;
+                    restore_inter_scan_on_eof!(self.parse_marker_inner(marker));
                 }
                 other => {
                     if self.options.strict_mode() {
@@ -895,9 +931,15 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     }
                     // Non-strict: skip unknown marker
                     warn!("Skipping unexpected marker {other:?} between scans");
-                    let length = self.stream.get_u16_be_err()?;
+                    let length = restore_inter_scan_on_eof!(
+                        self.stream.get_u16_be_err().map_err(DecodeErrors::IoErrors)
+                    );
                     if length >= 2 {
-                        self.stream.skip((length - 2) as usize)?;
+                        restore_inter_scan_on_eof!(
+                            self.stream
+                                .skip((length - 2) as usize)
+                                .map_err(DecodeErrors::IoErrors)
+                        );
                     }
                 }
             }

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -67,7 +67,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // Move the persistent multi-SOS coefficient buffer out of `self` so
         // the inner decoder can borrow it mutably while still calling methods
         // on `self`. The buffer is put back on return and survives across
-        // `decode_into` retries, which is what lets per-RST checkpoints stay
+        // `decode_into` retries, which is what lets scan checkpoints stay
         // allocation-free.
         let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
         let result = self.decode_mcu_ycbcr_baseline_inner::<B>(pixels, &mut progressive_mcus);
@@ -147,7 +147,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut tmp = [0_i32; DCT_BLOCK];
 
         let comp_len = self.components.len();
-        // True when we are resuming from a previously-saved RST checkpoint;
+        // True when we are resuming from a previously-saved scan checkpoint;
         // in that case the per-component `raw_coeff` and `progressive_mcus`
         // buffers still hold the data from the prior `decode_into` call and
         // must not be re-zeroed. On a fresh decode they are (re-)allocated.

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -1256,6 +1256,38 @@ fn entropy_start(data: &[u8]) -> usize {
     sos_pos + 2 + sos_len
 }
 
+fn sos_data_start(data: &[u8], sos_index: usize) -> usize {
+    let (offset, _, length) = list_jpeg_markers(data)
+        .into_iter()
+        .filter(|(_, code, _)| *code == 0xDA)
+        .nth(sos_index)
+        .expect("test image must contain the requested SOS marker");
+    offset + 2 + length.expect("SOS marker must have a length")
+}
+
+fn sos_marker_offset(data: &[u8], sos_index: usize) -> usize {
+    list_jpeg_markers(data)
+        .into_iter()
+        .filter(|(_, code, _)| *code == 0xDA)
+        .nth(sos_index)
+        .expect("test image must contain the requested SOS marker")
+        .0
+}
+
+fn multi_sos_first_scan_cutoff(data: &[u8]) -> usize {
+    let markers = list_jpeg_markers(data);
+    let sos_markers: Vec<_> = markers
+        .iter()
+        .copied()
+        .filter(|(_, code, _)| *code == 0xDA)
+        .collect();
+    assert!(sos_markers.len() > 1, "fixture must be baseline multi-SOS");
+    let first_scan_start = sos_data_start(data, 0);
+    let second_sos_offset = sos_markers[1].0;
+    assert!(first_scan_start < second_sos_offset);
+    second_sos_offset - 1
+}
+
 fn first_retry_seek_after_scan_eof(data: &[u8], incremental_mode: bool) -> usize {
     let expected = decode_oneshot(data);
     let entropy_start = entropy_start(data);
@@ -1310,6 +1342,156 @@ fn incremental_mode_records_checkpoint_on_first_scan_attempt() {
         incremental_seek > entropy_start,
         "incremental mode should resume from an entropy-data row checkpoint; \
          entropy_start={entropy_start}, seek={incremental_seek}"
+    );
+}
+
+#[test]
+fn baseline_multi_sos_resumes_from_scan_body_checkpoint_without_stable_scanlines() {
+    for (name, data) in [
+        (
+            "non_interleaved_444_64x64",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg").as_slice()
+        ),
+        (
+            "non_interleaved_420_64x64",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg").as_slice()
+        ),
+        (
+            "non_interleaved_422_64x64",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg").as_slice()
+        ),
+        (
+            "non_interleaved_440_64x64",
+            include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg").as_slice()
+        )
+    ] {
+        let expected = decode_oneshot(data);
+        let cutoff = multi_sos_first_scan_cutoff(data);
+        let first_scan_start = sos_data_start(data, 0);
+        let second_sos_offset = sos_marker_offset(data, 1);
+        let limit = Rc::new(Cell::new(cutoff));
+        let seek_log = Rc::new(RefCell::new(Vec::new()));
+        let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
+        let mut decoder = JpegDecoder::new(cursor);
+        decoder.set_incremental_mode(true);
+
+        decoder.decode_headers().expect("headers should be visible at cutoff");
+        let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+        let err = decoder
+            .decode_into(&mut out)
+            .expect_err("multi-SOS first scan truncation should be recoverable");
+        assert!(err.is_recoverable_eof(), "{name}: got {err:?}");
+        assert_eq!(
+            decoder.decoded_output_bytes(),
+            Some(0),
+            "{name}: multi-SOS output is not stable until final assembly"
+        );
+        assert_eq!(
+            decoder.decoded_scanlines(),
+            Some(0),
+            "{name}: multi-SOS output rows are not stable until final assembly"
+        );
+
+        seek_log.borrow_mut().clear();
+        limit.set(data.len());
+        decoder
+            .decode_into(&mut out)
+            .expect("full input should replay and finish multi-SOS baseline");
+        assert_pixels_match(&out, &expected, name, data.len());
+        assert_eq!(decoder.decoded_output_bytes(), Some(out.len()));
+        assert_eq!(
+            decoder.decoded_scanlines(),
+            Some(usize::from(decoder.info().unwrap().height))
+        );
+
+        let seeks = seek_log.borrow();
+        let first_retry_seek = seeks
+            .first()
+            .copied()
+            .expect("retry must seek to a multi-SOS scan checkpoint");
+        assert!(
+            first_retry_seek > first_scan_start && first_retry_seek < second_sos_offset,
+            "{name}: retry should resume inside the first scan body; \
+             first_scan_start={first_scan_start}, seek={first_retry_seek}, \
+             second_sos_offset={second_sos_offset}"
+        );
+    }
+}
+
+#[test]
+fn baseline_multi_sos_marker_boundaries_recover() {
+    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let markers = list_jpeg_markers(data);
+    let first_sos = markers
+        .iter()
+        .position(|(_, code, _)| *code == 0xDA)
+        .expect("fixture must contain SOS");
+    assert!(
+        markers.iter().skip(first_sos + 1).any(|(_, code, _)| *code == 0xDA),
+        "fixture must contain a later inter-scan SOS"
+    );
+
+    for (offset, code, length) in markers.into_iter().skip(1) {
+        let mut cutoffs = vec![offset, offset + 1];
+        if let Some(length) = length {
+            cutoffs.push(offset + 2);
+            cutoffs.push(offset + 2 + length - 1);
+            cutoffs.push(offset + 2 + length);
+        }
+
+        cutoffs.sort_unstable();
+        cutoffs.dedup();
+
+        for cutoff in cutoffs {
+            if cutoff < data.len() {
+                let label = format!(
+                    "baseline multi-SOS marker FF{code:02X} at {offset}, cutoff {cutoff}"
+                );
+                assert_split_at_recovers(data, cutoff, &label);
+            }
+        }
+    }
+}
+
+#[test]
+fn baseline_huffman_restart_resume_uses_rst_checkpoint() {
+    let data = include_bytes!("../../../test-images/jpeg/four_components.jpg");
+    let expected = decode_oneshot(data);
+    let markers = list_jpeg_markers(data);
+    let rst_positions: Vec<_> = markers
+        .iter()
+        .filter_map(|(offset, code, _)| (0xD0..=0xD7).contains(code).then_some(*offset))
+        .collect();
+    assert!(rst_positions.len() > 3, "fixture must contain restart markers");
+
+    let cutoff = rst_positions[3] + 64;
+    let limit = Rc::new(Cell::new(cutoff));
+    let seek_log = Rc::new(RefCell::new(Vec::new()));
+    let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    decoder.decode_headers().expect("headers should be visible at cutoff");
+    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+    let err = decoder
+        .decode_into(&mut out)
+        .expect_err("truncated restart scan should be recoverable");
+    assert!(err.is_recoverable_eof(), "got {err:?}");
+
+    seek_log.borrow_mut().clear();
+    limit.set(data.len());
+    decoder
+        .decode_into(&mut out)
+        .expect("full input should resume from a restart checkpoint");
+    assert_pixels_match(&out, &expected, "baseline_huffman_restart", data.len());
+
+    let restart_resume_positions: Vec<_> = rst_positions
+        .iter()
+        .map(|position| position + 2)
+        .collect();
+    let seeks = seek_log.borrow();
+    assert!(
+        seeks.iter().any(|position| restart_resume_positions.contains(position)),
+        "retry should seek to an RST checkpoint, got {seeks:?}; expected one of {restart_resume_positions:?}"
     );
 }
 


### PR DESCRIPTION
This PR extends baseline JPEG incremental decoding so row-granular checkpoints also work for baseline multi-SOS / non-interleaved images.

Previously, baseline row checkpoints were limited to single-SOS scans because multi-SOS scans could not safely expose stable output until all component scans had been decoded. This change keeps the stable-output contract intact while allowing scan-body resume within each baseline multi-SOS scan, using the decoder-owned coefficient buffers that persist across retries.

What Changed

- Enables baseline row checkpoints for multi-SOS / non-interleaved scan bodies.
- Preserves scan checkpoints across inter-scan marker parsing until the next SOS is fully parsed.
- Rolls back inter-scan marker side effects on recoverable EOF so retries can replay markers safely.
- Keeps default one-shot decode on the low-overhead path by only capturing rollback snapshots when an active scan checkpoint exists.
- Updates incremental decoding docs to clarify multi-SOS checkpoint behavior and stable-output semantics.
- Adds coverage for:
  - scan-body resume in non-interleaved 4:4:4, 4:2:0, 4:2:2, and 4:4:0 JPEGs
  - recoverable EOF at multi-SOS marker boundaries
  - restart-marker checkpoint resume behavior

This work is part of #375 