### PR TITLE
Add OpenSlide-oriented JPEG decode controls

### DIFF
--- a/crates/zune-core/src/options.rs
+++ b/crates/zune-core/src/options.rs
@@ -6,7 +6,7 @@
 //! All supported options are put into one _Options to allow for global configurations
 //! options e.g the same  `DecoderOption` can be reused for all other decoders
 //!
-pub use decoder::DecoderOptions;
+pub use decoder::{DecoderOptions, InputColorspaceOverride, JpegScale};
 pub use encoder::EncoderOptions;
 pub use encoder::PngCompression;
 mod decoder;

--- a/crates/zune-core/src/options/decoder.rs
+++ b/crates/zune-core/src/options/decoder.rs
@@ -12,6 +12,36 @@
 use crate::bit_depth::ByteEndian;
 use crate::colorspace::ColorSpace;
 
+/// JPEG input colorspace handling.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum InputColorspaceOverride {
+    /// Infer the JPEG input colorspace from markers and component layout.
+    Auto,
+    /// Force the JPEG input colorspace after marker parsing.
+    Force(ColorSpace)
+}
+
+/// JPEG output scaling.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum JpegScale {
+    Full,
+    Half,
+    Quarter,
+    Eighth
+}
+
+impl JpegScale {
+    /// Return the scale denominator.
+    pub const fn denominator(self) -> usize {
+        match self {
+            Self::Full => 1,
+            Self::Half => 2,
+            Self::Quarter => 4,
+            Self::Eighth => 8
+        }
+    }
+}
+
 /// A decoder that can handle errors
 fn decoder_error_tolerance_mode() -> DecoderFlags {
     // similar to fast options currently, so no need to write a new one
@@ -168,7 +198,14 @@ pub struct DecoderOptions {
     hevc_max_mdat_size: usize,
     /// Number of threads used for decoding
     ///
-    num_threads:        u8
+    num_threads:        u8,
+    /// JPEG input colorspace override.
+    ///
+    /// This is primarily useful for container formats that define the JPEG
+    /// colorspace out of band.
+    input_colorspace_override: InputColorspaceOverride,
+    /// JPEG output scale.
+    jpeg_scale: JpegScale
 }
 
 /// Initializers
@@ -454,6 +491,32 @@ impl DecoderOptions {
         self.out_colorspace = colorspace;
         self
     }
+
+    /// Get the JPEG input colorspace override.
+    pub const fn jpeg_get_input_colorspace_override(&self) -> InputColorspaceOverride {
+        self.input_colorspace_override
+    }
+
+    /// Set the JPEG input colorspace override.
+    #[must_use]
+    pub fn jpeg_set_input_colorspace_override(
+        mut self, override_: InputColorspaceOverride
+    ) -> Self {
+        self.input_colorspace_override = override_;
+        self
+    }
+
+    /// Get the JPEG output scale.
+    pub const fn jpeg_get_scale(&self) -> JpegScale {
+        self.jpeg_scale
+    }
+
+    /// Set the JPEG output scale.
+    #[must_use]
+    pub fn jpeg_set_scale(mut self, scale: JpegScale) -> Self {
+        self.jpeg_scale = scale;
+        self
+    }
 }
 
 /// Intrinsics support
@@ -726,7 +789,9 @@ impl Default for DecoderOptions {
             // 16 mb
             hevc_max_mdat_size: 1 << 24,
             num_threads:        4,
-            endianness:         ByteEndian::BE
+            endianness:         ByteEndian::BE,
+            input_colorspace_override: InputColorspaceOverride::Auto,
+            jpeg_scale:         JpegScale::Full
         }
     }
 }

--- a/crates/zune-jpeg/examples/openslide_api.rs
+++ b/crates/zune-jpeg/examples/openslide_api.rs
@@ -1,0 +1,53 @@
+use std::fs;
+use std::io::Cursor;
+
+use zune_core::colorspace::ColorSpace;
+use zune_core::options::{DecoderOptions, InputColorspaceOverride, JpegScale};
+use zune_jpeg::{
+    assemble_split_jpeg, DecodeRegion, JpegDecoder, JpegDimensions, RegionDecodeMode,
+};
+
+/// Demonstrate the OpenSlide-oriented JPEG helpers on local tile fixture files.
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let jpeg = fs::read("tile.jpg")?;
+
+    let mut full = JpegDecoder::new(Cursor::new(jpeg.as_slice()));
+    let pixels = full.decode()?;
+    let info = full.info().expect("headers were decoded");
+    println!("decoded {}x{} RGB bytes={}", info.width, info.height, pixels.len());
+
+    let region = DecodeRegion {
+        x: 128,
+        y: 96,
+        width: 256,
+        height: 256,
+    };
+    let mut region_decoder = JpegDecoder::new(Cursor::new(jpeg.as_slice()));
+    let region_pixels = region_decoder.decode_region(region, RegionDecodeMode::BestEffort)?;
+    println!("region RGB bytes={}", region_pixels.len());
+
+    let options = DecoderOptions::default()
+        .jpeg_set_out_colorspace(ColorSpace::BGRA)
+        .jpeg_set_input_colorspace_override(InputColorspaceOverride::Force(ColorSpace::YCbCr))
+        .jpeg_set_scale(JpegScale::Half);
+    let mut bgra = JpegDecoder::new_with_options(Cursor::new(jpeg.as_slice()), options);
+    let bgra_pixels = bgra.decode_region(region, RegionDecodeMode::BestEffort)?;
+    println!("scaled BGRA region bytes={}", bgra_pixels.len());
+
+    let table_header = fs::read("jpeg_tables.bin")?;
+    let abbreviated_scan = fs::read("tile_scan.bin")?;
+    let mut assembled = Vec::new();
+    assemble_split_jpeg(
+        &table_header,
+        &abbreviated_scan,
+        2,
+        JpegDimensions {
+            width: info.width,
+            height: info.height,
+        },
+        &mut assembled,
+    )?;
+    println!("assembled split JPEG bytes={}", assembled.len());
+
+    Ok(())
+}

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -18,7 +18,7 @@ use alloc::{format, vec};
 use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::colorspace::ColorSpace;
 use zune_core::log::{error, trace, warn};
-use zune_core::options::DecoderOptions;
+use zune_core::options::{DecoderOptions, InputColorspaceOverride, JpegScale};
 
 use crate::cancel::{CancelCheck, Debounced, CANCEL_POLL_INTERVAL_MCUS};
 
@@ -50,6 +50,87 @@ pub(crate) const MAX_COMPONENTS: usize = 4;
 
 /// Maximum image dimensions supported.
 pub(crate) const MAX_DIMENSIONS: usize = 1 << 27;
+
+/// A rectangle to decode from a JPEG image.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DecodeRegion {
+    pub x:      usize,
+    pub y:      usize,
+    pub width:  usize,
+    pub height: usize
+}
+
+/// Region decode strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionDecodeMode {
+    /// Decode only what is needed where possible.
+    BestEffort,
+    /// Prefer simple behavior matching full-image decode.
+    Conservative
+}
+
+/// JPEG dimensions used when assembling split header/data streams.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct JpegDimensions {
+    pub width:  u16,
+    pub height: u16
+}
+
+/// Assemble a JPEG stream from a reusable header and separate entropy payload.
+///
+/// The SOF marker at `sof_offset_in_header` must be a baseline, extended
+/// sequential, or progressive DCT SOF marker. Its height and width fields are
+/// patched to `dimensions`, `data` is appended after `header`, and an EOI marker
+/// is appended unless the assembled stream already ends with one.
+///
+/// # Errors
+/// Returns an error if the SOF offset cannot address the marker and
+/// height/width fields, or if the marker at that offset is not supported.
+pub fn assemble_split_jpeg(
+    header: &[u8], data: &[u8], sof_offset_in_header: usize, dimensions: JpegDimensions,
+    out: &mut Vec<u8>
+) -> Result<(), DecodeErrors> {
+    if dimensions.width == 0 || dimensions.height == 0 {
+        return Err(DecodeErrors::FormatStatic(
+            "Split JPEG dimensions must be non-zero"
+        ));
+    }
+
+    let sof_end = sof_offset_in_header
+        .checked_add(9)
+        .ok_or(DecodeErrors::FormatStatic("SOF offset overflows usize"))?;
+    if sof_end > header.len() {
+        return Err(DecodeErrors::FormatStatic(
+            "SOF offset cannot address JPEG dimensions"
+        ));
+    }
+
+    let marker = u16::from_be_bytes([
+        header[sof_offset_in_header],
+        header[sof_offset_in_header + 1]
+    ]);
+    if !matches!(marker, 0xffc0 | 0xffc1 | 0xffc2) {
+        return Err(DecodeErrors::FormatStatic(
+            "SOF offset does not point to a supported DCT SOF marker"
+        ));
+    }
+
+    out.clear();
+    out.reserve(header.len().saturating_add(data.len()).saturating_add(2));
+    out.extend_from_slice(header);
+    let height = dimensions.height.to_be_bytes();
+    let width = dimensions.width.to_be_bytes();
+    out[sof_offset_in_header + 5] = height[0];
+    out[sof_offset_in_header + 6] = height[1];
+    out[sof_offset_in_header + 7] = width[0];
+    out[sof_offset_in_header + 8] = width[1];
+    out.extend_from_slice(data);
+    if !out.ends_with(&[0xff, 0xd9]) {
+        out.extend_from_slice(&[0xff, 0xd9]);
+    }
+
+    Ok(())
+}
 
 /// Color conversion function that can convert YCbCr colorspace to RGB(A/X) for
 /// 16 values
@@ -509,6 +590,15 @@ where
         }
     }
 
