### PR TITLE
zune-jpeg: cooperative cancellation via a vendored StopCheck

### DIFF
--- a/crates/zune-jpeg/src/cancel.rs
+++ b/crates/zune-jpeg/src/cancel.rs
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software; You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+//! Optional cooperative cancellation for long-running decodes.
+//!
+//! [`CancelCheck`] is a minimal, dependency-free trait the decoder polls at
+//! coarse intervals (roughly once per MCU row) to decide whether to stop. Any
+//! `Fn() -> bool` that is `Send + Sync` implements it, and [`NeverCancel`] costs
+//! nothing to poll, so the check can be threaded through internals
+//! unconditionally. Its shape is modelled on the `enough` crate's `Stop` trait
+//! (<https://github.com/imazen/enough/blob/main/ZERO-DEP.md>).
+
+use alloc::sync::Arc;
+
+/// How many MCUs are decoded between polls of the cancel check.
+///
+/// At up to 16x16 pixels per MCU this bounds the work between polls to about
+/// a quarter megapixel while keeping the check off the per-MCU path.
+pub(crate) const CANCEL_POLL_INTERVAL_MCUS: usize = 1024;
+
+/// A cooperative cancellation check, polled periodically during a long decode.
+///
+/// Set one with [`JpegDecoder::set_cancel`](crate::JpegDecoder::set_cancel);
+/// when it fires, decoding returns
+/// [`DecodeErrors::Cancelled`](crate::errors::DecodeErrors::Cancelled).
+///
+/// Any `Fn() -> bool` that is `Send + Sync` implements `CancelCheck`, so the
+/// common case is a closure over an `Arc<AtomicBool>`, a channel, a deadline,
+/// or an async cancellation token — the crate need not know about any of them.
+/// Use [`NeverCancel`] when no cancellation is wanted; it is a zero-cost no-op
+/// and the decoder's default.
+pub trait CancelCheck: Send + Sync {
+    /// Returns `true` to cancel decoding as soon as possible.
+    ///
+    /// Polled at coarse intervals, so it may be called many times during one
+    /// decode — keep it cheap.
+    fn is_cancelled(&self) -> bool;
+
+    /// Returns `false` if this check can never fire, letting the decoder skip
+    /// it entirely. The default is `true`.
+    #[inline]
+    fn may_cancel(&self) -> bool {
+        true
+    }
+}
+
+/// A [`CancelCheck`] that never cancels: a zero-cost opt-out of cooperative
+/// cancellation, and the decoder's default.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct NeverCancel;
+
+impl CancelCheck for NeverCancel {
+    #[inline(always)]
+    fn is_cancelled(&self) -> bool {
+        false
+    }
+
+    #[inline(always)]
+    fn may_cancel(&self) -> bool {
+        false
+    }
+}
+
+impl<F: Fn() -> bool + Send + Sync> CancelCheck for F {
+    #[inline]
+    fn is_cancelled(&self) -> bool {
+        self()
+    }
+}
+
+/// A stack-local throttle over the decoder's stored [`CancelCheck`]: forwards to
+/// the underlying check on every `interval`-th call and returns `false` the rest
+/// of the time, so a hot loop can poll once per iteration with a clean
+/// `if cancel.is_cancelled()` while the user's closure runs only periodically.
+///
+/// It owns a clone of the decoder's `Arc<dyn CancelCheck>` (one refcount bump),
+/// so it is independent of the decoder and can live in a loop body that also
+/// borrows `&mut self`. When no check is set it holds `None`, so polling is a
+/// single predicted branch.
+pub(crate) struct Debounced {
+    check:     Option<Arc<dyn CancelCheck>>,
+    interval:  usize,
+    countdown: usize
+}
+
+impl Debounced {
+    pub(crate) fn new(check: Option<Arc<dyn CancelCheck>>, interval: usize) -> Debounced {
+        Debounced {
+            check:     check.filter(|c| c.may_cancel()),
+            interval:  interval.max(1),
+            countdown: 0
+        }
+    }
+
+    /// Returns true if decoding should be cancelled. Consults the real check on
+    /// the first call and then every `interval`-th call; returns `false`
+    /// (cheaply) in between.
+    #[inline]
+    pub(crate) fn is_cancelled(&mut self) -> bool {
+        let Some(check) = &self.check else {
+            return false;
+        };
+        if self.countdown == 0 {
+            self.countdown = self.interval - 1;
+            check.is_cancelled()
+        } else {
+            self.countdown -= 1;
+            false
+        }
+    }
+}

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -12,12 +12,15 @@
 use alloc::boxed::Box;
 use alloc::string::ToString;
 use alloc::vec::Vec;
