### PR TITLE
Resume progressive JPEG decoding after cancellation

### DIFF
--- a/crates/zune-jpeg/README.md
+++ b/crates/zune-jpeg/README.md
@@ -47,10 +47,11 @@ caller expects input to arrive incrementally; this records checkpoints during
 the first baseline Huffman scan attempt and can reduce replay work on the next
 retry.
 
-Fine-grained row checkpoints currently apply within baseline Huffman scan
-bodies, including baseline multi-SOS / non-interleaved images. Those images may
-still report no stable output rows until the later component scans have been
-decoded and final assembly has run.
+Incremental-EOF row checkpoints apply within baseline Huffman scan bodies.
+Progressive Huffman decoding uses the same row boundary for cooperative
+cancellation, while truncated progressive input keeps scan-start replay.
+Progressive and baseline multi-SOS images still report no stable output rows
+until every component scan has been decoded and final assembly has run.
 
 Scan checkpoints store only scalar resume state: stream position, next MCU
 row/column, restart countdown, SOS parameters, DC predictors, and bitstream
@@ -58,6 +59,10 @@ state. Coefficients for already-decoded component scans stay on the decoder
 across retries. For multi-SOS images this means a retry can continue inside the
 current component scan, then decode later component scans, but output rows are
 not considered stable until final assembly has all component data.