+    /// Apply the configured JPEG input colorspace override to the parsed header state.
+    fn apply_input_colorspace_override(&mut self) {
+        if let InputColorspaceOverride::Force(colorspace) =
+            self.options.jpeg_get_input_colorspace_override()
+        {
+            self.input_colorspace = colorspace;
+        }
+    }
+
     #[allow(clippy::redundant_field_names)]
     fn default(options: DecoderOptions, buffer: T) -> Self {
         let color_convert = choose_ycbcr_to_rgb_convert_func(ColorSpace::RGB, &options).unwrap();
@@ -590,6 +680,48 @@ where
         self.decode_headers()?;
 
         if self.expects_dnl {
+            if self.options.jpeg_get_scale() != JpegScale::Full {
+                let options = self.options;
+                self.options = options.jpeg_set_scale(JpegScale::Full);
+                let max_size = self
+                    .options
+                    .max_height()
+                    .checked_mul(usize::from(self.info.width))
+                    .and_then(|v| {
+                        v.checked_mul(
+                            self.options.jpeg_get_out_colorspace().num_components()
+                        )
+                    })
+                    .ok_or(DecodeErrors::FormatStatic(
+                        "DNL image dimensions overflow usize"
+                    ))?;
+                let mut full = vec![0u8; max_size];
+                let decode_result = self.decode_into(&mut full);
+                self.options = options;
+                decode_result?;
+                let full_size = self.full_output_buffer_size().ok_or(
+                    DecodeErrors::FormatStatic(
+                        "DNL image: full output size unavailable after decode"
+                    )
+                )?;
+                full.truncate(full_size);
+                let scaled_size = self.output_buffer_size().ok_or(
+                    DecodeErrors::FormatStatic(
+                        "DNL image: scaled output size unavailable after decode"
+                    )
+                )?;
+                let mut scaled = vec![0u8; scaled_size];
+                Self::scale_full_pixels(
+                    &full,
+                    usize::from(self.width()),
+                    usize::from(self.height()),
+                    options.jpeg_get_out_colorspace().num_components(),
+                    options.jpeg_get_scale(),
+                    &mut scaled
+                )?;
+                return Ok(scaled);
+            }
+
             // Height is unknown until DNL is encountered during entropy
             // decoding. Pre-allocate a buffer large enough for the worst case
             // (the configured max height), run decode_into normally — the MCU
@@ -666,13 +798,213 @@ where
     pub fn output_buffer_size(&self) -> Option<usize> {
         return if self.headers_decoded {
             Some(
-                usize::from(self.width())
-                    .checked_mul(usize::from(self.height()))?
+                self.scaled_width()
+                    .checked_mul(self.scaled_height())?
                     .checked_mul(self.options.jpeg_get_out_colorspace().num_components())?
             )
         } else {
             None
         };
+    }
+
+    /// Return the output buffer size before JPEG scaling is applied.
+    fn full_output_buffer_size(&self) -> Option<usize> {
+        if self.headers_decoded {
+            usize::from(self.width())
+                .checked_mul(usize::from(self.height()))?
+                .checked_mul(self.options.jpeg_get_out_colorspace().num_components())
+        } else {
+            None
+        }
+    }
+
+    /// Return the image width after applying the configured JPEG scale.
+    fn scaled_width(&self) -> usize {
+        usize::from(self.width()).div_ceil(self.options.jpeg_get_scale().denominator())
+    }
+
+    /// Return the image height after applying the configured JPEG scale.
+    fn scaled_height(&self) -> usize {
+        usize::from(self.height()).div_ceil(self.options.jpeg_get_scale().denominator())
+    }
+
+    /// Return the number of bytes required to hold a tightly packed decoded
+    /// region in the configured output colorspace.
+    #[must_use]
+    pub fn region_output_buffer_size(&self, region: DecodeRegion) -> Option<usize> {
+        self.validate_region(region).ok()?;
+        region
+            .width
+            .checked_mul(region.height)?
+            .checked_mul(self.options.jpeg_get_out_colorspace().num_components())
+    }
+
+    /// Decode a tightly packed rectangular region.
+    ///
+    /// Baseline Huffman images use MCU-row decoding where possible; other
+    /// encodings may fall back to full-image decode plus crop.
+    ///
+    /// # Errors
+    /// Returns an error when headers are invalid, the region is empty or out of
+    /// bounds, or the underlying decode fails.
+    pub fn decode_region(
+        &mut self, region: DecodeRegion, mode: RegionDecodeMode
+    ) -> Result<Vec<u8>, DecodeErrors> {
+        self.decode_headers()?;
+        let size = self.region_output_buffer_size(region).ok_or(DecodeErrors::FormatStatic(
+            "Decode region is empty, out of bounds, or overflows usize"
+        ))?;
+        let mut out = vec![0; size];
+        self.decode_region_into(region, mode, &mut out)?;
+        Ok(out)
+    }
+
+    /// Decode a tightly packed rectangular region into a caller-provided
+    /// buffer.
+    ///
+    /// `out` must be at least [`region_output_buffer_size`](Self::region_output_buffer_size)
+    /// bytes long. Extra bytes are left untouched.
+    ///
+    /// # Errors
+    /// Returns an error when headers are invalid, the region is empty or out of
+    /// bounds, the output buffer is too small, or the underlying decode fails.
+    pub fn decode_region_into(
+        &mut self, region: DecodeRegion, _mode: RegionDecodeMode, out: &mut [u8]
+    ) -> Result<(), DecodeErrors> {
+        self.decode_headers()?;
+        let region_size = self.region_output_buffer_size(region).ok_or(DecodeErrors::FormatStatic(
+            "Decode region is empty, out of bounds, or overflows usize"
+        ))?;
+        if out.len() < region_size {
+            return Err(DecodeErrors::TooSmallOutput(region_size, out.len()));
+        }
+
+        if self.options.jpeg_get_scale() == JpegScale::Full
+            && !self.is_progressive
+            && !self.is_arithmetic
+            && !self.expects_dnl
+            && !self.scan_decode_attempted
+        {
+            self.decode_mcu_ycbcr_baseline_region::<BitStreamHuffman>(region, out)?;
+            self.pixels_decoded = region_size;
+            return Ok(());
+        }
+
+        if self.options.jpeg_get_scale() != JpegScale::Full && !self.expects_dnl {
+            self.decode_scaled_region_into(region, &mut out[..region_size])?;
+            self.pixels_decoded = region_size;
+            return Ok(());
+        }
+
+        let full_size = self.output_buffer_size().ok_or(DecodeErrors::FormatStatic(
+            "Full output buffer size is unavailable after header decode"
+        ))?;
+        let mut full = vec![0; full_size];
+        self.decode_into(&mut full)?;
+
+        let components = self.options.jpeg_get_out_colorspace().num_components();
+        let full_stride = self.scaled_width()
+            .checked_mul(components)
+            .ok_or(DecodeErrors::FormatStatic("Full output stride overflows usize"))?;
+        let region_stride = region
+            .width
+            .checked_mul(components)
+            .ok_or(DecodeErrors::FormatStatic("Region output stride overflows usize"))?;
+        let start_x = region
+            .x
+            .checked_mul(components)
+            .ok_or(DecodeErrors::FormatStatic("Region x offset overflows usize"))?;
+
+        for row in 0..region.height {
+            let src_start = (region.y + row)
+                .checked_mul(full_stride)
+                .and_then(|v| v.checked_add(start_x))
+                .ok_or(DecodeErrors::FormatStatic("Region source offset overflows usize"))?;
+            let src_end = src_start
+                .checked_add(region_stride)
+                .ok_or(DecodeErrors::FormatStatic("Region source end overflows usize"))?;
+            let dst_start = row
+                .checked_mul(region_stride)
+                .ok_or(DecodeErrors::FormatStatic("Region destination offset overflows usize"))?;
+            let dst_end = dst_start
+                .checked_add(region_stride)
+                .ok_or(DecodeErrors::FormatStatic("Region destination end overflows usize"))?;
+            out[dst_start..dst_end].copy_from_slice(&full[src_start..src_end]);
+        }
+
+        Ok(())
+    }
+
+    /// Decode the scaled full image and copy a tightly packed region from it.
+    fn decode_scaled_region_into(
+        &mut self, region: DecodeRegion, out: &mut [u8]
+    ) -> Result<(), DecodeErrors> {
+        let scaled_size = self.output_buffer_size().ok_or(DecodeErrors::FormatStatic(
+            "Scaled output buffer size is unavailable after header decode"
+        ))?;
+        let mut scaled = vec![0; scaled_size];
+        self.decode_scaled_into(&mut scaled)?;
+
+        let components = self.options.jpeg_get_out_colorspace().num_components();
+        let full_stride = self
+            .scaled_width()
+            .checked_mul(components)
+            .ok_or(DecodeErrors::FormatStatic("Scaled output stride overflows usize"))?;
+        let region_stride = region
+            .width
+            .checked_mul(components)
+            .ok_or(DecodeErrors::FormatStatic("Scaled region stride overflows usize"))?;
+        let start_x = region
+            .x
+            .checked_mul(components)
+            .ok_or(DecodeErrors::FormatStatic("Scaled region x offset overflows usize"))?;
+
+        for row in 0..region.height {
+            let src_start = (region.y + row)
+                .checked_mul(full_stride)
+                .and_then(|v| v.checked_add(start_x))
+                .ok_or(DecodeErrors::FormatStatic(
+                    "Scaled region source offset overflows usize"
+                ))?;
+            let src_end = src_start.checked_add(region_stride).ok_or(
+                DecodeErrors::FormatStatic("Scaled region source end overflows usize")
+            )?;
+            let dst_start = row.checked_mul(region_stride).ok_or(
+                DecodeErrors::FormatStatic("Scaled region destination offset overflows usize")
+            )?;
+            let dst_end = dst_start.checked_add(region_stride).ok_or(
+                DecodeErrors::FormatStatic("Scaled region destination end overflows usize")
+            )?;
+            out[dst_start..dst_end].copy_from_slice(&scaled[src_start..src_end]);
+        }
+
+        Ok(())
+    }
+
+    /// Validate that a decode region is non-empty and inside the scaled image bounds.
+    fn validate_region(&self, region: DecodeRegion) -> Result<(), DecodeErrors> {
+        if !self.headers_decoded {
+            return Err(DecodeErrors::FormatStatic(
+                "Cannot validate decode region before headers are decoded"
+            ));
+        }
+        if region.width == 0 || region.height == 0 {
+            return Err(DecodeErrors::FormatStatic("Decode region must be non-empty"));
+        }
+        let image_width = self.scaled_width();
+        let image_height = self.scaled_height();
+        let x_end = region
+            .x
+            .checked_add(region.width)
+            .ok_or(DecodeErrors::FormatStatic("Decode region width overflows usize"))?;
+        let y_end = region
+            .y
+            .checked_add(region.height)
+            .ok_or(DecodeErrors::FormatStatic("Decode region height overflows usize"))?;
+        if x_end > image_width || y_end > image_height {
+            return Err(DecodeErrors::FormatStatic("Decode region is outside image bounds"));
+        }
+        Ok(())
     }
 
     /// Return the number of output bytes known to be stable after the most
@@ -722,13 +1054,13 @@ where
     #[must_use]
     pub fn decoded_scanlines(&self) -> Option<usize> {
         let decoded_output_bytes = self.decoded_output_bytes()?;
-        let row_stride = usize::from(self.width())
+        let row_stride = self.scaled_width()
             .checked_mul(self.options.jpeg_get_out_colorspace().num_components())?;
         if row_stride == 0 {
             return Some(0);
         }
 
-        Some((decoded_output_bytes / row_stride).min(usize::from(self.height())))
+        Some((decoded_output_bytes / row_stride).min(self.scaled_height()))
     }
 
     /// Get an immutable reference to the decoder options
@@ -1030,6 +1362,7 @@ where
             if is_rgb {
                 self.input_colorspace = ColorSpace::RGB;
             }
+            self.apply_input_colorspace_override();
 
             self.enter_scan_state()?;
             return Ok(MarkerStep::EnteredScan);
@@ -1408,6 +1741,10 @@ where
     ///
     #[allow(clippy::too_many_lines)]
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
+        if self.options.jpeg_get_scale() != JpegScale::Full {
+            return self.decode_scaled_into(out);
+        }
+
         // Pull the scan-resume state out into owned locals so the restore
         // below can freely mutate `self`. When headers haven't completed
         // yet, `scan_plan` is `None` and we just run header decoding below.
@@ -1571,6 +1908,89 @@ where
             }
             Err(e) => Err(e)
         }