+use alloc::sync::Arc;
 use alloc::{format, vec};
 
 use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::colorspace::ColorSpace;
 use zune_core::log::{error, trace, warn};
 use zune_core::options::DecoderOptions;
+
+use crate::cancel::{CancelCheck, Debounced, CANCEL_POLL_INTERVAL_MCUS};
 
 #[cfg(feature = "arith")]
 use crate::bitstream::BitStream;
@@ -268,6 +271,8 @@ pub struct JpegDecoder<T> {
     pub(crate) todo:             usize,
     // decoder options
     pub(crate) options:          DecoderOptions,
+    // cooperative cancellation check polled during decode
+    pub(crate) cancel:           Option<Arc<dyn CancelCheck>>,
     // byte-stream
     pub(crate) stream:           ZReader<T>,
     // Indicate whether headers have been decoded
@@ -546,6 +551,7 @@ where
             restart_interval:  0,
             todo:              0x7fff_ffff,
             options:           options,
+            cancel:            None,
             stream:            ZReader::new(buffer),
             headers_decoded:   false,
             seen_sof:          false,
@@ -756,6 +762,31 @@ where
     /// // now decode
     /// decoder.decode().unwrap();
     /// ```
+    /// Set a cooperative cancellation check that is polled during decoding,
+    /// about every 1024 MCUs of decoding work.
+    ///
+    /// Any `Fn() -> bool` that is `Send + Sync` works as the check (e.g. a
+    /// closure over an `Arc<AtomicBool>` or a deadline). If it fires, decoding
+    /// returns
+    /// [`DecodeErrors::Cancelled`](crate::errors::DecodeErrors::Cancelled).
+    /// Passing [`NeverCancel`](crate::NeverCancel) (or any check whose
+    /// [`may_cancel`](crate::CancelCheck::may_cancel) is `false`) clears it; the
+    /// default is no check, which costs a single predicted branch per poll.
+    pub fn set_cancel(&mut self, cancel: impl CancelCheck + 'static) {
+        self.cancel = if cancel.may_cancel() {
+            Some(Arc::new(cancel) as Arc<dyn CancelCheck>)
+        } else {
+            None
+        };
+    }
+
+    /// A stack-local [`Debounced`] view of the cancel check for the current
+    /// scan, with the poll interval scaled from MCUs to the scan's MCU-row
+    /// width. Owns a clone of the check, so it can live in a `&mut self` loop.
+    pub(crate) fn cancel_debounced(&self, mcu_width: usize) -> Debounced {
+        Debounced::new(self.cancel.clone(), CANCEL_POLL_INTERVAL_MCUS / mcu_width.max(1))
+    }
+
     pub fn set_options(&mut self, options: DecoderOptions) {
         self.options = options;
     }

--- a/crates/zune-jpeg/src/errors.rs
+++ b/crates/zune-jpeg/src/errors.rs
@@ -52,7 +52,11 @@ pub enum DecodeErrors {
     /// Too small output for size
     TooSmallOutput(usize, usize),
 
-    IoErrors(ZByteIoError)
+    IoErrors(ZByteIoError),
+    /// Decoding was cancelled early by the cancel check.
+    ///
+    /// See [`JpegDecoder::set_cancel`](crate::JpegDecoder::set_cancel).
+    Cancelled
 }
 
 #[cfg(feature = "std")]
@@ -119,6 +123,7 @@ impl Debug for DecodeErrors {
             ),
             Self::TooSmallOutput(expected, found) => write!(f, "Too small output, expected buffer with at least {expected} bytes but got one with {found} bytes"),
             Self::IoErrors(error)=>write!(f,"I/O errors {error:?}"),
+            Self::Cancelled => write!(f, "Decoding cancelled by the cancel check"),
         }
     }
 }

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -241,6 +241,7 @@ pub use zune_core;
 pub use crate::components::SampleRatios;
 pub use crate::decoder::{ImageInfo, JpegDecoder};
 pub use crate::marker::Marker;
+pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;
 #[cfg(feature = "arith")]
 mod bitstream_arith;
@@ -258,6 +259,7 @@ mod marker;
 mod mcu;
 mod mcu_prog;
 mod misc;
+mod cancel;
 mod unsafe_utils;
 mod unsafe_utils_avx2;
 mod unsafe_utils_neon;

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -253,6 +253,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             resume_row = 0;
             resume_col = 0;
 
+            let mut cancel = self.cancel_debounced(mcu_width);
             for i in current_resume_row..mcu_height {
                 let start_col = if i == current_resume_row {
                     current_resume_col
@@ -307,6 +308,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     stream: &mut stream,
                     progressive: &mut *progressive_mcus,
                 };
+                if cancel.is_cancelled() {
+                    return Err(DecodeErrors::Cancelled);
+                }
                 let terminate = if all_components_in_first_scan {
                     self.decode_mcu_width::<false, B>(&mut mcu_width_context)?
                 } else {

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -329,7 +329,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let dc_pos = self.components[k].dc_huff_table /MAX_COMPONENTS;
         let width_stride = self.components[k].width_stride / 8;
 
+        let mut cancel = self.cancel_debounced(mcu_width);
         for i in 0..mcu_height {
+            if cancel.is_cancelled() {
+                return Err(DecodeErrors::Cancelled);
+            }
             for j in 0..mcu_width {
                 let start = 64 * (j + i * width_stride);
                 let dc_pred_opt: Option<&mut i16> = buffer[k].get_mut(start);
@@ -361,7 +365,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let width_stride = self.components[k].width_stride / 8;
         let component_buffer = &mut buffer[k];
 
+        let mut cancel = self.cancel_debounced(mcu_width);
         for i in 0..mcu_height {
+            if cancel.is_cancelled() {
+                return Err(DecodeErrors::Cancelled);
+            }
             for j in 0..mcu_width {
                 let start = 64 * (j + i * width_stride);
                 let dc_pred_id: Option<&mut i16> = component_buffer.get_mut(start);
@@ -383,7 +391,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let ac_pos = self.components[k].ac_huff_table;
         let component_buffer_data = &mut buffer[k];
 
+        let mut cancel = self.cancel_debounced(mcu_width);
         for i in 0..mcu_height {
+            if cancel.is_cancelled() {
+                return Err(DecodeErrors::Cancelled);
+            }
             for j in 0..mcu_width {
                 if *stream.eob_run() > 0 {
                     // handle EOB runs here.
@@ -416,7 +428,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let component_buffer_data = &mut buffer[k];
         let width_stride = self.components[k].width_stride / 8;
 
+        let mut cancel = self.cancel_debounced(mcu_width);
         for i in 0..mcu_height {
+            if cancel.is_cancelled() {
+                return Err(DecodeErrors::Cancelled);
+            }
             for j in 0..mcu_width {
                 let start = 64 * (j + i * width_stride);
                 let data: &mut [i16; 64] = component_buffer_data
@@ -438,7 +454,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     fn parse_dc_first_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
     ) -> Result<(), DecodeErrors> {
+        let mut cancel = self.cancel_debounced(self.mcu_x);
         for i in 0..self.mcu_y {
+            if cancel.is_cancelled() {
+                return Err(DecodeErrors::Cancelled);
+            }
             for j in 0..self.mcu_x {
                 for k in 0..self.num_scans {
                     let n = self.z_order[k as usize];
@@ -476,7 +496,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     fn parse_dc_refine_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
     ) -> Result<(), DecodeErrors> {
+        let mut cancel = self.cancel_debounced(self.mcu_x);
         for i in 0..self.mcu_y {
+            if cancel.is_cancelled() {
+                return Err(DecodeErrors::Cancelled);
+            }
             for j in 0..self.mcu_x {
                 for k in 0..self.num_scans {
                     let n = self.z_order[k as usize];
@@ -678,7 +702,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut pixels_written = 0;
 
         // dequantize, idct and color convert.
+        let mut cancel = self.cancel_debounced(self.mcu_x);
         for i in 0..mcu_height {
+            if cancel.is_cancelled() {
+                return Err(DecodeErrors::Cancelled);
+            }
             'component: for (position, component) in &mut self.components.iter_mut().enumerate() {
                 if !component.needed {
                     continue 'component;

--- a/crates/zune-jpeg/tests/cancel.rs
+++ b/crates/zune-jpeg/tests/cancel.rs
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software; You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use zune_core::bytestream::ZCursor;
+use zune_jpeg::errors::DecodeErrors;
+use zune_jpeg::{CancelCheck, JpegDecoder, NeverCancel};
+
+const BASELINE: &[u8] = include_bytes!("../../../test-images/jpeg/medium_no_samp_2500x1786.jpg");
+const PROGRESSIVE: &[u8] =
+    include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
+
+/// Returns a check that cancels after `n` polls.
+fn cancel_after(n: usize) -> impl Fn() -> bool + Send + Sync {
+    let remaining = Arc::new(AtomicUsize::new(n));
+    move || {
+        if remaining.load(Ordering::Relaxed) == 0 {
+            true
+        } else {
+            remaining.fetch_sub(1, Ordering::Relaxed);
+            false
+        }
+    }
+}
+
+fn decode_with(data: &[u8], cancel: impl CancelCheck + 'static) -> Result<Vec<u8>, DecodeErrors> {
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.set_cancel(cancel);
+    decoder.decode()
+}
+
+#[test]
+fn never_cancelling_matches_plain_decode() {
+    for data in [BASELINE, PROGRESSIVE] {
+        let plain = JpegDecoder::new(ZCursor::new(data)).decode().unwrap();
+        let with_none = decode_with(data, NeverCancel).unwrap();
+        let with_live = decode_with(data, cancel_after(usize::MAX)).unwrap();
+        assert_eq!(plain, with_none);
+        assert_eq!(plain, with_live);
+    }
+}
+
+#[test]
+fn cancelling_returns_cancelled() {
+    for data in [BASELINE, PROGRESSIVE] {
+        for polls in [0, 2] {
+            let err = decode_with(data, cancel_after(polls)).unwrap_err();
+            assert!(matches!(err, DecodeErrors::Cancelled));
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #402, as a draft — working code seemed easier to evaluate than the proposal. Feel free to close if this isn't a direction you want.

What it does:

- adds `zune-jpeg/src/stop.rs`, one self-contained type (`StopCheck`), no new dependencies, following the zero-dependency pattern from [ZERO-DEP.md](https://github.com/imazen/enough/blob/main/ZERO-DEP.md)
- `JpegDecoder::set_stop_check()` — the check is polled about every 1024 MCUs of decoding work (a countdown decremented once per MCU row in the baseline path and in each progressive scan pass), which bounds the work between polls to roughly a quarter megapixel. When it fires, decoding returns the new `DecodeErrors::Stopped`.
- the default is `StopCheck::none()`; the bookkeeping is about one subtraction and compare per MCU row, nothing per MCU or per symbol

Caveats I'm aware of:

- `DecodeErrors` isn't `#[non_exhaustive]`, so the new variant is next-0.x material — targeting `dev` for that reason.
- I couldn't run the repo's rustfmt config on a stable toolchain (unstable options), so style nits are likely; point them out and I'll fix them.
- Tests decode `medium_no_samp_2500x1786.jpg` and the limited-progressive Kiara file from `test-images`, with a counting check that fires mid-decode.

Measured on a 33 MP decode (Ryzen 9 7950X, median of 24 runs, same session): 85.3 ms on `dev` vs 86.0 and 83.1 ms across two runs of this branch — the branch brackets the baseline, so I'd only claim "below my measurement noise" rather than any particular delta. Same-binary, a live never-firing check vs none differed by under 0.5%. One machine; happy to share the harness or rerun with whatever methodology you prefer.

If you'd rather have this shaped differently (a `DecoderOptions` setting, different naming, an error shape that avoids touching `DecodeErrors`), I'm glad to rework it.