### PR TITLE
fix(core): make no-op log macros expand to a valid expression

### DIFF
--- a/crates/zune-core/src/log.rs
+++ b/crates/zune-core/src/log.rs
@@ -41,14 +41,24 @@ macro_rules! __log_enabled {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __error {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __error {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 //
@@ -58,14 +68,24 @@ macro_rules! __error {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __warn {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __warn {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 //
@@ -75,14 +95,24 @@ macro_rules! __warn {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __info {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __info {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 //
@@ -92,14 +122,24 @@ macro_rules! __info {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __debug {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __debug {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 //
@@ -109,12 +149,52 @@ macro_rules! __debug {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __trace {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
 }
 
 #[cfg(not(feature = "std"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __trace {
-    ($($arg:tt)+) => {};
+    ($($arg:tt)+) => {{
+        // Expand to a block so the macro is usable in expression position.
+        // `{}` alone expands to *nothing*, which is a hard error for callers
+        // that use the macro as a trailing expression.
+        let _ = ::core::format_args!($($arg)+);
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::log::{debug, error, info, trace, warn};
+
+    /// The no-op logging macros must expand to a valid expression of type `()`,
+    /// not to nothing at all.
+    ///
+    /// Downstream crates call these as the trailing expression of a block, e.g.
+    /// `else { warn!("..") }`. A macro with an empty transcriber still works as
+    /// a statement, so this crate keeps compiling standalone and the breakage
+    /// only shows up in dependents.
+    #[test]
+    fn macros_expand_in_expression_position() {
+        let value = 42;
+
+        let _: () = { error!("error {}", value) };
+        let _: () = { warn!("warn {}", value) };
+        let _: () = { info!("info {}", value) };
+        let _: () = { debug!("debug {}", value) };
+        let _: () = { trace!("trace {}", value) };
+    }
+
+    /// Statement position must keep working too.
+    #[test]
+    fn macros_expand_in_statement_position() {
+        warn!("no args");
+        warn!("with args {} {:?}", 1, "two");
+    }
 }


### PR DESCRIPTION
Fixes #423.

## Problem

The no-op logging macros in `zune-core` use an empty transcriber:

```rust
macro_rules! __warn {
    ($($arg:tt)+) => {};
}
```

The braces there are the macro_rules! delimiter, not the expansion body, so
the macro expands to nothing rather than to an empty block. Expanding to
nothing is still valid in statement position, which is why zune-core compiles
standalone and cargo publish's verify build passes — the breakage only appears
in dependents that call the macro as a trailing expression:

```log
error: macro expansion ends with an incomplete expression: expected expression
  --> zune-jpeg-0.5.15/src/mcu_prog.rs:463:17
```

zune-jpeg depends on zune-core = "0.5.1", so publishing 0.5.2 pulled the
change into every existing 0.5.15 build automatically. This currently breaks
downstream consumers including egui and slint.

All five macros (__error, __warn, __info, __debug, __trace) are
affected, in both the std and not(std) branches, so no feature combination
avoids it.

Fix

Expand to a block instead:

```rust
macro_rules! __warn {
    ($($arg:tt)+) => {{
        let _ = ::core::format_args!($($arg)+);
    }};
}
```

{{ .. }} gives a real block expression of type (), valid in both expression
and statement position. Using let _ = format_args!(..) rather than a bare
{{}} additionally keeps the arguments type-checked and marked as used, so
downstream values referenced only inside a log call don't trigger
unused_variables. This matches what the log crate does for its disabled
macros, and works under no_std.

Tests

Added regression tests in log.rs covering expression position (let _: () = { warn!("..") };) and statement position.

Verified:
- cargo test -p zune-core --lib — passes
- cargo build -p zune-core --no-default-features — passes (no_std)
- cargo check --workspace — clean
- Unmodified zune-jpeg 0.5.15 from crates.io built against this branch via
[patch.crates-io] — compiles, confirming the fix resolves #423 without any
change to zune-jpeg

Note on release

Merging this doesn't unbreak users on crates.io by itself, since they resolve
zune-core from the registry. A zune-core 0.5.3 release (and/or yanking
0.5.2) is needed for the fix to actually reach them.

Hope this will help.