+    }
+
+    /// Decode the image using the configured reduced JPEG scale.
+    fn decode_scaled_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
+        self.decode_headers_internal()?;
+        let expected_size = self.output_buffer_size().unwrap();
+        if out.len() < expected_size {
+            return Err(DecodeErrors::TooSmallOutput(expected_size, out.len()));
+        }
+
+        if !self.is_progressive
+            && !self.is_arithmetic
+            && !self.expects_dnl
+            && !self.scan_decode_attempted
+            && self.restart_interval == 0
+            && usize::from(self.num_scans) == self.components.len()
+            && matches!(self.input_colorspace, ColorSpace::Luma | ColorSpace::YCbCr)
+            && self.input_colorspace.num_components() == self.components.len()
+        {
+            return self.decode_scaled_baseline_into::<BitStreamHuffman>(&mut out[..expected_size]);
+        }
+
+        let full_size = self.full_output_buffer_size().ok_or(DecodeErrors::FormatStatic(
+            "Full output buffer size is unavailable after header decode"
+        ))?;
+        let options = self.options;
+        self.options = options.jpeg_set_scale(JpegScale::Full);
+        let mut full = vec![0; full_size];
+        let decode_result = self.decode_into(&mut full);
+        self.options = options;
+        decode_result?;
+
+        Self::scale_full_pixels(
+            &full,
+            usize::from(self.width()),
+            usize::from(self.height()),
+            options.jpeg_get_out_colorspace().num_components(),
+            options.jpeg_get_scale(),
+            &mut out[..expected_size],
+        )?;
+        self.pixels_decoded = expected_size;
+        Ok(())
+    }
+
+    /// Downsample a fully decoded image by selecting pixels at the JPEG scale interval.
+    fn scale_full_pixels(
+        full: &[u8], full_width: usize, full_height: usize, components: usize, scale: JpegScale,
+        out: &mut [u8]
+    ) -> Result<(), DecodeErrors> {
+        let denominator = scale.denominator();
+        let scaled_width = full_width.div_ceil(denominator);
+        let scaled_height = full_height.div_ceil(denominator);
+        let full_stride = full_width
+            .checked_mul(components)
+            .ok_or(DecodeErrors::FormatStatic("Full scaled source stride overflows usize"))?;
+        let scaled_stride = scaled_width
+            .checked_mul(components)
+            .ok_or(DecodeErrors::FormatStatic("Scaled output stride overflows usize"))?;
+        let expected = scaled_stride
+            .checked_mul(scaled_height)
+            .ok_or(DecodeErrors::FormatStatic("Scaled output size overflows usize"))?;
+        if out.len() < expected {
+            return Err(DecodeErrors::TooSmallOutput(expected, out.len()));
+        }
+
+        for y in 0..scaled_height {
+            let src_y = (y * denominator).min(full_height.saturating_sub(1));
+            for x in 0..scaled_width {
+                let src_x = (x * denominator).min(full_width.saturating_sub(1));
+                let src = src_y
+                    .checked_mul(full_stride)
+                    .and_then(|v| v.checked_add(src_x.checked_mul(components)?))
+                    .ok_or(DecodeErrors::FormatStatic("Scaled source offset overflows usize"))?;
+                let dst = y
+                    .checked_mul(scaled_stride)
+                    .and_then(|v| v.checked_add(x.checked_mul(components)?))
+                    .ok_or(DecodeErrors::FormatStatic(
+                        "Scaled destination offset overflows usize"
+                    ))?;
+                out[dst..dst + components].copy_from_slice(&full[src..src + components]);
+            }
+        }
+        Ok(())
     }
 
     /// Read only headers from a jpeg image buffer

--- a/crates/zune-jpeg/src/idct.rs
+++ b/crates/zune-jpeg/src/idct.rs
@@ -34,7 +34,7 @@
 )]
 
 use zune_core::log::debug;
-use zune_core::options::DecoderOptions;
+use zune_core::options::{DecoderOptions, JpegScale};
 
 use crate::decoder::IDCTPtr;
 use crate::idct::scalar::{idct_int, idct_int_1x1};
