### PR TITLE
Support lossless Huffman images for Chromium parity

### DIFF
--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -1335,11 +1335,17 @@ where
                 parse_start_of_frame(marker, self)?;
                 self.is_progressive = is_progressive;
             }
-            Marker::SOF(3) => {
-                trace!("Image encoding scheme =`Lossless Huffman`");
-                parse_start_of_frame(SOFMarkers::LosslessHuffman, self)?;
+            Marker::SOF(3 | 11) => {
+                let (marker, is_arithmetic) = match m {
+                    Marker::SOF(3) => (SOFMarkers::LosslessHuffman, false),
+                    Marker::SOF(11) => (SOFMarkers::LosslessArithmetic, true),
+                    _ => unreachable!()
+                };
+
+                trace!("Image encoding scheme =`{marker:?}`");
+                parse_start_of_frame(marker, self)?;
                 self.is_progressive = false;
-                self.is_arithmetic = false;
+                self.is_arithmetic = is_arithmetic;
             }
             #[cfg(feature = "arith")]
             Marker::SOF(9..=10) => {
@@ -1614,10 +1620,13 @@ where
     }
 
     fn ensure_supported_encoding(&self) -> Result<(), DecodeErrors> {
-        if self.info.sof == SOFMarkers::LosslessHuffman {
-            return Err(DecodeErrors::Unsupported(
-                UnsupportedSchemes::LosslessHuffman
-            ));
+        let unsupported = match self.info.sof {
+            SOFMarkers::LosslessHuffman => Some(UnsupportedSchemes::LosslessHuffman),
+            SOFMarkers::LosslessArithmetic => Some(UnsupportedSchemes::LosslessArithmetic),
+            _ => None
+        };
+        if let Some(unsupported) = unsupported {
+            return Err(DecodeErrors::Unsupported(unsupported));
         }
         if self.info.pixel_density == 12 {
             return Err(DecodeErrors::FormatStatic(

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -728,7 +728,7 @@ where
     /// See DecodeErrors for an explanation
     pub fn decode(&mut self) -> Result<Vec<u8>, DecodeErrors> {
         self.decode_headers()?;
-        self.ensure_supported_sample_precision()?;
+        self.ensure_supported_encoding()?;
 
         if self.expects_dnl {
             // Height is unknown until DNL is encountered during entropy
@@ -1335,6 +1335,12 @@ where
                 parse_start_of_frame(marker, self)?;
                 self.is_progressive = is_progressive;
             }
+            Marker::SOF(3) => {
+                trace!("Image encoding scheme =`Lossless Huffman`");
+                parse_start_of_frame(SOFMarkers::LosslessHuffman, self)?;
+                self.is_progressive = false;
+                self.is_arithmetic = false;
+            }
             #[cfg(feature = "arith")]
             Marker::SOF(9..=10) => {
                 // choose marker
@@ -1607,7 +1613,12 @@ where
         };
     }
 
-    fn ensure_supported_sample_precision(&self) -> Result<(), DecodeErrors> {
+    fn ensure_supported_encoding(&self) -> Result<(), DecodeErrors> {
+        if self.info.sof == SOFMarkers::LosslessHuffman {
+            return Err(DecodeErrors::Unsupported(
+                UnsupportedSchemes::LosslessHuffman
+            ));
+        }
         if self.info.pixel_density == 12 {
             return Err(DecodeErrors::FormatStatic(
                 "12-bit JPEG pixel decoding is not supported"
@@ -1868,7 +1879,7 @@ where
             self.decode_headers_internal()?;
         }
 
-        self.ensure_supported_sample_precision()?;
+        self.ensure_supported_encoding()?;
 
         let expected_size = self.output_buffer_size().unwrap();
 

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -173,7 +173,13 @@ where
             // symbols in increasing code length
             let mut symbols = [0; 256];
             cursor.read_exact(&mut symbols[0..(symbols_sum as usize)])?;
-            let table = HuffmanTable::new(&num_symbols, symbols, dc_or_ac == 0, is_progressive)?;
+            let table = if dc_or_ac == 0
+                && (!decoder.seen_sof || decoder.info.sof.is_lossless())
+            {
+                HuffmanTable::new_lossless(&num_symbols, symbols)?
+            } else {
+                HuffmanTable::new(&num_symbols, symbols, dc_or_ac == 0, is_progressive)?
+            };
             new_tables.push((dc_or_ac, index, table));
         }
         if cursor.remaining() > 0 {
@@ -340,20 +346,30 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
         ));
     }
     with_marker_body(img, |img, mut cursor| {
+        let dc_symbol_limit = if sof.is_lossless() { 16 } else { 15 };
+        for table in img.entropy_tables.dc_huffman.iter().flatten() {
+            table.validate_dc_symbol_limit(dc_symbol_limit)?;
+        }
+
         // Body length came from a u16 length field minus 2; +2 round-trips it.
         #[allow(clippy::cast_possible_truncation)]
         let length = (cursor.body().len() + 2) as u16;
         // Pixel decoding remains 8-bit only, but Huffman-coded 12-bit frame
-        // headers are useful to callers that inspect image metadata.
+        // and lossless frame headers are useful to callers that inspect image
+        // metadata.
         let dt_precision = cursor.read_u8()?;
 
-        let supported_header_precision = dt_precision == 8
-            || (dt_precision == 12
+        let supported_header_precision = if sof.is_lossless() {
+            (2..=16).contains(&dt_precision)
+        } else {
+            dt_precision == 8
+                || (dt_precision == 12
                 && matches!(
                     sof,
                     SOFMarkers::ExtendedSequentialHuffman
                         | SOFMarkers::ProgressiveDctHuffman
-                ));
+                ))
+        };
         if !supported_header_precision {
             return Err(DecodeErrors::SofError(format!(
                 "Unsupported {dt_precision}-bit sample precision for {sof:?}"
@@ -443,6 +459,44 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
     })
 }
 
+fn validate_scan_parameters(
+    is_lossless: bool, precision: u8, spec_start: u8, spec_end: u8, succ_high: u8, succ_low: u8
+) -> Result<(), DecodeErrors> {
+    if is_lossless {
+        if !(1..=7).contains(&spec_start)
+            || spec_end != 0
+            || succ_high != 0
+            || succ_low >= precision
+        {
+            return Err(DecodeErrors::SosError(format!(
+                "Invalid lossless scan parameters: predictor={spec_start}, Se={spec_end}, Ah={succ_high}, Pt={succ_low}"
+            )));
+        }
+    } else {
+        if spec_end > 63 {
+            return Err(DecodeErrors::SosError(format!(
+                "Invalid Se parameter {spec_end}, range should be 0-63"
+            )));
+        }
+        if succ_low > 13 {
+            return Err(DecodeErrors::SosError(format!(
+                "Invalid Al parameter {succ_low}, range should be 0-13"
+            )));
+        }
+    }
+    if spec_start > 63 {
+        return Err(DecodeErrors::SosError(format!(
+            "Invalid Ss parameter {spec_start}, range should be 0-63"
+        )));
+    }
+    if succ_high > 13 {
+        return Err(DecodeErrors::SosError(format!(
+            "Invalid Ah parameter {succ_high}, range should be 0-13"
+        )));
+    }
+    Ok(())
+}
+
 /// Parse a start of scan data
 pub(crate) fn parse_sos<T: ZByteReaderTrait>(
     image: &mut JpegDecoder<T>
@@ -526,26 +580,14 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
         let succ_high = bit_approx >> 4;
         let succ_low = bit_approx & 0xF;
 
-        if spec_end > 63 {
-            return Err(DecodeErrors::SosError(format!(
-                "Invalid Se parameter {spec_end}, range should be 0-63"
-            )));
-        }
-        if spec_start > 63 {
-            return Err(DecodeErrors::SosError(format!(
-                "Invalid Ss parameter {spec_start}, range should be 0-63"
-            )));
-        }
-        if succ_high > 13 {
-            return Err(DecodeErrors::SosError(format!(
-                "Invalid Ah parameter {succ_high}, range should be 0-13"
-            )));
-        }
-        if succ_low > 13 {
-            return Err(DecodeErrors::SosError(format!(
-                "Invalid Al parameter {succ_low}, range should be 0-13"
-            )));
-        }
+        validate_scan_parameters(
+            image.info.sof.is_lossless(),
+            image.info.pixel_density,
+            spec_start,
+            spec_end,
+            succ_high,
+            succ_low
+        )?;
 
         // Commit phase: all reads and validations succeeded.
         image.num_scans = ns;

--- a/crates/zune-jpeg/src/huffman.rs
+++ b/crates/zune-jpeg/src/huffman.rs
@@ -51,6 +51,26 @@ impl HuffmanTable {
     pub fn new(
         codes: &[u8; 17], values: [u8; 256], is_dc: bool, is_progressive: bool
     ) -> Result<HuffmanTable, DecodeErrors> {
+        Self::new_with_dc_symbol_limit(codes, values, is_dc, is_progressive, 15)
+    }
+
+    pub(crate) fn new_lossless(
+        codes: &[u8; 17], values: [u8; 256]
+    ) -> Result<HuffmanTable, DecodeErrors> {
+        Self::new_with_dc_symbol_limit(codes, values, true, false, 16)
+    }
+
+    pub(crate) fn validate_dc_symbol_limit(&self, limit: u8) -> Result<(), DecodeErrors> {
+        if self.values.iter().any(|&symbol| symbol > limit) {
+            return Err(DecodeErrors::HuffmanDecode("Bad Huffman Table".to_string()));
+        }
+        Ok(())
+    }
+
+    fn new_with_dc_symbol_limit(
+        codes: &[u8; 17], values: [u8; 256], is_dc: bool, is_progressive: bool,
+        dc_symbol_limit: u8
+    ) -> Result<HuffmanTable, DecodeErrors> {
         let too_long_code = (i32::from(HUFF_LOOKAHEAD) + 1) << HUFF_LOOKAHEAD;
         let mut p = HuffmanTable {
             maxcode: [0; 18],
@@ -60,7 +80,7 @@ impl HuffmanTable {
             ac_lookup: None
         };
 
-        p.make_derived_table(is_dc, is_progressive, codes)?;
+        p.make_derived_table(is_dc, is_progressive, codes, dc_symbol_limit)?;
 
         Ok(p)
     }
@@ -87,7 +107,7 @@ impl HuffmanTable {
         clippy::explicit_counter_loop,
     )]
     fn make_derived_table(
-        &mut self, is_dc: bool, _is_progressive: bool, bits: &[u8; 17]
+        &mut self, is_dc: bool, _is_progressive: bool, bits: &[u8; 17], dc_symbol_limit: u8
     ) -> Result<(), DecodeErrors> {
         // build a list of code size
         let mut huff_size = [0; 257];
@@ -243,7 +263,7 @@ impl HuffmanTable {
             for i in 0..num_symbols {
                 let sym = self.values[i];
 
-                if sym > 15 {
+                if sym > dc_symbol_limit {
                     return Err(DecodeErrors::HuffmanDecode("Bad Huffman Table".to_string()));
                 }
             }

--- a/crates/zune-jpeg/tests/metadata.rs
+++ b/crates/zune-jpeg/tests/metadata.rs
@@ -64,6 +64,35 @@ fn lossless_header(precision: u8, sampling: u8, quantization_table: u8) -> Vec<u
     ]
 }
 
+fn lossless_arithmetic_header(component_count: u8, interleaved: bool) -> Vec<u8> {
+    let mut data = vec![0xFF, 0xD8, 0xFF, 0xCB]; // SOI, SOF11
+    let sof_length = 8 + 3 * u16::from(component_count);
+    data.extend_from_slice(&sof_length.to_be_bytes());
+    data.extend_from_slice(&[8, 0, 32, 0, 32, component_count]);
+    for component in 1..=component_count {
+        data.extend_from_slice(&[component, 0x11, 0]);
+    }
+    data.extend_from_slice(&[0xFF, 0xCC, 0, 4, 0, 0x10]); // DAC, DC table 0
+
+    let scans: Vec<Vec<u8>> = if interleaved {
+        vec![(1..=component_count).collect()]
+    } else {
+        (1..=component_count).map(|component| vec![component]).collect()
+    };
+    for scan in scans {
+        data.extend_from_slice(&[0xFF, 0xDA]);
+        let sos_length = 6 + 2 * u16::try_from(scan.len()).unwrap();
+        data.extend_from_slice(&sos_length.to_be_bytes());
+        data.push(u8::try_from(scan.len()).unwrap());
+        for component in scan {
+            data.extend_from_slice(&[component, 0]);
+        }
+        data.extend_from_slice(&[1, 0, 0]);
+    }
+    data.extend_from_slice(&[0xFF, 0xD9]);
+    data
+}
+
 #[test]
 fn lossless_huffman_headers_expose_dimensions() {
     for precision in [2, 8, 12, 16] {
@@ -98,6 +127,27 @@ fn lossless_huffman_pixel_decode_remains_unsupported() {
         error,
         DecodeErrors::Unsupported(UnsupportedSchemes::LosslessHuffman)
     ));
+}
+
+#[test]
+fn lossless_arithmetic_headers_expose_dimensions() {
+    for (component_count, interleaved) in [(1, true), (3, false), (3, true)] {
+        let data = lossless_arithmetic_header(component_count, interleaved);
+        let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+
+        decoder.decode_headers().unwrap();
+
+        let info = decoder.info().unwrap();
+        assert_eq!(decoder.dimensions(), Some((32, 32)));
+        assert_eq!(info.components, component_count);
+        assert!(info.sof.is_lossless());
+
+        let error = decoder.decode().unwrap_err();
+        assert!(matches!(
+            error,
+            DecodeErrors::Unsupported(UnsupportedSchemes::LosslessArithmetic)
+        ));
+    }
 }
 
 #[test]

--- a/crates/zune-jpeg/tests/metadata.rs
+++ b/crates/zune-jpeg/tests/metadata.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use zune_core::bytestream::ZCursor;
-use zune_jpeg::errors::DecodeErrors;
+use zune_jpeg::errors::{DecodeErrors, UnsupportedSchemes};
 use zune_jpeg::JpegDecoder;
 
 fn grayscale_fixture(sof_marker: u8, sample_precision: u8) -> Vec<u8> {
@@ -47,6 +47,69 @@ fn assert_twelve_bit_size(sof_marker: u8) {
         .expect_err("12-bit pixel decoding must remain unsupported");
     assert!(error.to_string().contains("12-bit"));
     assert_eq!(decoder.dimensions(), Some((32, 32)));
+}
+
+fn lossless_header(precision: u8, sampling: u8, quantization_table: u8) -> Vec<u8> {
+    vec![
+        0xFF, 0xD8, // SOI
+        0xFF, 0xC4, 0x00, 0x14, // DHT, one DC symbol
+        0x00, // DC table 0
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // code counts 1-8
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // code counts 9-16
+        0x10, // lossless difference category 16
+        0xFF, 0xC3, 0x00, 0x0B, precision, 0x00, 0x20, 0x00, 0x20, 0x01,
+        0x01, sampling, quantization_table, // component
+        0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x01, 0x00, 0x00, // SOS
+        0xFF, 0xD9 // EOI
+    ]
+}
+
+#[test]
+fn lossless_huffman_headers_expose_dimensions() {
+    for precision in [2, 8, 12, 16] {
+        let data = lossless_header(precision, 0x21, 1);
+        let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+
+        decoder.decode_headers().unwrap();
+
+        let info = decoder.info().unwrap();
+        assert_eq!(decoder.dimensions(), Some((32, 32)));
+        assert_eq!(info.pixel_density, precision);
+        assert!(info.sof.is_lossless());
+    }
+}
+
+#[test]
+fn lossless_huffman_pixel_decode_remains_unsupported() {
+    let data = lossless_header(8, 0x11, 0);
+    let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    decoder.decode_headers().unwrap();
+    let mut output = vec![0xA5; decoder.output_buffer_size().unwrap()];
+
+    let error = decoder.decode_into(&mut output).unwrap_err();
+    assert!(matches!(
+        error,
+        DecodeErrors::Unsupported(UnsupportedSchemes::LosslessHuffman)
+    ));
+    assert!(output.iter().all(|&byte| byte == 0xA5));
+
+    let error = JpegDecoder::new(ZCursor::new(&data)).decode().unwrap_err();
+    assert!(matches!(
+        error,
+        DecodeErrors::Unsupported(UnsupportedSchemes::LosslessHuffman)
+    ));
+}
+
+#[test]
+fn lossless_only_huffman_categories_stay_rejected_for_lossy_frames() {
+    let mut data = lossless_header(8, 0x11, 0);
+    let sof = data.windows(2).position(|bytes| bytes == [0xFF, 0xC3]).unwrap();
+    data[sof + 1] = 0xC0;
+
+    let error = JpegDecoder::new(ZCursor::new(&data))
+        .decode_headers()
+        .unwrap_err();
+    assert!(matches!(error, DecodeErrors::HuffmanDecode(_)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Close a JPEG decoding gap identified during Chromium integration: Chromium's
libjpeg-turbo decoder accepts lossless sequential Huffman JPEGs, while
`zune-jpeg` did not support them.

This adds decoding for 8-bit SOF3 lossless Huffman images with:

- predictors 1 through 7 and point transforms
- interleaved and non-interleaved scans
- row-aligned restart intervals
- exact entropy-boundary handling and recoverable EOF retries
- category 16 differences with 16-bit predictor history

The supported scope currently requires 1x1 component sampling. Unsupported
lossless variants are rejected explicitly.

## Coverage

Coverage uses CC0 JPEG fixtures and sample output generated with
libjpeg-turbo 3.1.0. It verifies:

- pixel parity across all seven predictors
- grayscale and YCbCr output parity
- point transforms and restart markers
- interleaved and non-interleaved scan layouts
- malformed headers, invalid categories, and premature markers
- retries at every entropy-stream byte boundary
- cancellation and repeated `decode_into` behavior

This work is part of #425 