+
+Cooperative cancellation can also be retried on the same decoder and output
+buffer. Replace or clear the cancellation check before retrying; a check that
+remains cancelled will immediately yield `DecodeErrors::Cancelled` again.
 
 ```Rust
 use zune_core::bytestream::ZCursor;

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -90,7 +90,35 @@ pub(crate) struct ScanDecodeState {
     pub(crate) append_snapshot:     HeaderAppendStateSnapshot,
     pub(crate) sos_snapshot:        SosParamsSnapshot,
     pub(crate) header_snapshot:     ScanHeaderStateSnapshot,
-    pub(crate) scan_checkpoint:     Option<Box<ScanCheckpoint>>
+    pub(crate) scan_checkpoint:     Option<Box<ScanCheckpoint>>,
+    pub(crate) progressive_resume:  Option<ProgressiveResumeState>
+}
+
+/// Row boundary where a cancelled progressive decode can resume safely.
+#[derive(Clone, Copy)]
+pub(crate) enum ProgressiveResumePhase {
+    /// Resume entropy decoding in the current SOS scan.
+    Entropy {
+        next_row:   usize,
+        seen_scans: usize
+    },
+    /// Resume final IDCT, upsampling, and color conversion.
+    Finish {
+        next_row:      usize,
+        pixels_written: usize
+    }
+}
+
+/// Minimal progressive state not already retained by `JpegDecoder`.
+///
+/// SOS parameters, entropy tables, predictors, restart state, coefficients,
+/// and upsampling carry remain in their existing decoder-owned fields. A
+/// progressive resume therefore bypasses first-SOS replay in `decode_into`.
+#[derive(Clone, Copy)]
+pub(crate) struct ProgressiveResumeState {
+    pub(crate) phase:           ProgressiveResumePhase,
+    pub(crate) stream_position: usize,
+    pub(crate) bitstream_state: BitstreamStateSnapshot
 }
 
 /// SOS fields restored before replaying scan data.
@@ -415,7 +443,8 @@ where
             append_snapshot,
             sos_snapshot,
             header_snapshot,
-            scan_checkpoint: None
+            scan_checkpoint: None,
+            progressive_resume: None
         }));
         Ok(())
     }
@@ -490,6 +519,33 @@ where
     pub(crate) fn invalidate_scan_checkpoint(&mut self) {
         if let Some(state) = self.scan_state.as_mut() {
             state.scan_checkpoint = None;
+        }
+    }
+
+    pub(crate) fn progressive_resume(&self) -> Option<ProgressiveResumeState> {
+        self.scan_state
+            .as_deref()
+            .and_then(|state| state.progressive_resume)
+    }
+
+    pub(crate) fn checkpoint_progressive(
+        &mut self, phase: ProgressiveResumePhase, bitstream_state: BitstreamStateSnapshot
+    ) -> Result<(), DecodeErrors> {
+        let stream_position = self.stream_position()?;
+        if let Some(state) = self.scan_state.as_mut() {
+            let resume = ProgressiveResumeState {
+                phase,
+                stream_position,
+                bitstream_state
+            };
+            state.progressive_resume = Some(resume);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn clear_progressive_resume(&mut self) {
+        if let Some(state) = self.scan_state.as_mut() {
+            state.progressive_resume = None;
         }
     }
 
@@ -800,6 +856,8 @@ where
     /// closure over an `Arc<AtomicBool>` or a deadline). If it fires, decoding
     /// returns
     /// [`DecodeErrors::Cancelled`](crate::errors::DecodeErrors::Cancelled).
+    /// A cancelled decode can resume on the same decoder and output buffer.
+    /// Replace or clear a check that remains cancelled before retrying.
     /// Passing [`NeverCancel`](crate::NeverCancel) (or any check whose
     /// [`may_cancel`](crate::CancelCheck::may_cancel) is `false`) clears it; the
     /// default is no check, which costs a single predicted branch per poll.
@@ -1429,6 +1487,7 @@ where
             pixels_written:  usize,
             dc_predictions:  [(i32, i32); MAX_COMPONENTS]
         }
+        let progressive_resume = self.progressive_resume();
         let scan_plan = self.scan_state.as_deref().map(|state| ScanPlan {
             scan_start_position:   state.scan_start_position,
             outer_append_snapshot: state.append_snapshot,
@@ -1445,7 +1504,17 @@ where
                 }
             })
         });
-        if let Some(plan) = scan_plan {
+        if let Some(resume) = progressive_resume {
+            // Cooperative progressive cancellation happens only before an MCU
+            // row. The decoder still owns the exact current SOS, tables,
+            // predictors, restart state, coefficients, and upsampling carry,
+            // so restoring first-SOS state here would destroy the checkpoint.
+            self.stream.set_position(resume.stream_position)?;
+            self.pixels_decoded = match resume.phase {
+                ProgressiveResumePhase::Entropy { .. } => 0,
+                ProgressiveResumePhase::Finish { pixels_written, .. } => pixels_written
+            };
+        } else if let Some(plan) = scan_plan {
             let ScanPlan {
                 scan_start_position,
                 outer_append_snapshot,
@@ -1565,6 +1634,7 @@ where
                 );
                 if let Some(state) = self.scan_state.as_deref_mut() {
                     state.scan_checkpoint = None;
+                    state.progressive_resume = None;
                 }
                 self.pixels_decoded = expected_size;
                 Ok(())

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -57,10 +57,11 @@
 //! the first baseline Huffman scan attempt and can reduce replay work on the next
 //! retry.
 //!
-//! Fine-grained row checkpoints currently apply within baseline Huffman scan
-//! bodies, including baseline multi-SOS / non-interleaved images. Those images may
-//! still report no stable output rows until the later component scans have been
-//! decoded and final assembly has run.
+//! Incremental-EOF row checkpoints apply within baseline Huffman scan bodies.
+//! Progressive Huffman decoding uses the same row boundary for cooperative
+//! cancellation, while truncated progressive input keeps scan-start replay.
+//! Progressive and baseline multi-SOS images still report no stable output rows
+//! until every component scan has been decoded and final assembly has run.
 //!
 //! Scan checkpoints store only scalar resume state: stream position, next MCU
 //! row/column, restart countdown, SOS parameters, DC predictors, and bitstream
@@ -68,6 +69,10 @@
 //! across retries. For multi-SOS images this means a retry can continue inside the
 //! current component scan, then decode later component scans, but output rows are
 //! not considered stable until final assembly has all component data.
+//!
+//! Cooperative cancellation can also be retried on the same decoder and output
+//! buffer. Replace or clear the cancellation check before retrying; a check that
+//! remains cancelled will immediately yield `DecodeErrors::Cancelled` again.
 //!
 //! ```no_run
 //! use zune_core::bytestream::ZCursor;

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -17,9 +17,9 @@ use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::colorspace::ColorSpace;
 use zune_core::log::{error, trace, warn};
 
