### PR TITLE
JpegDecoder: Restore lenient support for truncated files

### DIFF
--- a/crates/zune-jpeg/README.md
+++ b/crates/zune-jpeg/README.md
@@ -30,9 +30,10 @@ see additional documentation in the library.
 ### Incremental input
 
 `JpegDecoder` can be retried on the same decoder when the underlying reader can
-see more bytes later. Callers should treat `DecodeErrors::is_recoverable_eof()`
-as the signal to feed more input and retry; any other error is a hard decode
-failure.
+see more bytes later. Call `set_incremental_mode(true)` before scan decoding to
+make scan EOF recoverable in non-strict mode. Callers should treat
+`DecodeErrors::is_recoverable_eof()` as the signal to feed more input and retry;
+any other error is a hard decode failure.
 
 After `decode_headers()` succeeds, `info()` and `output_buffer_size()` are
 available. During `decode_into()`, the same decoder and output buffer must be
@@ -40,12 +41,13 @@ kept across retries. If scan decoding returns recoverable EOF,
 `decoded_output_bytes()` and `decoded_scanlines()` report the stable prefix of
 the output buffer that can be displayed or copied before retrying.
 
-By default, row checkpoints are recorded only after a previous scan decode
-attempt, so one-shot decoding keeps the lowest-overhead path. Call
-`set_incremental_mode(true)` before the first `decode_into()` attempt when the
-caller expects input to arrive incrementally; this records checkpoints during
-baseline Huffman scans and enables progressive preview preservation on the first
-progressive decode attempt.
+Without incremental mode, non-strict scan EOF preserves the legacy behavior:
+decoding succeeds with best-effort output for the truncated image. Strict mode
+and explicit incremental mode return an error on scan EOF. Incremental mode
+also records checkpoints during baseline Huffman scans and enables progressive
+preview preservation on the first progressive decode attempt. Header EOF
+remains recoverable regardless of this setting because scan decoding has not
+started yet.
 
 Fine-grained row checkpoints currently apply within baseline Huffman scan
 bodies, including baseline multi-SOS / non-interleaved images. Those images may

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -372,9 +372,10 @@ pub struct JpegDecoder<T> {
     /// Whether row checkpoints should also be recorded on the first scan
     /// decode attempt.
     ///
-    /// Disabled by default to keep one-shot decode free of checkpoint work;
-    /// streaming callers can opt in before `decode_into` to avoid replaying
-    /// from scan start after the first recoverable scan EOF.
+    /// Disabled by default to preserve best-effort output on scan EOF in
+    /// non-strict mode and keep one-shot decode free of checkpoint work.
+    /// Streaming callers opt in before `decode_into` to receive recoverable
+    /// scan EOF and avoid replaying from scan start.
     incremental_mode: bool,
     /// Whether this decoder has already attempted scan decoding.
     ///
@@ -883,9 +884,10 @@ where
 
     /// Return whether incremental mode is enabled.
     ///
-    /// Incremental mode records per-row checkpoints during the first scan
-    /// decode attempt, allowing a later retry after recoverable EOF to resume
-    /// from the latest stable row instead of replaying from scan start.
+    /// Incremental mode makes scan EOF recoverable in non-strict mode and
+    /// records per-row checkpoints during the first scan decode attempt,
+    /// allowing a later retry to resume from the latest stable row instead of
+    /// replaying from scan start.
     ///
     /// It is disabled by default so one-shot decoding keeps the lowest
     /// overhead path.
@@ -896,19 +898,19 @@ where
 
     /// Enable or disable incremental mode.
     ///
-    /// Call this before the first `decode_into` scan attempt when the caller
-    /// expects input to arrive incrementally. For baseline images, Huffman scans
-    /// save row checkpoints on the first attempt. For progressive images, the
-    /// active scan decodes through scratch coefficient storage so completed
-    /// scans can be rendered as previews if that first attempt reaches EOF.
-    ///
-    /// The default is `false`. A first-attempt one-shot progressive decode then
-    /// updates its existing coefficient buffers directly and does not clone them.
-    /// Incremental mode clones only the coefficient buffers touched by the active
-    /// progressive scan. After any previous scan decode attempt, later attempts
-    /// enable the same preservation automatically so retries remain idempotent.
+    /// Call this before the first `decode_into` scan attempt. When enabled,
+    /// scan EOF is recoverable and decoding can be retried with more input.
+    /// Otherwise, non-strict decoding returns best-effort output on scan EOF.
+    /// Strict mode always treats scan EOF as an error. The default is `false`.
     pub fn set_incremental_mode(&mut self, enabled: bool) {
         self.incremental_mode = enabled;
+    }
+
+    /// Whether scan EOF must be returned as an error.
+    /// Strict mode rejects truncated scans, while incremental mode uses the
+    /// error to signal that the caller should provide more input.
+    pub(crate) fn scan_eof_is_error(&self) -> bool {
+        self.options.strict_mode() || self.incremental_mode
     }
 
     /// Return the number of output scanlines known to be stable after the
@@ -1627,11 +1629,11 @@ where
     /// from hard failures: `Err(e)` where `e.is_recoverable_eof()` means feed
     /// more input and retry, while any other `Err` is non-recoverable.
     ///
-    /// By default, row checkpoints are enabled after a previous scan decode
-    /// attempt, so the first one-shot decode avoids checkpoint overhead. Call
-    /// [`set_incremental_mode`](Self::set_incremental_mode) before the first
-    /// scan attempt to record row checkpoints immediately when input is
-    /// expected to arrive incrementally.
+    /// Call [`set_incremental_mode`](Self::set_incremental_mode) before the
+    /// first scan attempt when input is expected to arrive incrementally. This
+    /// makes scan EOF recoverable in non-strict mode and records row
+    /// checkpoints immediately. Without incremental mode, non-strict scan EOF
+    /// completes with best-effort output for compatibility with truncated JPEGs.
     ///
     /// On success the decoder keeps scan-start replay state, so a later
     /// `decode_into` call is well-defined and produces bit-identical pixels.

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -40,9 +40,10 @@
 //! ## Incremental input
 //!
 //! `JpegDecoder` can be retried on the same decoder when the underlying reader can
-//! see more bytes later. Callers should treat `DecodeErrors::is_recoverable_eof()`
-//! as the signal to feed more input and retry; any other error is a hard decode
-//! failure.
+//! see more bytes later. Call `set_incremental_mode(true)` before scan decoding
+//! to make scan EOF recoverable in non-strict mode. Callers should treat
+//! `DecodeErrors::is_recoverable_eof()` as the signal to feed more input and
+//! retry; any other error is a hard decode failure.
 //!
 //! After `decode_headers()` succeeds, `info()` and `output_buffer_size()` are
 //! available. During `decode_into()`, the same decoder and output buffer must be
@@ -50,12 +51,13 @@
 //! `decoded_output_bytes()` and `decoded_scanlines()` report the stable prefix of
 //! the output buffer that can be displayed or copied before retrying.
 //!
-//! By default, row checkpoints are recorded only after a previous scan decode
-//! attempt, so one-shot decoding keeps the lowest-overhead path. Call
-//! `set_incremental_mode(true)` before the first `decode_into()` attempt when the
-//! caller expects input to arrive incrementally; this records checkpoints during
-//! baseline Huffman scans and enables progressive preview preservation on the
-//! first progressive decode attempt.
+//! Without incremental mode, non-strict scan EOF preserves the legacy behavior:
+//! decoding succeeds with best-effort output for the truncated image. Strict mode
+//! and explicit incremental mode return an error on scan EOF. Incremental mode
+//! also records checkpoints during baseline Huffman scans and enables progressive
+//! preview preservation on the first progressive decode attempt. Header EOF
+//! remains recoverable regardless of this setting because scan decoding has not
+//! started yet.
 //!
 //! Fine-grained row checkpoints currently apply within baseline Huffman scan
 //! bodies, including baseline multi-SOS / non-interleaved images. Those images may

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -272,10 +272,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     0
                 };
                 if stream.overread_by() > 0 {
-                    // The bitstream reader has exhausted available data.
-                    // Return a recoverable error so the caller can feed more
-                    // bytes and retry (incremental decoding).
-                    return Err(DecodeErrors::ExhaustedData);
+                    if self.scan_eof_is_error() {
+                        return Err(DecodeErrors::ExhaustedData);
+                    }
+                    if all_components_in_first_scan {
+                        if let Some(remaining) = pixels.get_mut(pixels_written..) {
+                            remaining.fill(128);
+                        }
+                        return Ok(());
+                    }
+                    break 'sos;
                 }
 
                 // Per-row checkpoint: save bitstream state at the start of
