### PR TITLE
fixes for clippy duplicate attribute warnings

### DIFF
--- a/crates/zune-core/src/bytestream/reader/no_std_readers.rs
+++ b/crates/zune-core/src/bytestream/reader/no_std_readers.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 #![allow(clippy::wrong_self_convention)]
-#![allow(clippy::wrong_self_convention)]
 
 use crate::bytestream::{ZByteIoError, ZByteReaderTrait, ZSeekFrom};
 /// Wraps an in memory buffer providing it with a `Seek` method

--- a/crates/zune-imageprocs/src/hsv_adjust.rs
+++ b/crates/zune-imageprocs/src/hsv_adjust.rs
@@ -149,7 +149,6 @@ impl OperationsTrait for HsvAdjust {
 }
 
 #[allow(clippy::many_single_char_names)]
-#[allow(clippy::many_single_char_names)]
 fn modulate_hsl<T>(r: &mut [T], g: &mut [T], b: &mut [T], h: f32, s: f32, v: f32)
 where
     f32: From<T>,


### PR DESCRIPTION
While these have no real effect, the `no_std` one shows up in `cargo clippy` for other modules, which can obscure real problems.

Plus clippy complaining about clippy is just too meta.