@@ -101,6 +101,16 @@ pub fn choose_idct_4x4_func(_options: &DecoderOptions) -> IDCTPtr {
 pub fn choose_idct_1x1_func(_: &DecoderOptions) -> IDCTPtr {
     // These are simple stores, no alternative implementation for now
     idct_int_1x1
+}
+
+/// Choose the IDCT implementation for the requested JPEG scale.
+pub fn choose_scaled_idct_func(scale: JpegScale, _options: &DecoderOptions) -> IDCTPtr {
+    match scale {
+        JpegScale::Full => choose_idct_func(_options),
+        JpegScale::Half => scalar::idct_int_scaled_4x4,
+        JpegScale::Quarter => scalar::idct_int_scaled_2x2,
+        JpegScale::Eighth => scalar::idct_int_scaled_1x1,
+    }
 }
 
 #[cfg(test)]
@@ -201,6 +211,51 @@ mod tests {
         for (wnd, name) in color.windows(2).zip(&dct_names) {
             let [a, b] = wnd else { unreachable!() };
             assert_eq!(a, b, "{name}");
+        }
+    }
+
+    #[test]
+    /// Confirm reduced IDCT output matches sampling from the full scalar IDCT.
+    fn scaled_idct_matches_full_idct_sampling() {
+        let coeff = [
+            91, -21, 13, 4, -9, 2, 1, -1,
+            7, -5, 3, -2, 1, 0, 0, 0,
+            -11, 8, -6, 4, -2, 1, 0, 0,
+            5, -3, 2, -1, 0, 0, 0, 0,
+            -4, 2, -1, 0, 0, 0, 0, 0,
+            3, -2, 1, 0, 0, 0, 0, 0,
+            -2, 1, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 0, 0, 0, 0,
+        ];
+
+        for (denominator, scale, scaled_idct) in [
+            (2, JpegScale::Half, scalar::idct_int_scaled_4x4 as IDCTPtr),
+            (4, JpegScale::Quarter, scalar::idct_int_scaled_2x2 as IDCTPtr),
+            (8, JpegScale::Eighth, scalar::idct_int_scaled_1x1 as IDCTPtr),
+        ] {
+            let mut full_coeff = coeff;
+            let mut full = [0_i16; 64];
+            scalar::idct_int(&mut full_coeff, &mut full, 8);
+
+            for candidate in [
+                scaled_idct,
+                choose_scaled_idct_func(scale, &DecoderOptions::new_safe()),
+            ] {
+                let mut scaled_coeff = coeff;
+                let mut scaled = [0_i16; 64];
+                candidate(&mut scaled_coeff, &mut scaled, 8);
+
+                let reduced = 8 / denominator;
+                for y in 0..reduced {
+                    for x in 0..reduced {
+                        assert_eq!(
+                            scaled[y * 8 + x],
+                            full[(y * denominator) * 8 + x * denominator],
+                            "scaled IDCT mismatch for denominator {denominator} at ({x},{y})"
+                        );
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/zune-jpeg/src/idct/scalar.rs
+++ b/crates/zune-jpeg/src/idct/scalar.rs
@@ -179,6 +179,155 @@ pub fn idct_int(in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize
     }
 }
 
+/// Produce a reduced IDCT block by evaluating only the requested output samples.
+fn idct_int_scaled_sampled(
+    in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize, denominator: usize,
+) {
+    if &in_vector[1..] == &[0_i32; 63] {
+        let coeff = ((wa(wa(in_vector[0], 4), 1024) >> 3).clamp(0, 255)) as i16;
+        let reduced = 8 / denominator;
+        for y in 0..reduced {
+            out_vector[y * stride..y * stride + reduced].fill(coeff);
+        }
+        return;
+    }
+
+    // Vertical pass is identical to the full scalar IDCT. The scaled variants
+    // reduce work in the horizontal pass by evaluating only requested output
+    // rows and columns.
+    for ptr in 0..8 {
+        let p2 = in_vector[ptr + 16];
+        let p3 = in_vector[ptr + 48];
+
+        let p1 = wm(wa(p2, p3), 2217);
+
+        let t2 = wa(p1, wm(p3, -7567));
+        let t3 = wa(p1, wm(p2, 3135));
+
+        let p2 = in_vector[ptr];
+        let p3 = in_vector[32 + ptr];
+
+        let t0 = fsh(wa(p2, p3));
+        let t1 = fsh(ws(p2, p3));
+
+        let x0 = wa(wa(t0, t3), 512);
+        let x3 = wa(ws(t0, t3), 512);
+        let x1 = wa(wa(t1, t2), 512);
+        let x2 = wa(ws(t1, t2), 512);
+
+        let mut t0 = in_vector[ptr + 56];
+        let mut t1 = in_vector[ptr + 40];
+        let mut t2 = in_vector[ptr + 24];
+        let mut t3 = in_vector[ptr + 8];
+
+        let p3 = wa(t0, t2);
+        let p4 = wa(t1, t3);
+        let p1 = wa(t0, t3);
+        let p2 = wa(t1, t2);
+        let p5 = wm(wa(p3, p4), 4816);
+
+        t0 = wm(t0, 1223);
+        t1 = wm(t1, 8410);
+        t2 = wm(t2, 12586);
+        t3 = wm(t3, 6149);
+
+        let p1 = wa(p5, wm(p1, -3685));
+        let p2 = wa(p5, wm(p2, -10497));
+        let p3 = wm(p3, -8034);
+        let p4 = wm(p4, -1597);
+
+        t3 = wa(t3, wa(p1, p4));
+        t2 = wa(t2, wa(p2, p3));
+        t1 = wa(t1, wa(p2, p4));
+        t0 = wa(t0, wa(p1, p3));
+
+        in_vector[ptr] = ws(wa(x0, t3), 0) >> 10;
+        in_vector[ptr + 8] = ws(wa(x1, t2), 0) >> 10;
+        in_vector[ptr + 16] = ws(wa(x2, t1), 0) >> 10;
+        in_vector[ptr + 24] = ws(wa(x3, t0), 0) >> 10;
+        in_vector[ptr + 32] = ws(ws(x3, t0), 0) >> 10;
+        in_vector[ptr + 40] = ws(ws(x2, t1), 0) >> 10;
+        in_vector[ptr + 48] = ws(ws(x1, t2), 0) >> 10;
+        in_vector[ptr + 56] = ws(ws(x0, t3), 0) >> 10;
+    }
+
+    let reduced = 8 / denominator;
+
+    for y in 0..reduced {
+        let src_row = y * denominator * 8;
+
+        let p2 = in_vector[src_row + 2];
+        let p3 = in_vector[src_row + 6];
+
+        let p1 = wm(wa(p2, p3), 2217);
+        let t2 = wa(p1, wm(p3, -7567));
+        let t3 = wa(p1, wm(p2, 3135));
+
+        let p2 = in_vector[src_row];
+        let p3 = in_vector[src_row + 4];
+
+        let t0 = fsh(wa(p2, p3));
+        let t1 = fsh(ws(p2, p3));
+
+        let x0 = wa(wa(t0, t3), SCALE_BITS);
+        let x3 = wa(ws(t0, t3), SCALE_BITS);
+        let x1 = wa(wa(t1, t2), SCALE_BITS);
+        let x2 = wa(ws(t1, t2), SCALE_BITS);
+
+        let mut t0 = in_vector[src_row + 7];
+        let mut t1 = in_vector[src_row + 5];
+        let mut t2 = in_vector[src_row + 3];
+        let mut t3 = in_vector[src_row + 1];
+
+        let p3 = wa(t0, t2);
+        let p4 = wa(t1, t3);
+        let p1 = wa(t0, t3);
+        let p2 = wa(t1, t2);
+        let p5 = wm(wa(p3, p4), f2f(1.175875602));
+
+        t0 = wm(t0, 1223);
+        t1 = wm(t1, 8410);
+        t2 = wm(t2, 12586);
+        t3 = wm(t3, 6149);
+
+        let p1 = wa(p5, wm(p1, -3685));
+        let p2 = wa(p5, wm(p2, -10497));
+        let p3 = wm(p3, -8034);
+        let p4 = wm(p4, -1597);
+
+        t3 = wa(t3, wa(p1, p4));
+        t2 = wa(t2, wa(p2, p3));
+        t1 = wa(t1, wa(p2, p4));
+        t0 = wa(t0, wa(p1, p3));
+
+        let row = &mut out_vector[y * stride..];
+        for x in 0..reduced {
+            row[x] = match x * denominator {
+                0 => clamp(wa(x0, t3) >> 17),
+                2 => clamp(wa(x2, t1) >> 17),
+                4 => clamp(ws(x3, t0) >> 17),
+                6 => clamp(ws(x1, t2) >> 17),
+                _ => unreachable!("scaled IDCT only samples columns 0, 2, 4, and 6"),
+            };
+        }
+    }
+}
+
+/// Produce a 4x4 output block from one JPEG DCT block.
+pub fn idct_int_scaled_4x4(in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize) {
+    idct_int_scaled_sampled(in_vector, out_vector, stride, 2);
+}
+
+/// Produce a 2x2 output block from one JPEG DCT block.
+pub fn idct_int_scaled_2x2(in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize) {
+    idct_int_scaled_sampled(in_vector, out_vector, stride, 4);
+}
+
+/// Produce a 1x1 output block from one JPEG DCT block.
+pub fn idct_int_scaled_1x1(in_vector: &mut [i32; 64], out_vector: &mut [i16], stride: usize) {
+    idct_int_scaled_sampled(in_vector, out_vector, stride, 8);
+}
+
 #[inline]
 #[allow(clippy::cast_possible_truncation)]
 /// Multiply a number by 4096

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -239,7 +239,9 @@ extern crate core;
 pub use zune_core;
 
 pub use crate::components::SampleRatios;
-pub use crate::decoder::{ImageInfo, JpegDecoder};
+pub use crate::decoder::{
+    assemble_split_jpeg, DecodeRegion, ImageInfo, JpegDecoder, JpegDimensions, RegionDecodeMode
+};
 pub use crate::marker::Marker;
 pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -14,11 +14,13 @@ use zune_core::bytestream::ZByteReaderTrait;
 use zune_core::colorspace::ColorSpace;
 use zune_core::colorspace::ColorSpace::Luma;
 use zune_core::log::{error, trace, warn};
+use zune_core::options::JpegScale;
 
 use crate::bitstream::BitStream;
 use crate::components::SampleRatios;
-use crate::decoder::{HeaderAppendStateSnapshot, MAX_COMPONENTS};
+use crate::decoder::{DecodeRegion, HeaderAppendStateSnapshot, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
+use crate::idct::choose_scaled_idct_func;
 use crate::marker::Marker;
 use crate::mcu_prog::get_marker;
 use crate::misc::{calculate_padded_width, setup_component_params};
@@ -42,6 +44,36 @@ struct McuWidthContext<'a, B: BitStream> {
     stream: &'a mut B,
     // Full-image coefficient buffers for multi-SOS baseline scans.
     progressive: &'a mut [Vec<i16>; MAX_COMPONENTS],
+}
+
+struct RegionOutput<'a> {
+    region:     DecodeRegion,
+    out:        &'a mut [u8],
+    components: usize,
+    width:      usize,
+    written:    usize
+}
+
+impl RegionOutput<'_> {
+    /// Copy decoded rows from a full-width stripe into the requested region buffer.
+    fn copy_from_stripe(&mut self, stripe: &[u8], start_row: usize, rows: usize) {
+        let full_stride = self.width * self.components;
+        let region_stride = self.region.width * self.components;
+        let region_y_end = self.region.y + self.region.height;
+        let region_x = self.region.x * self.components;
+
+        for row in 0..rows {
+            let image_row = start_row + row;
+            if image_row < self.region.y || image_row >= region_y_end {
+                continue;
+            }
+            let src = row * full_stride + region_x;
+            let dst = (image_row - self.region.y) * region_stride;
+            self.out[dst..dst + region_stride]
+                .copy_from_slice(&stripe[src..src + region_stride]);
+        }
+        self.written = self.written.max(region_stride * self.region.height);
+    }
 }
 
 impl<T: ZByteReaderTrait> JpegDecoder<T> {
@@ -70,9 +102,211 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // `decode_into` retries, which is what lets scan checkpoints stay
         // allocation-free.
         let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
-        let result = self.decode_mcu_ycbcr_baseline_inner::<B>(pixels, &mut progressive_mcus);
+        let result =
+            self.decode_mcu_ycbcr_baseline_inner::<B>(pixels, &mut progressive_mcus, None);
         self.progressive_mcus_buffer = progressive_mcus;
         result
+    }
+
+    /// Decode a baseline image while writing only the requested region.
+    pub(crate) fn decode_mcu_ycbcr_baseline_region<B: BitStream>(
+        &mut self, region: DecodeRegion, out: &mut [u8],
+    ) -> Result<(), DecodeErrors> {
+        let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
+        let components = self.options.jpeg_get_out_colorspace().num_components();
+        let width = usize::from(self.info.width);
+        let mut region_output = RegionOutput {
+            region,
+            out,
+            components,
+            width,
+            written: 0
+        };
+        let result = self.decode_mcu_ycbcr_baseline_inner::<B>(
+            &mut [],
+            &mut progressive_mcus,
+            Some(&mut region_output)
+        );
+        self.progressive_mcus_buffer = progressive_mcus;
+        result
+    }
+
+    /// Decode a single-scan baseline image directly into a reduced-scale output buffer.
+    pub(crate) fn decode_scaled_baseline_into<B: BitStream>(
+        &mut self, out: &mut [u8],
+    ) -> Result<(), DecodeErrors> {
+        setup_component_params(self)?;
+
+        let scale = self.options.jpeg_get_scale();
+        if scale == JpegScale::Full {
+            return Err(DecodeErrors::FormatStatic(
+                "Scaled baseline path requires a reduced JPEG scale"
+            ));
+        }
+        if self.restart_interval != 0 || usize::from(self.num_scans) != self.components.len() {
+            return Err(DecodeErrors::FormatStatic(
+                "Scaled baseline path only supports single-scan images without restarts"
+            ));
+        }
+        if !matches!(self.input_colorspace, ColorSpace::Luma | ColorSpace::YCbCr) {
+            return Err(DecodeErrors::FormatStatic(
+                "Scaled baseline path only supports Luma and YCbCr input"
+            ));
+        }
+        if self.input_colorspace.num_components() != self.components.len()
+        {
+            return Err(DecodeErrors::FormatStatic(
+                "Scaled baseline path requires the input colorspace component count to match the JPEG"
+            ));
+        }
+
+        self.check_tables::<B>()?;
+
+        let denominator = scale.denominator();
+        let block_output = 8 / denominator;
+        let scaled_width = usize::from(self.info.width).div_ceil(denominator);
+        let scaled_height = usize::from(self.info.height).div_ceil(denominator);
+        let out_components = self.options.jpeg_get_out_colorspace().num_components();
+        let expected_size = scaled_width
+            .checked_mul(scaled_height)
+            .and_then(|v| v.checked_mul(out_components))
+            .ok_or(DecodeErrors::FormatStatic(
+                "Scaled baseline output size overflows usize"
+            ))?;
+        if out.len() < expected_size {
+            return Err(DecodeErrors::TooSmallOutput(expected_size, out.len()));
+        }
+
+        let mcu_x = self.mcu_x;
+        let mcu_y = self.mcu_y;
+        let plane_shapes: Vec<(usize, usize)> = self
+            .components
+            .iter()
+            .map(|component| {
+                (
+                    mcu_x * component.horizontal_sample * block_output,
+                    mcu_y * component.vertical_sample * block_output,
+                )
+            })
+            .collect();
+        let mut planes: Vec<Vec<i16>> = plane_shapes
+            .iter()
+            .map(|(stride, rows)| vec![0; stride * rows])
+            .collect();
+        let mut stream = B::new();
+        let mut tmp = [0_i32; DCT_BLOCK];
+        let mut idct_out = [0_i16; DCT_BLOCK];
+        let idct = choose_scaled_idct_func(scale, &self.options);
+        let z_order = self.z_order;
+        let z_scans = &z_order[..usize::from(self.num_scans)];
+
+        for mcu_row in 0..mcu_y {
+            for mcu_col in 0..mcu_x {
+                for &component_index in z_scans {
+                    let (horizontal_sample, vertical_sample) = {
+                        let component = &self.components[component_index];
+                        (component.horizontal_sample, component.vertical_sample)
+                    };
+
+                    for v_samp in 0..vertical_sample {
+                        for h_samp in 0..horizontal_sample {
+                            tmp.fill(0);
+                            idct_out.fill(0);
+
+                            {
+                                let component = &mut self.components[component_index];
+                                let (dc_table, ac_table) = B::get_dc_ac_tables(
+                                    &mut self.entropy_tables,
+                                    component.dc_huff_table % MAX_COMPONENTS,
+                                    component.ac_huff_table % MAX_COMPONENTS,
+                                )?;
+                                stream.decode_mcu_block(
+                                    &mut self.stream,
+                                    dc_table,
+                                    ac_table,
+                                    &component.quantization_table,
+                                    &mut tmp,
+                                    &mut component.dc_pred,
+                                    &mut component.dc_diff,
+                                )?;
+                            }
+
+                            idct(&mut tmp, &mut idct_out, 8);
+
+                            let plane_stride = plane_shapes[component_index].0;
+                            let out_x =
+                                (mcu_col * horizontal_sample + h_samp) * block_output;
+                            let out_y =
+                                (mcu_row * vertical_sample + v_samp) * block_output;
+                            let plane = &mut planes[component_index];
+
+                            for y in 0..block_output {
+                                let dst_row = out_y + y;
+                                let dst = dst_row * plane_stride + out_x;
+                                plane[dst..dst + block_output]
+                                    .copy_from_slice(&idct_out[y * 8..y * 8 + block_output]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        match self.check_stream_marker_after_mcu_width(&mut stream)? {
+            McuContinuation::Ok | McuContinuation::Terminate => {}
+            McuContinuation::DnlFound => {
+                return Err(DecodeErrors::FormatStatic(
+                    "DNL is not supported in scaled baseline fast path"
+                ))
+            }
+            McuContinuation::AnotherSos | McuContinuation::InterScanMarker(_) => {
+                return Err(DecodeErrors::FormatStatic(
+                    "Multiple scans are not supported in scaled baseline fast path"
+                ))
+            }
+        }
+
+        let y_stride = plane_shapes[0].0;
+        let y_rows = plane_shapes[0].1;
+        let mut expanded: [Vec<i16>; MAX_COMPONENTS] = core::array::from_fn(|_| Vec::new());
+        expanded[0] = planes[0].clone();
+
+        if self.input_colorspace == ColorSpace::YCbCr {
+            for component_index in 1..self.components.len().min(3) {
+                expanded[component_index].resize(y_stride * y_rows, 0);
+                let component = &self.components[component_index];
+                let src_stride = plane_shapes[component_index].0;
+                let src_rows = plane_shapes[component_index].1;
+                let h_scale = self.h_max / component.horizontal_sample;
+                let v_scale = self.v_max / component.vertical_sample;
+
+                for y in 0..y_rows {
+                    let src_y = (y / v_scale).min(src_rows.saturating_sub(1));
+                    for x in 0..y_stride {
+                        let src_x = (x / h_scale).min(src_stride.saturating_sub(1));
+                        expanded[component_index][y * y_stride + x] =
+                            planes[component_index][src_y * src_stride + src_x];
+                    }
+                }
+            }
+        }
+
+        let mut channels: [&[i16]; MAX_COMPONENTS] = [&[]; MAX_COMPONENTS];
+        for (index, channel) in channels.iter_mut().enumerate() {
+            *channel = &expanded[index];
+        }
+        color_convert(
+            &channels,
+            self.color_convert_16,
+            self.input_colorspace,
+            self.options.jpeg_get_out_colorspace(),
+            &mut out[..expected_size],
+            scaled_width,
+            y_stride,
+        )?;
+
+        self.pixels_decoded = expected_size;
+        Ok(())
     }
 
     /// Inner implementation of [`Self::decode_mcu_ycbcr_baseline`].
@@ -92,6 +326,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[inline(never)]
     fn decode_mcu_ycbcr_baseline_inner<B: BitStream>(
         &mut self, pixels: &mut [u8], progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS],
+        mut region_output: Option<&mut RegionOutput<'_>>,
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
 
@@ -236,6 +471,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 .unwrap_or(0)
             * 8;
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
+        let row_stride = width * self.options.jpeg_get_out_colorspace().num_components();
+        let max_stripe_rows = (8 * self.v_max.max(1) * self.coeff.max(1))
+            .saturating_add(self.coeff.max(1) * self.v_max.max(1))
+            .max(16);
+        let mut region_stripe = if region_output.is_some() {
+            vec![0; row_stride * max_stripe_rows]
+        } else {
+            Vec::new()
+        };
+        let has_vertical_upsampling = self
+            .components
+            .iter()
+            .any(|c| c.sample_ratio == SampleRatios::HV || c.sample_ratio == SampleRatios::V);
 
         'sos: loop {
             trace!(
@@ -337,15 +585,49 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // process that width up until it's impossible. This is faster than allocation the
                 // full components, which we skipped earlier.
                 if all_components_in_first_scan {
-                    self.post_process(
-                        pixels,
-                        i,
-                        mcu_height,
-                        width,
-                        padded_width,
-                        &mut pixels_written,
-                        &mut upsampler_scratch_space,
-                    )?;
+                    if let Some(region_output) = region_output.as_deref_mut() {
+                        let start_row = pixels_written / row_stride;
+                        let rows_without_vertical_state = if self.is_interleaved
+                            && self.options.jpeg_get_out_colorspace() != ColorSpace::Luma
+                        {
+                            8 * self.coeff * self.v_max
+                        } else if let SampleRatios::Generic(_, v) = self.info.sample_ratio {
+                            8 * v * self.coeff
+                        } else {
+                            8 * self.coeff
+                        };
+                        if !has_vertical_upsampling
+                            && (start_row + rows_without_vertical_state <= region_output.region.y
+                                || start_row >= region_output.region.y + region_output.region.height)
+                        {
+                            pixels_written += rows_without_vertical_state * row_stride;
+                        } else {
+                            region_stripe.fill(0);
+                            let mut stripe_written = 0;
+                            self.post_process(
+                                &mut region_stripe,
+                                i,
+                                mcu_height,
+                                width,
+                                padded_width,
+                                &mut stripe_written,
+                                &mut upsampler_scratch_space,
+                            )?;
+                            let rows = stripe_written / row_stride;
+                            region_output.copy_from_stripe(&region_stripe, start_row, rows);
+                            pixels_written += stripe_written;
+                        }
+                    } else {
+                        self.post_process(
+                            pixels,
+                            i,
+                            mcu_height,
+                            width,
+                            padded_width,
+                            &mut pixels_written,
+                            &mut upsampler_scratch_space,
+                        )?;
+                    }
                     self.pixels_decoded = pixels_written;
                     // This row's coefficient buffers can be reused next, so
                     // any checkpoint inside the row is no longer valid.
@@ -459,7 +741,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         if !all_components_in_first_scan {
-            self.finish_baseline_decoding(progressive_mcus, mcu_width, pixels)?;
+            if let Some(region_output) = region_output.as_deref_mut() {
+                self.finish_baseline_decoding_region(progressive_mcus, region_output)?;
+            } else {
+                self.finish_baseline_decoding(progressive_mcus, mcu_width, pixels)?;
+            }
         }
 
         // it may happen that some images don't have the whole buffer
@@ -568,6 +854,96 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         return Ok(());
+    }
+
+    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::cast_sign_loss)]
+    /// Finish baseline decoding by post-processing stripes and copying a region.
+    fn finish_baseline_decoding_region(
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], region_output: &mut RegionOutput<'_>,
+    ) -> Result<(), DecodeErrors> {
+        let mcu_height = self.mcu_y;
+        let is_hv = usize::from(self.is_interleaved);
+        let upsampler_scratch_size = is_hv
+            * self
+                .components
+                .iter()
+                .map(|x| x.width_stride)
+                .max()
+                .unwrap_or(0)
+            * 8;
+        let width = usize::from(self.info.width);
+        let padded_width = calculate_padded_width(width, self.info.sample_ratio);
+        let components = self.options.jpeg_get_out_colorspace().num_components();
+        let row_stride = width * components;
+
+        let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
+        let max_stripe_rows = (8 * self.v_max.max(1) * self.coeff.max(1))
+            .saturating_add(self.coeff.max(1) * self.v_max.max(1))
+            .max(16);
+        let mut stripe = vec![0; row_stride * max_stripe_rows];
+        let has_vertical_upsampling = self
+            .components
+            .iter()
+            .any(|c| c.sample_ratio == SampleRatios::HV || c.sample_ratio == SampleRatios::V);
+        let rows_without_vertical_state = if self.is_interleaved
+            && self.options.jpeg_get_out_colorspace() != ColorSpace::Luma
+        {
+            8 * self.coeff * self.v_max
+        } else if let SampleRatios::Generic(_, v) = self.info.sample_ratio {
+            8 * v * self.coeff
+        } else {
+            8 * self.coeff
+        };
+
+        for (pos, comp) in self.components.iter_mut().enumerate() {
+            comp.needed = min(
+                self.options.jpeg_get_out_colorspace().num_components() - 1,
+                pos,
+            ) == pos
+                || self.input_colorspace == ColorSpace::YCCK
+                || self.input_colorspace == ColorSpace::CMYK;
+        }
+
+        let mut pixels_written = 0;
+        for i in 0..mcu_height {
+            'component: for (position, component) in &mut self.components.iter_mut().enumerate() {
+                if !component.needed {
+                    continue 'component;
+                }
+
+                let step = block[position].len() / mcu_height;
+                let slice = &block[position][i * step..][..step];
+                let temp_channel = &mut component.raw_coeff;
+                temp_channel[..step].copy_from_slice(slice);
+            }
+
+            let start_row = pixels_written / row_stride;
+            if !has_vertical_upsampling
+                && (start_row + rows_without_vertical_state <= region_output.region.y
+                    || start_row >= region_output.region.y + region_output.region.height)
+            {
+                pixels_written += rows_without_vertical_state * row_stride;
+                continue;
+            }
+
+            stripe.fill(0);
+            let mut stripe_written = 0;
+            self.post_process(
+                &mut stripe,
+                i,
+                mcu_height,
+                width,
+                padded_width,
+                &mut stripe_written,
+                &mut upsampler_scratch_space,
+            )?;
+            let rows = stripe_written / row_stride;
+            region_output.copy_from_stripe(&stripe, start_row, rows);
+            pixels_written += stripe_written;
+        }
+
+        Ok(())
     }
 
     fn decode_mcu_width<const PROGRESSIVE: bool, B: BitStream>(

--- a/crates/zune-jpeg/src/worker.rs
+++ b/crates/zune-jpeg/src/worker.rs
@@ -491,14 +491,29 @@ pub(crate) fn upsample(
                 }
 
                 if upsample {
-                    // upsample
-                    (component.up_sampler)(
-                        curr_row,
-                        row_up,
-                        row_down,
-                        upsampler_scratch_space,
-                        dest
-                    );
+                    let segment_width = component.horizontal_sample * 8;
+                    if component.sample_ratio == SampleRatios::HV
+                        && segment_width < curr_row.len()
+                        && curr_row.len() % segment_width == 0
+                    {
+                        upsample_hv_mcu_segments(
+                            curr_row,
+                            row_up,
+                            row_down,
+                            upsampler_scratch_space,
+                            dest,
+                            segment_width
+                        );
+                    } else {
+                        // upsample
+                        (component.up_sampler)(
+                            curr_row,
+                            row_up,
+                            row_down,
+                            upsampler_scratch_space,
+                            dest
+                        );
+                    }
                 }
             }
         }
@@ -544,9 +559,14 @@ pub(crate) fn upsample(
                 .chunks_exact(component.width_stride)
                 .zip(dest_coeff.chunks_exact_mut(component.width_stride * 2))
             {
-                // upsample using the fn pointer, should only be H, so no need for
-                // row up and row down
-                (component.up_sampler)(single_row, &[], &[], &mut [], output_stride);
+                let segment_width = component.horizontal_sample * 8;
+                if segment_width < single_row.len() && single_row.len() % segment_width == 0 {
+                    upsample_h_mcu_segments(single_row, output_stride, segment_width);
+                } else {
+                    // upsample using the fn pointer, should only be H, so no need for
+                    // row up and row down
+                    (component.up_sampler)(single_row, &[], &[], &mut [], output_stride);
+                }
             }
         }
         SampleRatios::Generic(h, v) => {
@@ -574,4 +594,118 @@ pub(crate) fn upsample(
         SampleRatios::None => {}
     }
     Ok(())
+}
+
+/// Horizontally upsample row segments without filtering across MCU boundaries.
+fn upsample_h_mcu_segments(input: &[i16], output: &mut [i16], segment_width: usize) {
+    if segment_width == 0 || segment_width >= input.len() || input.len() % segment_width != 0 {
+        upsample_h_row(input, output);
+        return;
+    }
+    for (input_segment, output_segment) in input
+        .chunks_exact(segment_width)
+        .zip(output.chunks_exact_mut(segment_width * 2))
+    {
+        upsample_h_row(input_segment, output_segment);
+    }
+}
+
+/// Horizontally and vertically upsample row segments without crossing MCU boundaries.
+fn upsample_hv_mcu_segments(
+    input: &[i16], in_near: &[i16], in_far: &[i16], scratch_space: &mut [i16],
+    output: &mut [i16], segment_width: usize
+) {
+    if segment_width == 0 || segment_width >= input.len() || input.len() % segment_width != 0 {
+        upsample_hv_row(input, in_near, in_far, scratch_space, output);
+        return;
+    }
+    let scratch_space = &mut scratch_space[..input.len() * 2];
+    let (top, bottom) = scratch_space.split_at_mut(input.len());
+    for pos in 0..input.len() {
+        top[pos] = (((3 * input[pos]) + 2) + in_near[pos]) >> 2;
+        bottom[pos] = (((3 * input[pos]) + 2) + in_far[pos]) >> 2;
+    }
+    let output_half = output.len() / 2;
+    let (output_top, output_bottom) = output.split_at_mut(output_half);
+    upsample_h_mcu_segments(&scratch_space[..input.len()], output_top, segment_width);
+    upsample_h_mcu_segments(&scratch_space[input.len()..], output_bottom, segment_width);
+}
+
+/// Horizontally and vertically upsample one complete row.
+fn upsample_hv_row(
+    input: &[i16], in_near: &[i16], in_far: &[i16], scratch_space: &mut [i16], output: &mut [i16]
+) {
+    let scratch_space = &mut scratch_space[..input.len() * 2];
+    let (top, bottom) = scratch_space.split_at_mut(input.len());
+    for pos in 0..input.len() {
+        top[pos] = (((3 * input[pos]) + 2) + in_near[pos]) >> 2;
+        bottom[pos] = (((3 * input[pos]) + 2) + in_far[pos]) >> 2;
+    }
+    let output_half = output.len() / 2;
+    let (output_top, output_bottom) = output.split_at_mut(output_half);
+    upsample_h_row(&scratch_space[..input.len()], output_top);
+    upsample_h_row(&scratch_space[input.len()..], output_bottom);
+}
+
+/// Horizontally upsample one complete row with edge replication.
+fn upsample_h_row(input: &[i16], output: &mut [i16]) {
+    output[0] = input[0];
+    output[1] = (input[0] * 3 + input[1] + 2) >> 2;
+    for (output_window, input_window) in output[2..].chunks_exact_mut(2).zip(input.windows(3)) {
+        let sample = 3 * input_window[1] + 2;
+        output_window[0] = (sample + input_window[0]) >> 2;
+        output_window[1] = (sample + input_window[2]) >> 2;
+    }
+    let out_len = output.len() - 2;
+    let input_len = input.len() - 2;
+    let f_out = &mut output[out_len..];
+    let i_last = &input[input_len..];
+    f_out[0] = (3 * i_last[1] + i_last[0] + 2) >> 2;
+    f_out[1] = i_last[1];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Confirm horizontal upsampling restarts its filter at segment boundaries.
+    fn h_upsampling_resets_at_mcu_segment_boundary() {
+        let input = [10, 20, 30, 40, 200, 210, 220, 230];
+        let mut output = [0; 16];
+        let mut expected = [0; 16];
+
+        upsample_h_mcu_segments(&input, &mut output, 4);
+        upsample_h_row(&input[..4], &mut expected[..8]);
+        upsample_h_row(&input[4..], &mut expected[8..]);
+
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    /// Confirm HV upsampling does not mix samples across horizontal segments.
+    fn hv_upsampling_resets_horizontal_filter_without_mixing_rows() {
+        let input = [10, 20, 30, 40, 200, 210, 220, 230];
+        let near = [8, 18, 28, 38, 198, 208, 218, 228];
+        let far = [12, 22, 32, 42, 202, 212, 222, 232];
+        let mut output = [0; 32];
+        let mut scratch = [0; 16];
+
+        upsample_hv_mcu_segments(&input, &near, &far, &mut scratch, &mut output, 4);
+
+        let mut first = [0; 16];
+        let mut second = [0; 16];
+        let mut scratch_first = [0; 8];
+        let mut scratch_second = [0; 8];
+        upsample_hv_row(&input[..4], &near[..4], &far[..4], &mut scratch_first, &mut first);
+        upsample_hv_row(&input[4..], &near[4..], &far[4..], &mut scratch_second, &mut second);
+
+        let mut expected = [0; 32];
+        expected[..8].copy_from_slice(&first[..8]);
+        expected[8..16].copy_from_slice(&second[..8]);
+        expected[16..24].copy_from_slice(&first[8..]);
+        expected[24..].copy_from_slice(&second[8..]);
+
+        assert_eq!(output, expected);
+    }
 }

--- a/crates/zune-jpeg/tests/dnl_test.rs
+++ b/crates/zune-jpeg/tests/dnl_test.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use zune_core::bytestream::ZCursor;
+use zune_core::options::{DecoderOptions, JpegScale};
 use zune_jpeg::JpegDecoder;
 
 #[test]
@@ -22,4 +23,27 @@ fn test_dnl_decoding() {
     let info_after = decoder.info().unwrap();
     assert_eq!(info_after.height, 7524, "DNL image: height must be set after decode()");
     assert_eq!(pixels.len(), 8192 * 7524 * 3);
+
+    let scale = JpegScale::Eighth;
+    let options = DecoderOptions::default().jpeg_set_scale(scale);
+    let mut scaled_decoder = JpegDecoder::new_with_options(ZCursor::new(&bytes[..]), options);
+    let scaled = scaled_decoder.decode().unwrap();
+    let scaled_info = scaled_decoder.info().unwrap();
+    let scaled_width = 8192_usize.div_ceil(scale.denominator());
+    let scaled_height = 7524_usize.div_ceil(scale.denominator());
+
+    assert_eq!(scaled_info.height, 7524, "DNL image: height must be set before scaling");
+    assert_eq!(scaled.len(), scaled_width * scaled_height * 3);
+
+    let full_stride = 8192 * 3;
+    let scaled_stride = scaled_width * 3;
+    for y in 0..scaled_height {
+        let src_y = (y * scale.denominator()).min(7524 - 1);
+        for x in 0..scaled_width {
+            let src_x = (x * scale.denominator()).min(8192 - 1);
+            let src = src_y * full_stride + src_x * 3;
+            let dst = y * scaled_stride + x * 3;
+            assert_eq!(&scaled[dst..dst + 3], &pixels[src..src + 3]);
+        }
+    }
 }

--- a/crates/zune-jpeg/tests/openslide_api.rs
+++ b/crates/zune-jpeg/tests/openslide_api.rs
@@ -1,0 +1,652 @@
+use std::io::Cursor;
+
+use zune_core::colorspace::ColorSpace;
+use zune_core::options::{DecoderOptions, InputColorspaceOverride, JpegScale};
+use zune_jpeg::{
+    assemble_split_jpeg, DecodeRegion, JpegDecoder, JpegDimensions, RegionDecodeMode
+};
+
+/// Copy a tightly packed rectangular region out of a full decoded image.
+fn crop_from_full(
+    full: &[u8], image_width: usize, components: usize, region: DecodeRegion,
+) -> Vec<u8> {
+    let full_stride = image_width * components;
+    let region_stride = region.width * components;
+    let mut out = vec![0; region_stride * region.height];
+
+    for row in 0..region.height {
+        let src_start = (region.y + row) * full_stride + region.x * components;
+        let dst_start = row * region_stride;
+        out[dst_start..dst_start + region_stride]
+            .copy_from_slice(&full[src_start..src_start + region_stride]);
+    }
+
+    out
+}
+
+/// Build an expected scaled image by conservatively sampling a full decode.
+fn scaled_from_full(
+    full: &[u8], width: usize, height: usize, components: usize, scale: JpegScale,
+) -> Vec<u8> {
+    let denominator = scale.denominator();
+    let scaled_width = width.div_ceil(denominator);
+    let scaled_height = height.div_ceil(denominator);
+    let full_stride = width * components;
+    let scaled_stride = scaled_width * components;
+    let mut out = vec![0; scaled_stride * scaled_height];
+
+    for y in 0..scaled_height {
+        let src_y = (y * denominator).min(height - 1);
+        for x in 0..scaled_width {
+            let src_x = (x * denominator).min(width - 1);
+            let src = src_y * full_stride + src_x * components;
+            let dst = y * scaled_stride + x * components;
+            out[dst..dst + components].copy_from_slice(&full[src..src + components]);
+        }
+    }
+
+    out
+}
+
+/// Find the offset of the first JPEG marker whose code is in `markers`.
+fn find_marker(data: &[u8], markers: &[u8]) -> Option<usize> {
+    data.windows(2).position(|window| window[0] == 0xff && markers.contains(&window[1]))
+}
+
+/// Return the byte offset where entropy-coded data starts after the first SOS marker.
+fn sos_entropy_start(data: &[u8]) -> Option<usize> {
+    let sos = find_marker(data, &[0xda])?;
+    let length = u16::from_be_bytes([*data.get(sos + 2)?, *data.get(sos + 3)?]) as usize;
+    sos.checked_add(2)?.checked_add(length).filter(|offset| *offset <= data.len())
+}
+
+/// Construct a minimal baseline grayscale JPEG with a zero DC coefficient block.
+fn baseline_luma_8x8_dc_zero_jpeg() -> Vec<u8> {
+    let mut jpeg = vec![0xff, 0xd8];
+
+    jpeg.extend_from_slice(&[0xff, 0xdb, 0x00, 0x43, 0x00]);
+    jpeg.extend_from_slice(&[1; 64]);
+
+    jpeg.extend_from_slice(&[
+        0xff, 0xc0, 0x00, 0x0b, 0x08, 0x00, 0x08, 0x00, 0x08, 0x01, 0x01, 0x11, 0x00,
+    ]);
+
+    jpeg.extend_from_slice(&[
+        0xff, 0xc4, 0x00, 0x14, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+    jpeg.extend_from_slice(&[
+        0xff, 0xc4, 0x00, 0x14, 0x10, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    ]);
+
+    jpeg.extend_from_slice(&[
+        0xff, 0xda, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0x03, 0xff, 0xd9,
+    ]);
+    jpeg
+}
+
+#[test]
+/// Check that full-scale region decode matches cropping a full decode.
+fn decode_region_matches_full_decode_crop() {
+    let image = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
+    let region = DecodeRegion {
+        x: 7,
+        y: 11,
+        width: 23,
+        height: 19,
+    };
+
+    let mut full_decoder = JpegDecoder::new(Cursor::new(image.as_slice()));
+    let full = full_decoder.decode().unwrap();
+    let info = full_decoder.info().unwrap();
+    let expected = crop_from_full(&full, info.width as usize, 3, region);
+
+    let mut region_decoder = JpegDecoder::new(Cursor::new(image.as_slice()));
+    region_decoder.decode_headers().unwrap();
+    assert_eq!(
+        region_decoder.region_output_buffer_size(region),
+        Some(region.width * region.height * 3)
+    );
+
+    let decoded = region_decoder
+        .decode_region(region, RegionDecodeMode::Conservative)
+        .unwrap();
+    assert_eq!(decoded, expected);
+}
+
+#[test]
+/// Check region decode across representative sampling modes.
+fn decode_region_matches_full_decode_crop_for_sampling_modes() {
+    let cases: &[(&[u8], DecodeRegion)] = &[
+        (
+            include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg"),
+            DecodeRegion {
+                x:      3,
+                y:      4,
+                width:  17,
+                height: 13
+            }
+        ),
+        (
+            include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg"),
+            DecodeRegion {
+                x:      5,
+                y:      7,
+                width:  19,
+                height: 11
+            }
+        ),
+        (
+            include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg"),
+            DecodeRegion {
+                x:      9,
+                y:      10,
+                width:  21,
+                height: 15
+            }
+        ),
+        (
+            include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+            DecodeRegion {
+                x:      2,
+                y:      6,
+                width:  12,
+                height: 10
+            }
+        )
+    ];
+
+    for (image, region) in cases {
+        let mut full_decoder = JpegDecoder::new(Cursor::new(*image));
+        let full = full_decoder.decode().unwrap();
+        let info = full_decoder.info().unwrap();
+        let components = full_decoder.output_colorspace().unwrap().num_components();
+        let expected = crop_from_full(&full, info.width as usize, components, *region);
+
+        let mut region_decoder = JpegDecoder::new(Cursor::new(*image));
+        let decoded = region_decoder
+            .decode_region(*region, RegionDecodeMode::BestEffort)
+            .unwrap();
+        assert_eq!(decoded, expected);
+    }
+}
+
+#[test]
+/// Check interleaved baseline region decode reports region-sized output.
+fn baseline_interleaved_region_decode_uses_region_sized_output_accounting() {
+    let image = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let region = DecodeRegion {
+        x:      4,
+        y:      5,
+        width:  16,
+        height: 12
+    };
+
+    let mut decoder = JpegDecoder::new(Cursor::new(image.as_slice()));
+    let decoded = decoder
+        .decode_region(region, RegionDecodeMode::BestEffort)
+        .unwrap();
+
+    assert_eq!(decoded.len(), region.width * region.height * 3);
+    assert_eq!(
+        decoder.decoded_output_bytes(),
+        Some(region.width * region.height * 3)
+    );
+}
+
+#[test]
+/// Check multi-SOS baseline region decode reports region-sized output.
+fn baseline_multi_sos_region_decode_uses_region_sized_output_accounting() {
+    let image = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
+    let region = DecodeRegion {
+        x:      6,
+        y:      9,
+        width:  18,
+        height: 14
+    };
+
+    let mut decoder = JpegDecoder::new(Cursor::new(image.as_slice()));
+    let decoded = decoder
+        .decode_region(region, RegionDecodeMode::BestEffort)
+        .unwrap();
+
+    assert_eq!(decoded.len(), region.width * region.height * 3);
+    assert_eq!(
+        decoder.decoded_output_bytes(),
+        Some(region.width * region.height * 3)
+    );
+}
+
+#[test]
+/// Check BGR and BGRA region decode against full-decode crops.
+fn decode_region_matches_full_decode_crop_for_bgr_and_bgra() {
+    let image = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let region = DecodeRegion {
+        x:      8,
+        y:      5,
+        width:  16,
+        height: 12
+    };
+
+    for colorspace in [ColorSpace::BGR, ColorSpace::BGRA] {
+        let options = DecoderOptions::default().jpeg_set_out_colorspace(colorspace);
+        let mut full_decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+        let full = full_decoder.decode().unwrap();
+        let info = full_decoder.info().unwrap();
+        let components = colorspace.num_components();
+        let expected = crop_from_full(&full, info.width as usize, components, region);
+
+        let mut region_decoder =
+            JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+        let decoded = region_decoder
+            .decode_region(region, RegionDecodeMode::Conservative)
+            .unwrap();
+        assert_eq!(decoded, expected);
+    }
+}
+
+#[test]
+/// Check reduced grayscale baseline decode uses the scaled IDCT path.
+fn scaled_luma_baseline_decode_uses_reduced_idct_path() {
+    let image = baseline_luma_8x8_dc_zero_jpeg();
+
+    for scale in [JpegScale::Half, JpegScale::Quarter, JpegScale::Eighth] {
+        let options = DecoderOptions::default()
+            .jpeg_set_out_colorspace(ColorSpace::Luma)
+            .jpeg_set_scale(scale);
+        let mut decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+        decoder.decode_headers().unwrap();
+        let expected_size = 8_usize.div_ceil(scale.denominator()).pow(2);
+        assert_eq!(decoder.output_buffer_size(), Some(expected_size));
+
+        let scaled = decoder.decode().unwrap();
+
+        assert_eq!(scaled, vec![128; expected_size]);
+        assert_eq!(decoder.decoded_output_bytes(), Some(expected_size));
+        assert_eq!(
+            decoder.decoded_scanlines(),
+            Some(8_usize.div_ceil(scale.denominator()))
+        );
+    }
+}
+
+#[test]
+/// Check scaled decode matches conservative sampling from a full decode.
+fn scaled_decode_matches_conservative_full_decode_sampling() {
+    let image = include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg");
+
+    let mut full_decoder = JpegDecoder::new(Cursor::new(image.as_slice()));
+    let full = full_decoder.decode().unwrap();
+    let info = full_decoder.info().unwrap();
+
+    for scale in [JpegScale::Half, JpegScale::Quarter, JpegScale::Eighth] {
+        let options = DecoderOptions::default().jpeg_set_scale(scale);
+        let mut decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+        decoder.decode_headers().unwrap();
+        let scaled_width = (info.width as usize).div_ceil(scale.denominator());
+        let scaled_height = (info.height as usize).div_ceil(scale.denominator());
+        assert_eq!(
+            decoder.output_buffer_size(),
+            Some(scaled_width * scaled_height * 3)
+        );
+
+        let scaled = decoder.decode().unwrap();
+        let expected = scaled_from_full(
+            &full,
+            info.width as usize,
+            info.height as usize,
+            3,
+            scale
+        );
+        assert_eq!(scaled, expected);
+    }
+}
+
+#[test]
+/// Check scaled color decode and region decode produce consistent RGB output.
+fn scaled_interleaved_baseline_color_decode_and_region_are_consistent() {
+    let image = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+
+    for scale in [JpegScale::Half, JpegScale::Quarter, JpegScale::Eighth] {
+        let options = DecoderOptions::default()
+            .jpeg_set_input_colorspace_override(InputColorspaceOverride::Force(ColorSpace::YCbCr))
+            .jpeg_set_scale(scale);
+        let mut decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+        let scaled = decoder.decode().unwrap();
+        let info = decoder.info().unwrap();
+        let scaled_width = (info.width as usize).div_ceil(scale.denominator());
+        let scaled_height = (info.height as usize).div_ceil(scale.denominator());
+        assert_eq!(scaled.len(), scaled_width * scaled_height * 3);
+        assert_eq!(decoder.decoded_output_bytes(), Some(scaled.len()));
+
+        let x = 3.min(scaled_width - 1);
+        let y = 4.min(scaled_height - 1);
+        let region = DecodeRegion {
+            x,
+            y,
+            width:  11.min(scaled_width - x),
+            height: 9.min(scaled_height - y)
+        };
+        let expected = crop_from_full(&scaled, scaled_width, 3, region);
+        let mut region_decoder =
+            JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+        let region_pixels = region_decoder
+            .decode_region(region, RegionDecodeMode::BestEffort)
+            .unwrap();
+
+        assert_eq!(region_pixels, expected);
+    }
+}
+
+#[test]
+/// Check scaled BGR/BGRA region decode is consistent with scaled full decode.
+fn scaled_interleaved_baseline_bgr_and_bgra_decode_regions_are_consistent() {
+    let image = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let scale = JpegScale::Quarter;
+
+    for colorspace in [ColorSpace::BGR, ColorSpace::BGRA] {
+        let options = DecoderOptions::default()
+            .jpeg_set_input_colorspace_override(InputColorspaceOverride::Force(ColorSpace::YCbCr))
+            .jpeg_set_out_colorspace(colorspace)
+            .jpeg_set_scale(scale);
+        let mut decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+        let scaled = decoder.decode().unwrap();
+        let info = decoder.info().unwrap();
+        let scaled_width = (info.width as usize).div_ceil(scale.denominator());
+        let scaled_height = (info.height as usize).div_ceil(scale.denominator());
+        let components = colorspace.num_components();
+        assert_eq!(scaled.len(), scaled_width * scaled_height * components);
+
+        let region = DecodeRegion {
+            x:      5,
+            y:      6,
+            width:  13,
+            height: 10
+        };
+        let expected = crop_from_full(&scaled, scaled_width, components, region);
+        let mut region_decoder =
+            JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+        let region_pixels = region_decoder
+            .decode_region(region, RegionDecodeMode::BestEffort)
+            .unwrap();
+
+        assert_eq!(region_pixels, expected);
+    }
+}
+
+#[test]
+/// Check scaled region decode matches cropping the scaled full image.
+fn scaled_region_decode_matches_scaled_full_decode_crop() {
+    let image = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
+    let options = DecoderOptions::default().jpeg_set_scale(JpegScale::Quarter);
+    let region = DecodeRegion {
+        x:      2,
+        y:      3,
+        width:  9,
+        height: 7
+    };
+
+    let mut full_decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+    let scaled = full_decoder.decode().unwrap();
+    let expected = crop_from_full(&scaled, 16, 3, region);
+
+    let mut region_decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+    let region_pixels = region_decoder
+        .decode_region(region, RegionDecodeMode::BestEffort)
+        .unwrap();
+    assert_eq!(region_pixels, expected);
+    assert_eq!(
+        region_decoder.decoded_output_bytes(),
+        Some(region.width * region.height * 3)
+    );
+}
+
+#[test]
+/// Check scaled decode reports stable scanlines in scaled output coordinates.
+fn scaled_decode_reports_scaled_stable_scanlines() {
+    let image = include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg");
+    let scale = JpegScale::Eighth;
+    let options = DecoderOptions::default().jpeg_set_scale(scale);
+    let mut decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+    decoder.decode_headers().unwrap();
+    let info = decoder.info().unwrap();
+    let scaled_width = (info.width as usize).div_ceil(scale.denominator());
+    let scaled_height = (info.height as usize).div_ceil(scale.denominator());
+    let expected_size = scaled_width * scaled_height * 3;
+    let mut out = vec![0; expected_size];
+
+    decoder.decode_into(&mut out).unwrap();
+
+    assert_eq!(decoder.decoded_output_bytes(), Some(expected_size));
+    assert_eq!(decoder.decoded_scanlines(), Some(scaled_height));
+}
+
+#[test]
+/// Check region decode rejects output buffers smaller than the region size.
+fn decode_region_into_rejects_small_output() {
+    let image = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let region = DecodeRegion {
+        x: 2,
+        y: 3,
+        width: 6,
+        height: 5,
+    };
+
+    let mut decoder = JpegDecoder::new(Cursor::new(image.as_slice()));
+    decoder.decode_headers().unwrap();
+    let required = decoder.region_output_buffer_size(region).unwrap();
+    let mut too_small = vec![0; required - 1];
+
+    assert!(decoder
+        .decode_region_into(region, RegionDecodeMode::BestEffort, &mut too_small)
+        .is_err());
+}
+
+#[test]
+/// Check empty and out-of-bounds regions are rejected.
+fn decode_region_rejects_empty_and_out_of_bounds_regions() {
+    let image = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let mut decoder = JpegDecoder::new(Cursor::new(image.as_slice()));
+    decoder.decode_headers().unwrap();
+
+    assert_eq!(
+        decoder.region_output_buffer_size(DecodeRegion {
+            x: 0,
+            y: 0,
+            width: 0,
+            height: 1
+        }),
+        None
+    );
+    assert_eq!(
+        decoder.region_output_buffer_size(DecodeRegion {
+            x: 15,
+            y: 15,
+            width: 2,
+            height: 1
+        }),
+        None
+    );
+}
+
+#[test]
+/// Check input colorspace override is applied after marker parsing.
+fn input_colorspace_override_is_applied_after_header_markers() {
+    let image = include_bytes!("../../../test-images/jpeg/four_components.jpg");
+    let options = DecoderOptions::default()
+        .jpeg_set_input_colorspace_override(InputColorspaceOverride::Force(ColorSpace::YCbCr));
+
+    let mut decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+    decoder.decode_headers().unwrap();
+
+    assert_eq!(decoder.input_colorspace(), Some(ColorSpace::YCbCr));
+    assert_eq!(
+        decoder.options().jpeg_get_input_colorspace_override(),
+        InputColorspaceOverride::Force(ColorSpace::YCbCr)
+    );
+}
+
+#[test]
+/// Check input colorspace override survives repeated decode calls.
+fn input_colorspace_override_survives_decode_into_replay() {
+    let image = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let options = DecoderOptions::default()
+        .jpeg_set_input_colorspace_override(InputColorspaceOverride::Force(ColorSpace::YCbCr));
+    let mut decoder = JpegDecoder::new_with_options(Cursor::new(image.as_slice()), options);
+
+    decoder.decode_headers().unwrap();
+    assert_eq!(decoder.input_colorspace(), Some(ColorSpace::YCbCr));
+
+    let mut first = vec![0; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut first).unwrap();
+    assert_eq!(decoder.input_colorspace(), Some(ColorSpace::YCbCr));
+
+    let mut replay = vec![0; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut replay).unwrap();
+
+    assert_eq!(decoder.input_colorspace(), Some(ColorSpace::YCbCr));
+    assert_eq!(replay, first);
+}
+
+#[test]
+/// Check split JPEG assembly patches SOF dimensions and appends EOI.
+fn assemble_split_jpeg_patches_sof_dimensions_and_appends_eoi() {
+    let header = [
+        0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01, 0x03
+    ];
+    let data = [0x11, 0x22, 0x33];
+    let mut out = vec![0xaa, 0xbb];
+
+    assemble_split_jpeg(
+        &header,
+        &data,
+        2,
+        JpegDimensions {
+            width:  513,
+            height: 258
+        },
+        &mut out
+    )
+    .unwrap();
+
+    assert_eq!(&out[..2], &[0xff, 0xd8]);
+    assert_eq!(&out[7..9], &258u16.to_be_bytes());
+    assert_eq!(&out[9..11], &513u16.to_be_bytes());
+    assert_eq!(&out[header.len()..header.len() + data.len()], &data);
+    assert!(out.ends_with(&[0xff, 0xd9]));
+}
+
+#[test]
+/// Check split JPEG assembly does not append a duplicate EOI marker.
+fn assemble_split_jpeg_does_not_duplicate_existing_eoi() {
+    let header = [
+        0xff, 0xd8, 0xff, 0xc2, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01, 0x03
+    ];
+    let data = [0x11, 0x22, 0xff, 0xd9];
+    let mut out = Vec::new();
+
+    assemble_split_jpeg(
+        &header,
+        &data,
+        2,
+        JpegDimensions {
+            width:  1,
+            height: 1
+        },
+        &mut out
+    )
+    .unwrap();
+
+    assert_eq!(&out[out.len() - 4..], &[0x11, 0x22, 0xff, 0xd9]);
+}
+
+#[test]
+/// Check split JPEG assembly rejects unsupported SOF offsets.
+fn assemble_split_jpeg_rejects_invalid_sof_offset() {
+    let header = [0xff, 0xd8, 0xff, 0xe0, 0x00, 0x02, 0x00, 0x00, 0x00];
+    let mut out = Vec::new();
+
+    assert!(assemble_split_jpeg(
+        &header,
+        &[],
+        2,
+        JpegDimensions {
+            width:  1,
+            height: 1
+        },
+        &mut out
+    )
+    .is_err());
+    assert!(out.is_empty());
+}
+
+#[test]
+/// Check split JPEG assembly rejects zero dimensions without mutating output.
+fn assemble_split_jpeg_rejects_zero_dimensions_without_mutating_output() {
+    let header = [
+        0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x01, 0x00, 0x01, 0x03
+    ];
+    let original = vec![0xaa, 0xbb, 0xcc];
+    let mut out = original.clone();
+
+    assert!(assemble_split_jpeg(
+        &header,
+        &[],
+        2,
+        JpegDimensions {
+            width:  0,
+            height: 1
+        },
+        &mut out
+    )
+    .is_err());
+    assert_eq!(out, original);
+
+    assert!(assemble_split_jpeg(
+        &header,
+        &[],
+        2,
+        JpegDimensions {
+            width:  1,
+            height: 0
+        },
+        &mut out
+    )
+    .is_err());
+    assert_eq!(out, original);
+}
+
+#[test]
+/// Check an assembled split JPEG decodes identically to the original fixture.
+fn assemble_split_jpeg_reassembled_stream_decodes_like_original() {
+    let image = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let sof_offset = find_marker(image, &[0xc0, 0xc1, 0xc2]).unwrap();
+    let entropy_start = sos_entropy_start(image).unwrap();
+    let original_without_eoi = image
+        .strip_suffix(&[0xff, 0xd9])
+        .expect("fixture should end with EOI");
+    let data = &original_without_eoi[entropy_start..];
+    let mut assembled = Vec::new();
+
+    assemble_split_jpeg(
+        &image[..entropy_start],
+        data,
+        sof_offset,
+        JpegDimensions {
+            width:  16,
+            height: 16
+        },
+        &mut assembled
+    )
+    .unwrap();
+
+    let mut original_decoder = JpegDecoder::new(Cursor::new(image.as_slice()));
+    let original_pixels = original_decoder.decode().unwrap();
+    let mut assembled_decoder = JpegDecoder::new(Cursor::new(assembled.as_slice()));
+    let assembled_pixels = assembled_decoder.decode().unwrap();
+
+    assert_eq!(assembled_decoder.info().unwrap().width, 16);
+    assert_eq!(assembled_decoder.info().unwrap().height, 16);
+    assert_eq!(assembled_pixels, original_pixels);
+}


### PR DESCRIPTION
This edit enables lower-level JPEG access that is needed by https://github.com/henriksson-lab/openslide-pure-rs.
This library is able to read tissue scanner images where one frequently need to be able to decode just part of a much larger image to get performance

Edit made with Codex, then cleaned up and manually inspected. But I confess to be no expert on JPEG at all so my audit is only for code smells; function was only verified more extensively by testing vs original C++ openslide code output, on some large tissue scanner datasets

- split JPEG assembly helper
- input colorspace override
- 1/2, 1/4, and 1/8 JPEG output scaling
- rectangular region decode API
- MCU-boundary-safe upsampling for segmented rows
- example and tests covering the new behavior

This works:
- cargo check -p zune-jpeg --examples
- cargo test -p zune-jpeg worker
- cargo test -p zune-jpeg --test openslide_api

Note:
I got a zune-bmp UEFI CI failure but it seems unrelated to this edit