-use crate::bitstream::BitStream;
+use crate::bitstream::{BitStream, BitstreamStateSnapshot};
 use crate::components::SampleRatios;
-use crate::decoder::{JpegDecoder, MAX_COMPONENTS};
+use crate::decoder::{JpegDecoder, ProgressiveResumePhase, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
 use crate::headers::parse_sos;
 use crate::marker::Marker;
@@ -43,14 +43,41 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     pub(crate) fn decode_mcu_ycbcr_progressive<B: BitStream>(
         &mut self, pixels: &mut [u8],
     ) -> Result<(), DecodeErrors> {
+        let mut block = core::mem::take(&mut self.progressive_mcus_buffer);
+        let result = self.decode_mcu_ycbcr_progressive_inner::<B>(pixels, &mut block);
+
+        match &result {
+            Err(DecodeErrors::Cancelled) => {}
+            Err(error) if error.is_recoverable_eof() => {
+                self.clear_progressive_resume();
+                for component in &mut block {
+                    component.clear();
+                }
+            }
+            Err(_) | Ok(()) => {
+                self.clear_progressive_resume();
+                for component in &mut block {
+                    *component = Vec::new();
+                }
+            }
+        }
+
+        self.progressive_mcus_buffer = block;
+        result
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn decode_mcu_ycbcr_progressive_inner<B: BitStream>(
+        &mut self, pixels: &mut [u8], block: &mut [Vec<i16>; MAX_COMPONENTS],
+    ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
         let mut mcu_height;
-
-        // Progressive retries replay from scan start with a fresh buffer.
-        let mut block: [Vec<i16>; MAX_COMPONENTS] = [vec![], vec![], vec![], vec![]];
         let mut mcu_width;
-
-        let mut seen_scans = 1;
+        let resume = self.progressive_resume();
+        let mut seen_scans = match resume.map(|state| state.phase) {
+            Some(ProgressiveResumePhase::Entropy { seen_scans, .. }) => seen_scans,
+            _ => 1
+        };
 
         if self.input_colorspace == ColorSpace::Luma && self.is_interleaved {
             warn!("Grayscale image with down-sampled component, resetting component details");
@@ -89,20 +116,56 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         mcu_width *= 64;
 
-        // Refine scans read-modify-write coefficient data, so progressive
-        // recoverable EOF falls back to first-SOS replay.
+        // The decoder owns coefficient planes across cooperative cancellation.
+        // Recoverable EOF and hard errors clear them in the outer wrapper so a
+        // later retry keeps the established first-SOS replay behavior.
         for (i, comp) in self.components.iter().enumerate() {
             let len = mcu_width * comp.vertical_sample * comp.horizontal_sample * mcu_height;
-            block[i] = vec![0; len];
+            if resume.is_none() || block[i].len() != len {
+                block[i].clear();
+                block[i].resize(len, 0);
+            }
         }
 
-        // Progressive does not use per-RST checkpoints.
         let mut stream = B::new_progressive(self.succ_low, self.spec_start, self.spec_end);
 
+        if let Some(resume) = resume {
+            match resume.phase {
+                ProgressiveResumePhase::Entropy { .. } => {
+                    stream.restore_snapshot(resume.bitstream_state);
+                }
+                ProgressiveResumePhase::Finish {
+                    next_row,
+                    pixels_written
+                } => {
+                    return self.finish_progressive_decoding(
+                        block,
+                        pixels,
+                        next_row,
+                        pixels_written
+                    );
+                }
+            }
+        }
+
+        let (resume_row, resuming_scan) = match resume.map(|state| state.phase) {
+            Some(ProgressiveResumePhase::Entropy { next_row, .. }) => (next_row, true),
+            _ => (0, false)
+        };
+
         // there are multiple scans in the stream, this should resolve the first scan
-        let result = self.parse_entropy_coded_data(&mut stream, &mut block);
+        let result = self.parse_entropy_coded_data(
+            &mut stream,
+            block,
+            resume_row,
+            seen_scans,
+            resuming_scan
+        );
 
         if let Err(ref e) = result {
+            if matches!(e, DecodeErrors::Cancelled) {
+                return Err(DecodeErrors::Cancelled);
+            }
             // Always propagate ExhaustedData for incremental decoding support
             // — the caller can retry with more data.
             if e.is_recoverable_eof() {
@@ -116,9 +179,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             } else {
                 error!("{}", result.err().unwrap());
                 // Go process it and return as much as we can, exiting here
-                return self.finish_progressive_decoding(&block, pixels);
+                return self.finish_progressive_decoding(block, pixels, 0, 0);
             };
         }
+        self.clear_progressive_resume();
         if stream.overread_by() > 0 {
             return Err(DecodeErrors::ExhaustedData);
         }
@@ -134,6 +198,13 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         'eoi: while marker != Marker::EOI {
             match marker {
                 Marker::SOS => {
+                    seen_scans += 1;
+                    if seen_scans > self.options.jpeg_get_max_scans() {
+                        return Err(DecodeErrors::Format(format!(
+                            "Too many scans, exceeded limit of {}",
+                            self.options.jpeg_get_max_scans()
+                        )));
+                    }
                     parse_sos(self)?;
 
                     stream.update_progressive_params(
@@ -143,11 +214,15 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         self.spec_end,
                     );
                     // after every SOS, marker, parse data for that scan.
-                    let result = self.parse_entropy_coded_data(&mut stream, &mut block);
+                    let result =
+                        self.parse_entropy_coded_data(&mut stream, block, 0, seen_scans, false);
 
                     // Do not error out too fast, allows the decoder to continue as much as possible
                     // even after errors — but always propagate ExhaustedData.
                     if let Err(ref e) = result {
+                        if matches!(e, DecodeErrors::Cancelled) {
+                            return Err(DecodeErrors::Cancelled);
+                        }
                         if e.is_recoverable_eof() {
                             return Err(result.err().unwrap());
                         }
@@ -164,19 +239,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     if stream.overread_by() > 0 {
                         return Err(DecodeErrors::ExhaustedData);
                     }
+                    self.clear_progressive_resume();
                     // extract marker, might either indicate end of image or we continue
                     // scanning(hence the continue statement to determine).
                     match get_marker(&mut self.stream, &mut stream) {
                         Ok(marker_n) => {
                             marker = marker_n;
-                            seen_scans += 1;
-                            if seen_scans > self.options.jpeg_get_max_scans() {
-                                return Err(DecodeErrors::Format(format!(
-                                    "Too many scans, exceeded limit of {}",
-                                    self.options.jpeg_get_max_scans()
-                                )));
-                            }
-
                             stream.reset();
                             B::reset_arith_tables(&mut self.entropy_tables);
                             continue 'eoi;
@@ -221,7 +289,22 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
         }
 
-        self.finish_progressive_decoding(&block, pixels)
+        self.finish_progressive_decoding(block, pixels, 0, 0)
+    }
+
+    fn checkpoint_progressive_entropy<B: BitStream>(
+        &mut self, stream: &B, next_row: usize, seen_scans: usize
+    ) -> Result<(), DecodeErrors> {
+        if B::supports_mcu_checkpoint() {
+            self.checkpoint_progressive(
+                ProgressiveResumePhase::Entropy {
+                    next_row,
+                    seen_scans
+                },
+                stream.snapshot_state()
+            )?;
+        }
+        Ok(())
     }
 
     /// Reset progressive parameters
@@ -238,14 +321,18 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
     /// Parse a progressive scan's entropy-coded data into `buffer`.
     ///
-    /// Progressive scans always start at MCU `(0, 0)` — per-RST checkpoints
-    /// are not recorded for progressive (refine passes do read-modify-write
-    /// on `buffer`, so mid-scan resume would re-apply partial deltas).
+    /// Progressive Huffman scans can resume at a completed MCU-row boundary.
+    /// A row being decoded is never checkpointed mid-mutation, so refinement
+    /// deltas are not applied twice. Arithmetic scans retain scan-start replay
+    /// because their statistical context is not checkpoint-safe.
     #[allow(clippy::too_many_lines, clippy::cast_sign_loss)]
     fn parse_entropy_coded_data<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        start_row: usize, seen_scans: usize, resuming_scan: bool,
     ) -> Result<(), DecodeErrors> {
-        self.reset_prog_params(stream);
+        if !resuming_scan {
+            self.reset_prog_params(stream);
+        }
 
         if usize::from(self.num_scans) > self.input_colorspace.num_components() {
             return Err(DecodeErrors::Format(format!(
@@ -273,15 +360,39 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // Dispatch depending on type
             if self.spec_start == 0 {
                 if self.succ_high == 0 {
-                    self.parse_dc_first_non_interleaved(stream, buffer, k)?;
+                    self.parse_dc_first_non_interleaved(
+                        stream,
+                        buffer,
+                        k,
+                        start_row,
+                        seen_scans
+                    )?;
                 } else {
-                    self.parse_dc_refine_non_interleaved(stream, buffer, k)?;
+                    self.parse_dc_refine_non_interleaved(
+                        stream,
+                        buffer,
+                        k,
+                        start_row,
+                        seen_scans
+                    )?;
                 }
             } else {
                 if self.succ_high == 0 {
-                    self.parse_ac_first_non_interleaved(stream, buffer, k)?;
+                    self.parse_ac_first_non_interleaved(
+                        stream,
+                        buffer,
+                        k,
+                        start_row,
+                        seen_scans
+                    )?;
                 } else {
-                    self.parse_ac_refine_non_interleaved(stream, buffer, k)?;
+                    self.parse_ac_refine_non_interleaved(
+                        stream,
+                        buffer,
+                        k,
+                        start_row,
+                        seen_scans
+                    )?;
                 }
             }
         } else {
@@ -304,9 +415,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             if self.succ_high == 0 {
-                self.parse_dc_first_interleaved(stream, buffer)?;
+                self.parse_dc_first_interleaved(stream, buffer, start_row, seen_scans)?;
             } else {
-                self.parse_dc_refine_interleaved(stream, buffer)?;
+                self.parse_dc_refine_interleaved(stream, buffer, start_row, seen_scans)?;
             }
         }
         Ok(())
@@ -324,14 +435,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_dc_first_non_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        start_row: usize, seen_scans: usize,
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let dc_pos = self.components[k].dc_huff_table /MAX_COMPONENTS;
         let width_stride = self.components[k].width_stride / 8;
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        for i in start_row..mcu_height {
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_entropy(stream, i, seen_scans)?;
                 return Err(DecodeErrors::Cancelled);
             }
             for j in 0..mcu_width {
@@ -360,14 +473,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_dc_refine_non_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        start_row: usize, seen_scans: usize,
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let width_stride = self.components[k].width_stride / 8;
         let component_buffer = &mut buffer[k];
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        for i in start_row..mcu_height {
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_entropy(stream, i, seen_scans)?;
                 return Err(DecodeErrors::Cancelled);
             }
             for j in 0..mcu_width {
@@ -386,14 +501,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_ac_first_non_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        start_row: usize, seen_scans: usize,
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
         let component_buffer_data = &mut buffer[k];
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        for i in start_row..mcu_height {
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_entropy(stream, i, seen_scans)?;
                 return Err(DecodeErrors::Cancelled);
             }
             for j in 0..mcu_width {
@@ -422,6 +539,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_ac_refine_non_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        start_row: usize, seen_scans: usize,
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
@@ -429,8 +547,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let width_stride = self.components[k].width_stride / 8;
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        for i in start_row..mcu_height {
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_entropy(stream, i, seen_scans)?;
                 return Err(DecodeErrors::Cancelled);
             }
             for j in 0..mcu_width {
@@ -453,10 +572,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_dc_first_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        start_row: usize, seen_scans: usize,
     ) -> Result<(), DecodeErrors> {
         let mut cancel = self.cancel_debounced(self.mcu_x);
-        for i in 0..self.mcu_y {
+        for i in start_row..self.mcu_y {
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_entropy(stream, i, seen_scans)?;
                 return Err(DecodeErrors::Cancelled);
             }
             for j in 0..self.mcu_x {
@@ -495,10 +616,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_dc_refine_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        start_row: usize, seen_scans: usize,
     ) -> Result<(), DecodeErrors> {
         let mut cancel = self.cancel_debounced(self.mcu_x);
-        for i in 0..self.mcu_y {
+        for i in start_row..self.mcu_y {
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_entropy(stream, i, seen_scans)?;
                 return Err(DecodeErrors::Cancelled);
             }
             for j in 0..self.mcu_x {
@@ -631,6 +754,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::needless_range_loop, clippy::cast_sign_loss)]
     fn finish_progressive_decoding(
         &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        start_row: usize, mut pixels_written: usize,
     ) -> Result<(), DecodeErrors> {
         // This function is complicated because we need to replicate
         // the function in mcu.rs
@@ -693,18 +817,26 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 let len = comp.width_stride * comp.vertical_sample * 8;
 
                 comp.needed = true;
-                comp.raw_coeff = vec![0; len];
+                if start_row == 0 || comp.raw_coeff.len() != len {
+                    comp.raw_coeff.clear();
+                    comp.raw_coeff.resize(len, 0);
+                }
             } else {
                 comp.needed = false;
             }
         }
 
-        let mut pixels_written = 0;
-
         // dequantize, idct and color convert.
         let mut cancel = self.cancel_debounced(self.mcu_x);
-        for i in 0..mcu_height {
+        for i in start_row..mcu_height {
             if cancel.is_cancelled() {
+                self.checkpoint_progressive(
+                    ProgressiveResumePhase::Finish {
+                        next_row: i,
+                        pixels_written
+                    },
+                    BitstreamStateSnapshot::None
+                )?;
                 return Err(DecodeErrors::Cancelled);
             }
             'component: for (position, component) in &mut self.components.iter_mut().enumerate() {
@@ -782,6 +914,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 &mut pixels_written,
                 &mut upsampler_scratch_space,
             )?;
+            self.pixels_decoded = pixels_written;
         }
 
         trace!("Finished decoding image");
@@ -891,6 +1024,13 @@ mod tests {
 
         let mut decoder = JpegDecoder::new(ZCursor::new(JPEG));
         let pixels = decoder.decode().unwrap();
+        assert!(
+            decoder
+                .progressive_mcus_buffer
+                .iter()
+                .all(|component| component.capacity() == 0),
+            "successful decode should release progressive coefficient buffers"
+        );
         let (w, h) = decoder.dimensions().unwrap();
         assert_eq!((w, h), (16, 16));
 

--- a/crates/zune-jpeg/tests/cancel.rs
+++ b/crates/zune-jpeg/tests/cancel.rs
@@ -4,6 +4,7 @@
  * This software is free software; You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
+use std::io::{BufRead, Cursor, Read, Seek, SeekFrom};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
@@ -14,6 +15,41 @@ use zune_jpeg::{CancelCheck, JpegDecoder, NeverCancel};
 const BASELINE: &[u8] = include_bytes!("../../../test-images/jpeg/medium_no_samp_2500x1786.jpg");
 const PROGRESSIVE: &[u8] =
     include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
+const PROGRESSIVE_GRAYSCALE: &[u8] =
+    include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
+#[cfg(feature = "arith")]
+const PROGRESSIVE_ARITHMETIC: &[u8] =
+    include_bytes!("../../../test-images/jpeg/arith/prog.jpg");
+
+struct PositionCountingReader<'a> {
+    inner:           Cursor<&'a [u8]>,
+    position_queries: Arc<AtomicUsize>
+}
+
+impl Read for PositionCountingReader<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buffer)
+    }
+}
+
+impl BufRead for PositionCountingReader<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    fn consume(&mut self, amount: usize) {
+        self.inner.consume(amount);
+    }
+}
+
+impl Seek for PositionCountingReader<'_> {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        if matches!(position, SeekFrom::Current(0)) {
+            self.position_queries.fetch_add(1, Ordering::Relaxed);
+        }
+        self.inner.seek(position)
+    }
+}
 
 /// Returns a check that cancels after `n` polls.
 fn cancel_after(n: usize) -> impl Fn() -> bool + Send + Sync {
@@ -43,6 +79,74 @@ fn decode_with_interval(
     decoder.decode()
 }
 
+fn decode_with_repeated_cancellation(data: &[u8], polls_per_attempt: usize) -> Vec<u8> {
+    const MAX_ATTEMPTS: usize = 128;
+
+    let expected = JpegDecoder::new(ZCursor::new(data)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    decoder.set_incremental_mode(true);
+    decoder.set_cancel_interval(1);
+
+    let mut out = vec![0; decoder.output_buffer_size().unwrap()];
+    let mut cancellations = 0;
+    let mut stable_bytes = 0;
+
+    for _ in 0..MAX_ATTEMPTS {
+        decoder.set_cancel(cancel_after(polls_per_attempt));
+
+        match decoder.decode_into(&mut out) {
+            Ok(()) => {
+                assert!(cancellations > 1, "fixture should require multiple resumptions");
+                if let Some(index) = out.iter().zip(&expected).position(|(a, b)| a != b) {
+                    panic!(
+                        "resumed output first differs at byte {index}: actual={}, expected={}",
+                        out[index], expected[index]
+                    );
+                }
+                return out;
+            }
+            Err(DecodeErrors::Cancelled) => {
+                cancellations += 1;
+                let next_stable = decoder.decoded_output_bytes().unwrap();
+                assert!(
+                    next_stable >= stable_bytes,
+                    "stable output must not move backwards across resumptions"
+                );
+                stable_bytes = next_stable;
+            }
+            Err(error) => panic!("unexpected decode error after {cancellations} yields: {error:?}")
+        }
+    }
+
+    panic!("decode did not progress after {MAX_ATTEMPTS} cancellation resumptions");
+}
+
+fn decode_after_one_cancellation(data: &[u8], polls_before_cancel: usize) -> Vec<u8> {
+    let expected = JpegDecoder::new(ZCursor::new(data)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    decoder.set_incremental_mode(true);
+    decoder.set_cancel_interval(1);
+
+    let mut out = vec![0; decoder.output_buffer_size().unwrap()];
+    decoder.set_cancel(cancel_after(polls_before_cancel));
+    assert!(matches!(
+        decoder.decode_into(&mut out),
+        Err(DecodeErrors::Cancelled)
+    ));
+
+    decoder.set_cancel(NeverCancel);
+    decoder.decode_into(&mut out).unwrap();
+    if let Some(index) = out.iter().zip(&expected).position(|(a, b)| a != b) {
+        panic!(
+            "output after cancellation at poll {polls_before_cancel} first differs at byte {index}: actual={}, expected={}",
+            out[index], expected[index]
+        );
+    }
+    out
+}
+
 #[test]
 fn never_cancelling_matches_plain_decode() {
     for data in [BASELINE, PROGRESSIVE] {
@@ -52,6 +156,17 @@ fn never_cancelling_matches_plain_decode() {
         assert_eq!(plain, with_none);
         assert_eq!(plain, with_live);
     }
+}
+
+#[test]
+fn incremental_progressive_without_cancellation_matches_plain_decode() {
+    let expected = JpegDecoder::new(ZCursor::new(PROGRESSIVE)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(PROGRESSIVE));
+    decoder.decode_headers().unwrap();
+    decoder.set_incremental_mode(true);
+    let mut out = vec![0; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut out).unwrap();
+    assert_eq!(out, expected);
 }
 
 #[test]
@@ -88,6 +203,29 @@ fn interval_does_not_change_output() {
 }
 
 #[test]
+fn non_firing_progressive_cancel_does_not_query_position_per_row() {
+    let position_queries = Arc::new(AtomicUsize::new(0));
+    let reader = PositionCountingReader {
+        inner: Cursor::new(PROGRESSIVE),
+        position_queries: Arc::clone(&position_queries)
+    };
+    let mut decoder = JpegDecoder::new(reader);
+    decoder.decode_headers().unwrap();
+    let queries_after_headers = position_queries.load(Ordering::Relaxed);
+    decoder.set_cancel(cancel_after(usize::MAX));
+    decoder.set_cancel_interval(1);
+
+    let mut out = vec![0; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut out).unwrap();
+
+    assert_eq!(
+        position_queries.load(Ordering::Relaxed),
+        queries_after_headers,
+        "a non-firing cancel check must not query the reader position"
+    );
+}
+
+#[test]
 fn fine_interval_still_cancels() {
     // Polling as often as the loop allows (interval 1 -> once per MCU row) must
     // still surface a cancel on the very first poll.
@@ -95,4 +233,59 @@ fn fine_interval_still_cancels() {
         let err = decode_with_interval(data, cancel_after(0), 1).unwrap_err();
         assert!(matches!(err, DecodeErrors::Cancelled));
     }
+}
+
+#[test]
+fn baseline_decode_resumes_after_repeated_cancellation() {
+    decode_with_repeated_cancellation(BASELINE, 32);
+}
+
+#[test]
+fn progressive_decode_resumes_after_repeated_cancellation() {
+    for data in [PROGRESSIVE, PROGRESSIVE_GRAYSCALE] {
+        decode_with_repeated_cancellation(data, 32);
+    }
+}
+
+#[test]
+fn progressive_decode_resumes_after_one_cancellation() {
+    for polls in [0, 1, 8, 32, 128, 512] {
+        decode_after_one_cancellation(PROGRESSIVE, polls);
+    }
+}
+
+#[test]
+fn progressive_scan_limit_survives_repeated_cancellation() {
+    let expected = JpegDecoder::new(ZCursor::new(PROGRESSIVE)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(PROGRESSIVE));
+    decoder.set_options(decoder.options().jpeg_set_max_scans(8));
+    decoder.decode_headers().unwrap();
+    decoder.set_incremental_mode(true);
+    decoder.set_cancel_interval(1);
+    let mut out = vec![0; decoder.output_buffer_size().unwrap()];
+
+    for _ in 0..128 {
+        decoder.set_cancel(cancel_after(32));
+        match decoder.decode_into(&mut out) {
+            Err(DecodeErrors::Cancelled) => {}
+            Err(DecodeErrors::Format(message)) => {
+                assert!(message.contains("Too many scans"));
+                decoder.set_options(decoder.options().jpeg_set_max_scans(100));
+                decoder.set_cancel(NeverCancel);
+                decoder.decode_into(&mut out).unwrap();
+                assert_eq!(out, expected, "hard-error cleanup must permit exact replay");
+                return;
+            }
+            Err(error) => panic!("unexpected decode error: {error:?}"),
+            Ok(()) => panic!("cancellation must not bypass the progressive scan limit")
+        }
+    }
+
+    panic!("decode did not reach the progressive scan limit");
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn progressive_arithmetic_replays_safely_after_cancellation() {
+    decode_after_one_cancellation(PROGRESSIVE_ARITHMETIC, 32);
 }


### PR DESCRIPTION
## Summary

- resume progressive Huffman entropy decoding at safe MCU-row boundaries after cooperative cancellation
- resume final IDCT, upsampling, and color conversion without rewriting completed output rows
- preserve progressive scan-limit accounting across repeated yields and retain scan-start replay for arithmetic JPEGs
- release coefficient memory after success or hard failure while retaining capacity for recoverable EOF replay

## Compatibility

- no public API, C ABI, dependency, or default-behavior changes
- one-shot decoding remains deterministic
- callers retry with the same decoder and output buffer after replacing or clearing a fired cancellation check

## Verification

- `cargo test -p zune-jpeg`
- `cargo test -p zune-jpeg --features arith`
- `cargo check -p zune-jpeg --no-default-features`
- `cargo clippy -p zune-jpeg --all-targets` (patch introduces no warnings; existing warnings remain in `zune-core/src/bytestream/reader/no_std_readers.rs` and `zune-jpeg/src/mcu.rs`)
- exact pixel parity after one and repeated cancellations across color and grayscale progressive fixtures
- arithmetic-progressive cancellation replay parity
- scan-limit enforcement after repeated cancellations
- instrumented reader proves a non-firing cancellation check performs no per-row position queries

## Repository baseline notes

Repository-wide formatting currently reports unrelated pre-existing drift, and strict Clippy is blocked by a duplicate pre-existing lint attribute in `zune-core`. This PR does not modify those files.