@@ -310,21 +316,22 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
                 // decode a whole MCU width,
                 // this takes into account interleaved components.
-                let mut mcu_width_context = McuWidthContext {
-                    mcu_width,
-                    mcu_row: i,
-                    start_col,
-                    pixels_written,
-                    tmp: &mut tmp,
-                    stream: &mut stream,
-                    progressive: &mut *progressive_mcus,
-                };
                 if cancel.is_cancelled() {
                     return Err(DecodeErrors::Cancelled);
                 }
-                let terminate = if all_components_in_first_scan {
-                    self.decode_mcu_width::<false, B>(&mut mcu_width_context)?
-                } else {
+                let terminate_result = {
+                    let mut mcu_width_context = McuWidthContext {
+                        mcu_width,
+                        mcu_row: i,
+                        start_col,
+                        pixels_written,
+                        tmp: &mut tmp,
+                        stream: &mut stream,
+                        progressive: &mut *progressive_mcus,
+                    };
+                    if all_components_in_first_scan {
+                        self.decode_mcu_width::<false, B>(&mut mcu_width_context)
+                    } else {
                     /* NB: (cae). This code was added due to the issue at https://github.com/etemesi254/zune-image/issues/277
                     *
                     * There is a particular set of images that interleave the start of scan (SOS) with the MCU,
@@ -342,7 +349,34 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     *
                     */
 
-                    self.decode_mcu_width::<true, B>(&mut mcu_width_context)?
+                        self.decode_mcu_width::<true, B>(&mut mcu_width_context)
+                    }
+                };
+
+                let terminate = match terminate_result {
+                    Ok(terminate) => terminate,
+                    Err(e) if e.is_recoverable_eof() && !self.scan_eof_is_error() => {
+                        error!("{e}");
+                        if all_components_in_first_scan {
+                            self.post_process(
+                                pixels,
+                                i,
+                                mcu_height,
+                                width,
+                                padded_width,
+                                &mut pixels_written,
+                                &mut upsampler_scratch_space,
+                            )?;
+                            self.pixels_decoded = pixels_written;
+                            if let Some(remaining) = pixels.get_mut(pixels_written..) {
+                                remaining.fill(128);
+                            }
+                        } else {
+                            pixels.fill(128);
+                        }
+                        return Ok(());
+                    }
+                    Err(e) => return Err(e)
                 };
 
                 // process that width up until it's impossible. This is faster than allocation the
@@ -419,7 +453,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         break;
                     }
                     Err(e) if e.is_recoverable_eof() => {
-                        return Err(e);
+                        if self.scan_eof_is_error() {
+                            return Err(e);
+                        }
+                        break;
                     }
                     Err(e) => {
                         if self.options.strict_mode() {
@@ -440,7 +477,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // This catches the case where the final MCU row consumed data past EOF
         // (e.g. a 0xFF at the boundary was misinterpreted as byte-stuffing)
         // without a subsequent row to detect it.
-        if stream.overread_by() > 0 {
+        if stream.overread_by() > 0 && self.scan_eof_is_error() {
             return Err(DecodeErrors::ExhaustedData);
         }
 
@@ -488,7 +525,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     trace!("Found marker {_m:?}");
                 }
                 Err(e) if e.is_recoverable_eof() => {
-                    return Err(e);
+                    if self.scan_eof_is_error() {
+                        return Err(e);
+                    }
+                    error!("{e}");
                 }
                 Err(e) => {
                     if self.options.strict_mode() {

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -292,17 +292,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             if matches!(e, DecodeErrors::Cancelled) {
                 return Err(e);
             }
-            // Completed scans are displayable, but a truncated scan is not:
-            // refinement passes read-modify-write coefficient data, so the
-            // scratch copy is discarded on recoverable EOF.
-            if e.is_recoverable_eof() {
+            if e.is_recoverable_eof() && self.scan_eof_is_error() {
                 if fine_resume.is_some() {
                     self.invalidate_progressive_fine_checkpoint();
                 }
                 self.finish_progressive_partial(block, pixels)?;
                 return Err(e);
             }
-            if self.stream.eof()? {
+            if self.stream.eof()? && self.scan_eof_is_error() {
                 if fine_resume.is_some() {
                     self.invalidate_progressive_fine_checkpoint();
                 }
@@ -313,22 +310,38 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 return Err(e);
             }
             error!("{e}");
-            // Match the direct path's best-effort non-strict output: keep
-            // partial corrupt-scan coefficients, but never for recoverable EOF.
+            // Match the direct path's best-effort non-strict output by keeping
+            // partial coefficients, including lenient non-incremental EOF.
             for idx in 0..MAX_COMPONENTS {
                 if touched_components[idx] {
                     core::mem::swap(&mut block[idx], &mut scan_block[idx]);
                 }
             }
+            if fine_resume.is_some() {
+                self.invalidate_progressive_fine_checkpoint();
+            }
             self.invalidate_progressive_scan_checkpoint();
             return Ok(false);
         }
         if stream.overread_by() > 0 {
+            if self.scan_eof_is_error() {
+                if fine_resume.is_some() {
+                    self.invalidate_progressive_fine_checkpoint();
+                }
+                self.finish_progressive_partial(block, pixels)?;
+                return Err(DecodeErrors::ExhaustedData);
+            }
+            error!("{}", DecodeErrors::ExhaustedData);
+            for idx in 0..MAX_COMPONENTS {
+                if touched_components[idx] {
+                    core::mem::swap(&mut block[idx], &mut scan_block[idx]);
+                }
+            }
             if fine_resume.is_some() {
                 self.invalidate_progressive_fine_checkpoint();
             }
-            self.finish_progressive_partial(block, pixels)?;
-            return Err(DecodeErrors::ExhaustedData);
+            self.invalidate_progressive_scan_checkpoint();
+            return Ok(false);
         }
 
         for idx in 0..MAX_COMPONENTS {
@@ -351,11 +364,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 self.discard_progressive_partial();
                 return Err(e);
             }
-            if e.is_recoverable_eof() {
+            if e.is_recoverable_eof() && self.scan_eof_is_error() {
                 self.discard_progressive_partial();
                 return Err(e);
             }
-            if self.stream.eof()? {
+            if self.stream.eof()? && self.scan_eof_is_error() {
                 self.discard_progressive_partial();
                 return Err(DecodeErrors::ExhaustedData);
             }
@@ -366,8 +379,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             return Ok(false);
         }
         if stream.overread_by() > 0 {
-            self.discard_progressive_partial();
-            return Err(DecodeErrors::ExhaustedData);
+            if self.scan_eof_is_error() {
+                self.discard_progressive_partial();
+                return Err(DecodeErrors::ExhaustedData);
+            }
+            error!("{}", DecodeErrors::ExhaustedData);
+            return Ok(false);
         }
 
         self.progressive_completed_scans += 1;
@@ -381,7 +398,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         if matches!(error, DecodeErrors::Cancelled) {
             return Err(error);
         }
-        if error.is_recoverable_eof() {
+        if error.is_recoverable_eof() && self.scan_eof_is_error() {
             if preserve_completed_scans {
                 self.finish_progressive_partial(block, pixels)?;
             } else {

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -143,6 +143,12 @@ fn assert_pixels_match(actual: &[u8], expected: &[u8], name: &str, available: us
     }
 }
 
+fn fnv1a(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf2_9ce4_8422_2325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x0100_0000_01b3)
+    })
+}
+
 fn assert_incremental_decode_matches_oneshot(name: &str, data: &[u8], step: usize) {
     assert!(step > 0, "incremental step must be non-zero");
 
@@ -150,6 +156,7 @@ fn assert_incremental_decode_matches_oneshot(name: &str, data: &[u8], step: usiz
     let limit = Rc::new(Cell::new(0_usize));
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     let mut header_done = false;
     let mut out: Vec<u8> = Vec::new();
@@ -672,6 +679,7 @@ fn scan_resume_two_step() {
     let limit = Rc::new(Cell::new(0_usize));
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     // Expose 80% of data — headers should complete, scan should fail
     let partial = data.len() * 80 / 100;
@@ -705,6 +713,7 @@ fn scan_resume_small_chunks() {
     let limit = Rc::new(Cell::new(0_usize));
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     let mut out: Vec<u8> = Vec::new();
     let chunk = 10;
@@ -938,41 +947,69 @@ fn progressive_completed_dc_scan_is_displayable() {
 }
 
 #[test]
-fn progressive_preview_first_attempt_is_incremental_opt_in() {
-    let name = "down_sampled_grayscale_prog_first_attempt_preview_opt_in";
+fn progressive_scan_eof_respects_lenient_and_incremental_modes() {
     let data = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
-    let expected = decode_oneshot(data);
     let scans = progressive_sos_scans(data);
     assert!(scans.len() > 1, "fixture must contain multiple scans");
+    let truncated = &data[..scans[1].data_start + 1];
 
-    let cutoff = scans[1].data_start + 1;
-    let limit = Rc::new(Cell::new(cutoff));
-    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
-    let mut decoder = JpegDecoder::new(cursor);
-
-    decoder
-        .decode_headers()
-        .expect("headers should be visible at cutoff");
-    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
-    let err = decoder
-        .decode_into(&mut out)
-        .expect_err("truncated second progressive scan should be recoverable");
-    assert!(err.is_recoverable_eof(), "got {err:?}");
-    assert_eq!(decoder.decoded_scans(), Some(0));
-    assert_eq!(decoder.decoded_output_bytes(), Some(0));
-    assert_eq!(decoder.decoded_scanlines(), Some(0));
-    assert_eq!(decoder.decoded_preview_output_bytes(), Some(0));
-    assert_eq!(decoder.decoded_preview_scanlines(), Some(0));
+    let lenient = decode_with_mode(truncated, false, false)
+        .expect("non-strict one-shot decode should accept a truncated scan");
     assert!(
-        out.iter().all(|byte| *byte == 0),
-        "first non-incremental attempt should not render a progressive preview"
+        lenient.iter().any(|byte| *byte != 0),
+        "lenient truncated decode should produce best-effort pixels"
     );
 
-    limit.set(data.len());
-    decoder
-        .decode_into(&mut out)
-        .expect("full input should finish progressive decode");
-    assert_pixels_match(&out, &expected, name, data.len());
+    let strict_error = decode_with_mode(truncated, false, true)
+        .expect_err("strict decode should reject a truncated scan");
+    assert!(strict_error.is_recoverable_eof());
+
+    let incremental_error = decode_with_mode(truncated, true, false)
+        .expect_err("incremental decode should report recoverable scan EOF");
+    assert!(incremental_error.is_recoverable_eof());
+}
+
+#[test]
+fn baseline_scan_eof_respects_lenient_and_incremental_modes() {
+    let data = include_bytes!("../../../test-images/jpeg/sampling_factors.jpg");
+    let entropy_start = entropy_start(data);
+    let cutoff = entropy_start + (data.len() - entropy_start) * 60 / 100;
+    let truncated = &data[..cutoff];
+
+    let lenient = decode_with_mode(truncated, false, false)
+        .expect("non-strict one-shot decode should accept a truncated scan");
+    assert!(
+        lenient.iter().any(|byte| *byte != 0),
+        "lenient truncated decode should produce best-effort pixels"
+    );
+    assert_eq!(
+        fnv1a(&lenient),
+        0x1eab_e750_2dcb_ddc3,
+        "lenient output should match the legacy decoded pixels"
+    );
+
+    let strict_error = decode_with_mode(truncated, false, true)
+        .expect_err("strict decode should reject a truncated scan");
+    assert!(strict_error.is_recoverable_eof());
+
+    let incremental_error = decode_with_mode(truncated, true, false)
+        .expect_err("incremental decode should report recoverable scan EOF");
+    assert!(incremental_error.is_recoverable_eof());
+}
+
+#[test]
+fn baseline_multi_sos_lenient_eof_preserves_neutral_output() {
+    let data = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let cutoffs = [sos_data_start(data, 0) + 4, sos_data_start(data, 2) + 3];
+
+    for cutoff in cutoffs {
+        let pixels = decode_with_mode(&data[..cutoff], false, false)
+            .expect("non-strict one-shot decode should accept a truncated component scan");
+        assert!(
+            pixels.iter().all(|byte| *byte == 128),
+            "cutoff {cutoff}: incomplete component scans should produce neutral output"
+        );
+    }
 }
 
 #[test]
@@ -1573,6 +1610,7 @@ fn arithmetic_restart_resume_uses_rst_checkpoint() {
     let seek_log = Rc::new(RefCell::new(Vec::new()));
     let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     decoder
         .decode_headers()
@@ -1612,6 +1650,7 @@ fn inplace_byte_by_byte_full_decode() {
     let limit = Rc::new(Cell::new(0_usize));
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     let mut out: Vec<u8> = Vec::new();
     for avail in 1..=data.len() {
@@ -1675,6 +1714,7 @@ fn inline_marker_in_scan_does_not_duplicate_icc() {
     let limit = Rc::new(Cell::new(0_usize));
     let cursor = GrowableCursor::new(&data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     let mut out: Vec<u8> = Vec::new();
     for avail in 1..=data.len() {
@@ -2033,7 +2073,7 @@ fn multi_sos_first_scan_cutoff(data: &[u8]) -> usize {
     second_sos_offset - 1
 }
 
-fn first_retry_seek_after_scan_eof(data: &[u8], incremental_mode: bool) -> usize {
+fn first_retry_seek_after_scan_eof(data: &[u8]) -> usize {
     let expected = decode_oneshot(data);
     let entropy_start = entropy_start(data);
     let cutoff = entropy_start + (data.len() - entropy_start) * 60 / 100;
@@ -2042,12 +2082,12 @@ fn first_retry_seek_after_scan_eof(data: &[u8], incremental_mode: bool) -> usize
     let seek_log = Rc::new(RefCell::new(Vec::new()));
     let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
     let mut decoder = JpegDecoder::new(cursor);
-    decoder.set_incremental_mode(incremental_mode);
+    decoder.set_incremental_mode(true);
 
     decoder
         .decode_headers()
         .expect("headers should be fully visible at cutoff");
-    assert_eq!(decoder.incremental_mode(), incremental_mode);
+    assert!(decoder.incremental_mode());
     let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
 
     let err = decoder
@@ -2076,13 +2116,7 @@ fn incremental_mode_records_checkpoint_on_first_scan_attempt() {
     let data = include_bytes!("../../../test-images/jpeg/sampling_factors.jpg");
     let entropy_start = entropy_start(data);
 
-    let default_seek = first_retry_seek_after_scan_eof(data, false);
-    assert_eq!(
-        default_seek, entropy_start,
-        "default mode should replay from scan start on the first retry"
-    );
-
-    let incremental_seek = first_retry_seek_after_scan_eof(data, true);
+    let incremental_seek = first_retry_seek_after_scan_eof(data);
     assert!(
         incremental_seek > entropy_start,
         "incremental mode should resume from an entropy-data row checkpoint; \
@@ -2214,6 +2248,7 @@ fn baseline_huffman_restart_resume_uses_rst_checkpoint() {
     let seek_log = Rc::new(RefCell::new(Vec::new()));
     let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     decoder.decode_headers().expect("headers should be visible at cutoff");
     let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
@@ -2240,14 +2275,8 @@ fn baseline_huffman_restart_resume_uses_rst_checkpoint() {
     );
 }
 
-/// Per-row checkpoint: truncating a non-RST image mid-scan and retrying
-/// must eventually resume from a row checkpoint rather than replaying
-/// from scan start. In default mode, per-row checkpointing is only enabled
-/// after a previous scan decode attempt has run, so the sequence is:
-///   1. First call: partial data → ExhaustedData (no checkpoints saved)
-///   2. Second call (retry, checkpoints now enabled): still partial → ExhaustedData
-///      (per-row checkpoints ARE saved this time)
-///   3. Third call: full data → resumes from per-row checkpoint
+/// Per-row checkpoint: truncating a non-RST image mid-scan in incremental
+/// mode must resume from a row checkpoint rather than replaying from scan start.
 #[test]
 fn per_row_checkpoint_avoids_full_scan_replay() {
     // sampling_factors.jpg is baseline with NO RST markers — perfect for testing per-row.
@@ -2263,6 +2292,7 @@ fn per_row_checkpoint_avoids_full_scan_replay() {
     let seek_log = Rc::new(RefCell::new(Vec::new()));
     let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     decoder
         .decode_headers()
@@ -2271,8 +2301,7 @@ fn per_row_checkpoint_avoids_full_scan_replay() {
     assert_eq!(decoder.decoded_scanlines(), Some(0));
     let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
 
-    // First decode attempt — should fail with recoverable EOF.
-    // Per-row checkpoints are NOT saved on the first call (one-shot fast path).
+    // First decode attempt records row checkpoints and returns recoverable EOF.
     let err = decoder
         .decode_into(&mut out)
         .expect_err("truncated scan should give recoverable EOF");
@@ -2293,9 +2322,7 @@ fn per_row_checkpoint_avoids_full_scan_replay() {
         "expected a stable partial prefix, got {first_scanlines} scanlines"
     );
 
-    // Second attempt — still truncated. Now a previous scan decode attempt
-    // has run, so this replays from scan start and saves per-row checkpoints
-    // as it decodes.
+    // A retry with the same truncated input remains recoverable and idempotent.
     let err = decoder
         .decode_into(&mut out)
         .expect_err("still truncated, should give recoverable EOF again");
@@ -2351,6 +2378,7 @@ fn per_row_checkpoint_preserves_vertical_upsampling_state() {
     let seek_log = Rc::new(RefCell::new(Vec::new()));
     let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
     let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
 
     decoder
         .decode_headers()


### PR DESCRIPTION
When lenient (non strict) mode is configured, it is expected that truncated files are succesfully decoded at best effort. However, this was not happening after including support of resumable decoding as unexpected EOF would be propagated to the caller to allow decoding retries when additional data is received. This change is adding control on when EOF is propagated to avoid propagating it when strict mode is disabled.

This fix is part of #375