### PR TITLE
JpegDecoder: expose dimensions for 12-bit Huffman images

### DIFF
--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -652,6 +652,7 @@ where
     /// See DecodeErrors for an explanation
     pub fn decode(&mut self) -> Result<Vec<u8>, DecodeErrors> {
         self.decode_headers()?;
+        self.ensure_supported_sample_precision()?;
 
         if self.expects_dnl {
             // Height is unknown until DNL is encountered during entropy
@@ -724,7 +725,7 @@ where
     ///
     /// # Returns
     ///  - `Some(usize)`: Minimum size for a buffer needed to decode the image
-    ///  - `None`: Indicates the image was not decoded, or image dimensions would overflow a usize
+    ///  - `None`: Indicates headers are unavailable or image dimensions overflow `usize`
     ///
     #[must_use]
     pub fn output_buffer_size(&self) -> Option<usize> {
@@ -1224,8 +1225,9 @@ where
                 // choose marker
                 let (marker, is_progressive) =
                     match m {
-                        Marker::SOF(0 | 1) =>
-                            (SOFMarkers::BaselineDct, false),
+                        Marker::SOF(0) => (SOFMarkers::BaselineDct, false),
+                        Marker::SOF(1) =>
+                            (SOFMarkers::ExtendedSequentialHuffman, false),
                         Marker::SOF(2) =>
                             (SOFMarkers::ProgressiveDctHuffman, true),
                         _ => unreachable!(),
@@ -1508,6 +1510,15 @@ where
         };
     }
 
+    fn ensure_supported_sample_precision(&self) -> Result<(), DecodeErrors> {
+        if self.info.pixel_density == 12 {
+            return Err(DecodeErrors::FormatStatic(
+                "12-bit JPEG pixel decoding is not supported"
+            ));
+        }
+        Ok(())
+    }
+
     /// Decode into a pre-allocated buffer
     ///
     /// It is an error if the buffer size is smaller than
@@ -1705,6 +1716,8 @@ where
         } else {
             self.decode_headers_internal()?;
         }
+
+        self.ensure_supported_sample_precision()?;
 
         let expected_size = self.output_buffer_size().unwrap();
 
@@ -1912,7 +1925,7 @@ pub struct ImageInfo {
     pub width: u16,
     /// Height of image
     pub height: u16,
-    /// PixelDensity
+    /// Sample precision in bits.
     pub pixel_density: u8,
     /// Start of frame markers
     pub sof: SOFMarkers,

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -332,13 +332,20 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
         // Body length came from a u16 length field minus 2; +2 round-trips it.
         #[allow(clippy::cast_possible_truncation)]
         let length = (cursor.body().len() + 2) as u16;
-        // usually 8, but can be 12 and 16, we currently support only 8
-        // so sorry about that 12 bit images
+        // Pixel decoding remains 8-bit only, but Huffman-coded 12-bit frame
+        // headers are useful to callers that inspect image metadata.
         let dt_precision = cursor.read_u8()?;
 
-        if dt_precision != 8 {
+        let supported_header_precision = dt_precision == 8
+            || (dt_precision == 12
+                && matches!(
+                    sof,
+                    SOFMarkers::ExtendedSequentialHuffman
+                        | SOFMarkers::ProgressiveDctHuffman
+                ));
+        if !supported_header_precision {
             return Err(DecodeErrors::SofError(format!(
-                "The library can only parse 8-bit images, the image has {dt_precision} bits of precision"
+                "Unsupported {dt_precision}-bit sample precision for {sof:?}"
             )));
         }
 

--- a/crates/zune-jpeg/tests/metadata.rs
+++ b/crates/zune-jpeg/tests/metadata.rs
@@ -1,6 +1,53 @@
 use std::io::Cursor;
 
+use zune_core::bytestream::ZCursor;
+use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::JpegDecoder;
+
+fn grayscale_fixture(sof_marker: u8, sample_precision: u8) -> Vec<u8> {
+    let mut data =
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg").to_vec();
+    let sof = data
+        .windows(2)
+        .position(|bytes| bytes == [0xFF, 0xC2])
+        .expect("fixture must contain SOF2");
+
+    data[sof + 1] = sof_marker;
+    data[sof + 4] = sample_precision;
+    data[sof + 5..sof + 7].copy_from_slice(&32_u16.to_be_bytes());
+    data[sof + 7..sof + 9].copy_from_slice(&32_u16.to_be_bytes());
+    data[sof + 11] = 0x11;
+
+    let sos = data[sof..]
+        .windows(2)
+        .position(|bytes| bytes == [0xFF, 0xDA])
+        .map(|offset| sof + offset)
+        .expect("fixture must contain SOS");
+    let sos_length = usize::from(u16::from_be_bytes([data[sos + 2], data[sos + 3]]));
+    if sof_marker == 0xC1 {
+        let scan_parameters = sos + 2 + sos_length - 3;
+        data[scan_parameters..scan_parameters + 3].copy_from_slice(&[0, 63, 0]);
+    }
+    data.truncate(sos + 2 + sos_length);
+    data
+}
+
+fn assert_twelve_bit_size(sof_marker: u8) {
+    let data = grayscale_fixture(sof_marker, 12);
+    let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+
+    decoder
+        .decode_headers()
+        .expect("12-bit Huffman headers should parse");
+    assert_eq!(decoder.dimensions(), Some((32, 32)));
+
+    let mut output = vec![0; decoder.output_buffer_size().unwrap()];
+    let error = decoder
+        .decode_into(&mut output)
+        .expect_err("12-bit pixel decoding must remain unsupported");
+    assert!(error.to_string().contains("12-bit"));
+    assert_eq!(decoder.dimensions(), Some((32, 32)));
+}
 
 #[test]
 fn iptc_metadata() {
@@ -70,4 +117,48 @@ fn test_sample_ratios() {
             "Expected sample ratio {expected:?} for image"
         );
     }
+}
+
+#[test]
+fn extended_huffman_12_bit_headers() {
+    assert_twelve_bit_size(0xC1);
+}
+
+#[test]
+fn progressive_huffman_12_bit_headers() {
+    assert_twelve_bit_size(0xC2);
+}
+
+#[test]
+fn baseline_12_bit_headers_remain_rejected() {
+    let data = grayscale_fixture(0xC0, 12);
+    let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    let error = decoder
+        .decode_headers()
+        .expect_err("12-bit baseline SOF0 is not a supported header format");
+    assert!(matches!(error, DecodeErrors::SofError(_)));
+}
+
+#[test]
+fn extended_huffman_8_bit_decode_remains_supported() {
+    let baseline = include_bytes!("../../../test-images/jpeg/sampling_factors.jpg");
+    let mut extended = baseline.to_vec();
+    let sof = extended
+        .windows(2)
+        .position(|bytes| bytes == [0xFF, 0xC0])
+        .expect("fixture must contain SOF0");
+    extended[sof + 1] = 0xC1;
+
+    let mut baseline_decoder = JpegDecoder::new(ZCursor::new(baseline));
+    let expected = baseline_decoder
+        .decode()
+        .expect("SOF0 fixture should decode");
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(&extended));
+        decoder
+            .decode_headers()
+            .expect("8-bit SOF1 headers should parse");
+
+    let actual = decoder.decode().expect("8-bit SOF1 pixels should decode");
+    assert_eq!(actual, expected);
 }


### PR DESCRIPTION
## Summary

Allow 12-bit extended sequential and progressive Huffman JPEG headers to be parsed without enabling 12-bit pixel decoding.

This matches the behavior Chromium observes from its libjpeg-turbo build: image dimensions are available after header parsing, while attempting to decode the pixels still fails as unsupported.

## Changes

- Recognize 12-bit SOF1 and SOF2 frame headers.
- Preserve the correct SOF1 frame classification.
- Report image dimensions and header metadata through the existing APIs.
- Reject 12-bit images before entering the 8-bit pixel decoding path.
- Add tests covering:
  - 12-bit extended sequential header parsing and dimensions.
  - 12-bit progressive header parsing and dimensions.
  - Rejection of invalid 12-bit baseline headers.
  - Continued support for decoding 8-bit SOF1 images.

This does not add 12-bit pixel decoding or change the public API.

This work is part of #425 