### PR TITLE
remove log from zune-bmp dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2354,7 +2354,6 @@ dependencies = [
 name = "zune-bmp"
 version = "0.5.2"
 dependencies = [
- "log",
  "zune-core 0.5.1",
 ]
 

--- a/crates/zune-bmp/Cargo.toml
+++ b/crates/zune-bmp/Cargo.toml
@@ -21,4 +21,3 @@ rgb_inverse = []
 
 [dependencies]
 zune-core = { version = "^0.5.1", path = "../zune-core" }
-log = "0.4"

--- a/crates/zune-bmp/src/decoder.rs
+++ b/crates/zune-bmp/src/decoder.rs
@@ -98,11 +98,10 @@
 use alloc::vec::Vec;
 use alloc::{format, vec};
 
-use log::error;
 use zune_core::bit_depth::BitDepth;
 use zune_core::bytestream::{ZByteIoError, ZByteReaderTrait, ZReader};
 use zune_core::colorspace::{ColorPrimaries, ColorSpace, RenderingIntent};
-use zune_core::log::{trace, warn};
+use zune_core::log::{error, trace, warn};
 use zune_core::options::DecoderOptions;
 
 use crate::common::{BmpCompression, BmpPixelFormat, PROFILE_EMBEDDED, PROFILE_LINKED};


### PR DESCRIPTION
remove log crate from dependencies and use `zune-core::log` instead