### PR TITLE
Decode MCUs with a block list

### DIFF
--- a/crates/zune-jpeg/src/components.rs
+++ b/crates/zune-jpeg/src/components.rs
@@ -32,6 +32,7 @@ pub type UpSampler = fn(
     output: &mut [i16]
 );
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ScanBlock {
     pub(crate) component: usize,
     pub(crate) vertical: u8,

--- a/crates/zune-jpeg/src/components.rs
+++ b/crates/zune-jpeg/src/components.rs
@@ -32,6 +32,21 @@ pub type UpSampler = fn(
     output: &mut [i16]
 );
 
+pub struct ScanBlock {
+    pub(crate) component: usize,
+    pub(crate) vertical: u8,
+    pub(crate) horizontal: u8,
+}
+
+impl ScanBlock {
+    /// A default initialization for the decoder.
+    pub(crate) const INVALID: ScanBlock = ScanBlock {
+        component: 0,
+        vertical: 0,
+        horizontal: 0,
+    };
+}
+
 /// Component Data from start of frame
 #[derive(Clone)]
 pub(crate) struct Components {

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -29,13 +29,13 @@ use crate::bitstream::{BitstreamStateSnapshot, BitStreamHuffman};
 #[cfg(feature = "arith")]
 use crate::bitstream_arith::{ArithACTables, ArithDCTables, BitStreamArithmetic};
 use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
-use crate::components::{Components, SampleRatios};
+use crate::components::{Components, SampleRatios, ScanBlock};
 use crate::errors::{DecodeErrors, UnsupportedSchemes};
 #[cfg(feature = "arith")]
 use crate::headers::parse_dac;
 use crate::headers::{
     parse_app1, parse_app13, parse_app14, parse_app2, parse_dqt, parse_huffman, parse_sos,
-    parse_start_of_frame, with_marker_body
+    parse_start_of_frame, with_marker_body,
 };
 use crate::huffman::HuffmanTable;
 use crate::idct::{choose_idct_1x1_func, choose_idct_4x4_func, choose_idct_func};
@@ -269,7 +269,14 @@ pub struct JpegDecoder<T> {
     /// Number of components.
     pub(crate) num_scans:        u8,
     /// For a scan, check if any component has vertical/horizontal sampling.
+    ///
+    /// This tells us if blocks occur in the same natural image order in all components part of the
+    /// scan or not. If multiple blocks from a component are part of an MCU they occur in vertical/
+    /// horizontal order of blocks within an MCU, for each MCU.
     pub(crate) scan_subsampled:  bool,
+    pub(crate) scan_blocks:      [ScanBlock; 10],
+    /// Number of component blocks in the scan.
+    pub(crate) num_scan_blocks:  u8,
     // Function pointers, for pointy stuff.
     /// Dequantize and idct function
     // This is determined at runtime which function to run, statically it's
@@ -610,6 +617,8 @@ where
             succ_high:                   0,
             succ_low:                    0,
             num_scans:                   0,
+            scan_blocks:                 [ScanBlock::INVALID; 10],
+            num_scan_blocks:             0,
             scan_subsampled:             false,
             idct_func:                   choose_idct_func(&options),
             idct_4x4_func:               choose_idct_4x4_func(&options),

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -120,7 +120,9 @@ pub(crate) struct SosParamsSnapshot {
     pub(crate) succ_high:       u8,
     pub(crate) succ_low:        u8,
     pub(crate) dc_huff_tables:  [usize; MAX_COMPONENTS],
-    pub(crate) ac_huff_tables:  [usize; MAX_COMPONENTS]
+    pub(crate) ac_huff_tables:  [usize; MAX_COMPONENTS],
+    pub(crate) scan_blocks:     [ScanBlock; 10],
+    pub(crate) num_scan_blocks: u8,
 }
 
 /// Marker-defined decode state restored for first-SOS replay.
@@ -416,7 +418,9 @@ where
                 self.components
                     .get(i)
                     .map_or(0, |component| component.ac_huff_table)
-            })
+            }),
+            scan_blocks:     self.scan_blocks,
+            num_scan_blocks: self.num_scan_blocks,
         }
     }
 
@@ -1654,6 +1658,8 @@ where
             self.spec_end = resume_sos_snapshot.spec_end;
             self.succ_high = resume_sos_snapshot.succ_high;
             self.succ_low = resume_sos_snapshot.succ_low;
+            self.scan_blocks = resume_sos_snapshot.scan_blocks;
+            self.num_scan_blocks = resume_sos_snapshot.num_scan_blocks;
             debug_assert!(
                 self.components.len() <= MAX_COMPONENTS,
                 "components vector exceeds MAX_COMPONENTS; SOS restore would index out of bounds"

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -18,7 +18,7 @@ use core::cmp::max;
 use zune_core::bytestream::ZByteReaderTrait;
 use zune_core::log::{trace, warn};
 
-use crate::components::{Components, SampleRatios};
+use crate::components::{Components, SampleRatios, ScanBlock};
 use crate::decoder::{ExtendedXmpSegment, GainMapInfo, ICCChunk, JpegDecoder, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
 use crate::huffman::HuffmanTable;
@@ -30,8 +30,8 @@ use crate::misc::{SOFMarkers, UN_ZIGZAG};
 /// I/O failure has already happened (and been surfaced to the caller) before
 /// the parser starts mutating decoder fields.
 pub(crate) struct MarkerBody<'a> {
-    body:     &'a [u8],
-    position: usize
+    body: &'a [u8],
+    position: usize,
 }
 
 impl<'a> MarkerBody<'a> {
@@ -48,9 +48,12 @@ impl<'a> MarkerBody<'a> {
     }
 
     fn read_u8(&mut self) -> Result<u8, DecodeErrors> {
-        let byte = *self.body.get(self.position).ok_or(DecodeErrors::FormatStatic(
-            "Marker payload shorter than declared length"
-        ))?;
+        let byte = *self
+            .body
+            .get(self.position)
+            .ok_or(DecodeErrors::FormatStatic(
+                "Marker payload shorter than declared length",
+            ))?;
         self.position += 1;
         Ok(byte)
     }
@@ -58,7 +61,7 @@ impl<'a> MarkerBody<'a> {
     fn read_u16_be(&mut self) -> Result<u16, DecodeErrors> {
         if self.position + 2 > self.body.len() {
             return Err(DecodeErrors::FormatStatic(
-                "Marker payload shorter than declared length"
+                "Marker payload shorter than declared length",
             ));
         }
         let v = u16::from_be_bytes([self.body[self.position], self.body[self.position + 1]]);
@@ -69,7 +72,7 @@ impl<'a> MarkerBody<'a> {
     fn read_exact(&mut self, dst: &mut [u8]) -> Result<(), DecodeErrors> {
         if self.position + dst.len() > self.body.len() {
             return Err(DecodeErrors::FormatStatic(
-                "Marker payload shorter than declared length"
+                "Marker payload shorter than declared length",
             ));
         }
         dst.copy_from_slice(&self.body[self.position..self.position + dst.len()]);
@@ -87,11 +90,11 @@ impl<'a> MarkerBody<'a> {
 /// body scoped to the closure also makes it impossible for safe code to hold
 /// a marker body after the decoder has been dropped.
 pub(crate) fn with_marker_body<T, R, F>(
-    decoder: &mut JpegDecoder<T>, parse: F
+    decoder: &mut JpegDecoder<T>, parse: F,
 ) -> Result<R, DecodeErrors>
 where
     T: ZByteReaderTrait,
-    F: FnOnce(&mut JpegDecoder<T>, MarkerBody<'_>) -> Result<R, DecodeErrors>
+    F: FnOnce(&mut JpegDecoder<T>, MarkerBody<'_>) -> Result<R, DecodeErrors>,
 {
     let length = decoder.stream.get_u16_be_err()?;
     let body_len = usize::from(length)
@@ -117,7 +120,7 @@ where
 ///**B.2.4.2 Huffman table-specification syntax**
 #[allow(clippy::similar_names, clippy::cast_sign_loss)]
 pub(crate) fn parse_huffman<T: ZByteReaderTrait>(
-    decoder: &mut JpegDecoder<T>
+    decoder: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors>
 where
 {
@@ -150,7 +153,7 @@ where
             let symbols_sum: i32 = num_symbols.iter().map(|f| i32::from(*f)).sum();
             if symbols_sum > 256 {
                 return Err(DecodeErrors::FormatStatic(
-                    "Encountered Huffman table with excessive length in DHT"
+                    "Encountered Huffman table with excessive length in DHT",
                 ));
             }
             if symbols_sum as usize > cursor.remaining() {
@@ -184,21 +187,21 @@ where
 #[cfg(feature = "arith")]
 #[allow(clippy::similar_names, clippy::cast_sign_loss)]
 pub(crate) fn parse_dac<T: ZByteReaderTrait>(
-    decoder: &mut JpegDecoder<T>
+    decoder: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors>
 where
 {
     with_marker_body(decoder, |decoder, mut cursor| {
         if cursor.body().len() % 2 != 0 {
             return Err(DecodeErrors::FormatStatic(
-                "Bogus (odd) Arithmetic-coding conditioning segment length"
+                "Bogus (odd) Arithmetic-coding conditioning segment length",
             ));
         }
         // Validate everything before committing: collect new entries into a
         // local Vec and apply them only when the whole body parses cleanly.
         enum DacEntry {
             Dc { index: usize, l: u8, u: u8 },
-            Ac { index: usize, kx: u8 }
+            Ac { index: usize, kx: u8 },
         }
         let mut entries: Vec<DacEntry> = Vec::with_capacity(cursor.body().len() / 2);
         while cursor.remaining() >= 2 {
@@ -232,7 +235,10 @@ where
                             "Invalid conditioning table value {cs_value} for AC table, should be in [1,63]"
                         )));
                     }
-                    entries.push(DacEntry::Ac { index, kx: cs_value });
+                    entries.push(DacEntry::Ac {
+                        index,
+                        kx: cs_value,
+                    });
                 }
                 _ => {
                     return Err(DecodeErrors::ArithmeticDecode(format!(
@@ -321,11 +327,11 @@ pub(crate) fn parse_dqt<T: ZByteReaderTrait>(img: &mut JpegDecoder<T>) -> Result
 
 /// Section:`B.2.2 Frame header syntax`
 pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
-    sof: SOFMarkers, img: &mut JpegDecoder<T>
+    sof: SOFMarkers, img: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors> {
     if img.seen_sof {
         return Err(DecodeErrors::SofError(
-            "Two Start of Frame Markers".to_string()
+            "Two Start of Frame Markers".to_string(),
         ));
     }
     with_marker_body(img, |img, mut cursor| {
@@ -368,7 +374,7 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
 
         if num_components == 0 {
             return Err(DecodeErrors::SofError(
-                "Number of components cannot be zero.".to_string()
+                "Number of components cannot be zero.".to_string(),
             ));
         }
 
@@ -402,7 +408,7 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
             (1, 2) => SampleRatios::V,
             (2, 1) => SampleRatios::H,
             (2, 2) => SampleRatios::HV,
-            (hs, vs) => SampleRatios::Generic(hs, vs)
+            (hs, vs) => SampleRatios::Generic(hs, vs),
         };
 
         // Commit phase: all reads succeeded, mutate the decoder.
@@ -427,11 +433,11 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
 
 /// Parse a start of scan data
 pub(crate) fn parse_sos<T: ZByteReaderTrait>(
-    image: &mut JpegDecoder<T>
+    image: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors> {
     with_marker_body(image, |image, mut cursor| {
         let ls = cursor.body().len() + 2; // total scan header length including the length field
-        // Number of image components in scan
+                                          // Number of image components in scan
         let ns = cursor.read_u8()?;
 
         let mut seen: [_; 5] = [-1; { MAX_COMPONENTS + 1 }];
@@ -452,7 +458,7 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
 
         if image.info.components == 0 {
             return Err(DecodeErrors::FormatStatic(
-                "Error decoding SOF Marker, Number of components cannot be zero."
+                "Error decoding SOF Marker, Number of components cannot be zero.",
             ));
         }
 
@@ -499,6 +505,58 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
             if component.vertical_sample != 1 || component.horizontal_sample != 1 {
                 scan_subsampled = true;
             }
+        }
+
+        // A.2.3 (Interleaved order).
+        //
+        // Scans of only one component are never interleaved. For all other scans the order of
+        // blocks within the MCU depends on the sample definitions from the header. There's as many
+        // vertical and horizontal samples in the scan as defined for the component.
+        //
+        // B.2.1 (High-level syntax)
+        //
+        // This clarifies that for progressive images only the first scan with DC components is
+        // allowed to be interleaved. All other scans with other components are not to be
+        // interleaved, implying those can not contain multiple subsampled components.
+        if scan_subsampled && ns > 1 {
+            let mut idx_block = 0;
+
+            for i in 0..ns {
+                let k = z_order[i as usize];
+                let component = &image.components[usize::from(k)];
+
+                for j in 0..component.vertical_sample {
+                    for i in 0..component.horizontal_sample {
+                        image.scan_blocks[idx_block] = ScanBlock {
+                            component: k,
+                            horizontal: i as u8,
+                            vertical: j as u8,
+                        };
+
+                        idx_block += 1;
+                    }
+                }
+            }
+
+            if idx_block > 10 {
+                return Err(DecodeErrors::SofError(format!(
+                    "Invalid scan with {:?} components, must be at most 10",
+                    idx_block,
+                )));
+            }
+
+            image.num_scan_blocks = idx_block as u8;
+        } else {
+            for i in 0..ns {
+                let component = z_order[usize::from(i)];
+                image.scan_blocks[usize::from(i)] = ScanBlock {
+                    component,
+                    horizontal: 0,
+                    vertical: 0,
+                };
+            }
+
+            image.num_scan_blocks = ns;
         }
 
         // Spectral parameters.
@@ -557,17 +615,18 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
 
 /// Parse the APP13 (IPTC) segment.
 pub(crate) fn parse_app13<T: ZByteReaderTrait>(
-    decoder: &mut JpegDecoder<T>
+    decoder: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors> {
     const IPTC_PREFIX: &[u8] = b"Photoshop 3.0\0";
     with_marker_body(decoder, |decoder, cursor| {
         let body = cursor.body();
 
-        let new_iptc = if body.len() > IPTC_PREFIX.len() && &body[..IPTC_PREFIX.len()] == IPTC_PREFIX {
-            Some(body[IPTC_PREFIX.len()..].to_vec())
-        } else {
-            None
-        };
+        let new_iptc =
+            if body.len() > IPTC_PREFIX.len() && &body[..IPTC_PREFIX.len()] == IPTC_PREFIX {
+                Some(body[IPTC_PREFIX.len()..].to_vec())
+            } else {
+                None
+            };
 
         // Commit phase.
         if let Some(iptc_bytes) = new_iptc {
@@ -579,7 +638,7 @@ pub(crate) fn parse_app13<T: ZByteReaderTrait>(
 
 /// Parse Adobe App14 segment
 pub(crate) fn parse_app14<T: ZByteReaderTrait>(
-    decoder: &mut JpegDecoder<T>
+    decoder: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors> {
     with_marker_body(decoder, |decoder, cursor| {
         let body = cursor.body();
@@ -589,7 +648,7 @@ pub(crate) fn parse_app14<T: ZByteReaderTrait>(
             // Adobe segment must be at least 12 bytes of body (6 id + 5 ver/flags + 1 transform).
             if body.len() < 12 {
                 return Err(DecodeErrors::FormatStatic(
-                    "Too short of a length for App14 segment"
+                    "Too short of a length for App14 segment",
                 ));
             }
             // adobe id = 6, version/flags = 5, transform = 1
@@ -604,7 +663,10 @@ pub(crate) fn parse_app14<T: ZByteReaderTrait>(
                 }
             }
         } else {
-            warn!("Not a valid Adobe APP14 Segment, skipping {} bytes", body.len());
+            warn!(
+                "Not a valid Adobe APP14 Segment, skipping {} bytes",
+                body.len()
+            );
             None
         };
 
@@ -620,7 +682,7 @@ pub(crate) fn parse_app14<T: ZByteReaderTrait>(
 ///
 /// This contains the exif tag
 pub(crate) fn parse_app1<T: ZByteReaderTrait>(
-    decoder: &mut JpegDecoder<T>
+    decoder: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors> {
     const XMP_NAMESPACE_PREFIX: &[u8] = b"http://ns.adobe.com/xap/1.0/\0";
     const EXTENDED_XMP_NAMESPACE_PREFIX: &[u8] = b"http://ns.adobe.com/xmp/extension/\0";
@@ -634,7 +696,7 @@ pub(crate) fn parse_app1<T: ZByteReaderTrait>(
         Exif(Vec<u8>),
         Xmp(Vec<u8>),
         ExtendedXmp(ExtendedXmpSegment),
-        Unknown
+        Unknown,
     }
 
     with_marker_body(decoder, |decoder, cursor| {
@@ -665,7 +727,12 @@ pub(crate) fn parse_app1<T: ZByteReaderTrait>(
             let offset_end = offset_start + EXTENDED_XMP_OFFSET_SIZE;
             let offset = u32::from_be_bytes(rest[offset_start..offset_end].try_into().unwrap());
             let data = rest[EXTENDED_XMP_HEADER_SIZE..].to_vec();
-            App1Payload::ExtendedXmp(ExtendedXmpSegment { offset, total_size, guid, data })
+            App1Payload::ExtendedXmp(ExtendedXmpSegment {
+                offset,
+                total_size,
+                guid,
+                data,
+            })
         } else {
             warn!("Unknown format for APP1 tag, skipping");
             App1Payload::Unknown
@@ -683,7 +750,7 @@ pub(crate) fn parse_app1<T: ZByteReaderTrait>(
 }
 
 pub(crate) fn parse_app2<T: ZByteReaderTrait>(
-    decoder: &mut JpegDecoder<T>
+    decoder: &mut JpegDecoder<T>,
 ) -> Result<(), DecodeErrors> {
     static HDR_META: &[u8] = b"urn:iso:std:iso:ts:21496:-1\0";
     static MPF_DATA: &[u8] = b"MPF\0";
@@ -693,64 +760,67 @@ pub(crate) fn parse_app2<T: ZByteReaderTrait>(
         IccChunk(ICCChunk),
         GainMap(GainMapInfo),
         Mpf { offset: u64, data: Vec<u8> },
-        Unknown
+        Unknown,
     }
 
     with_marker_body(decoder, |decoder, cursor| {
         let body = cursor.body();
 
-        let payload = if body.len() > ICC_PROFILE.len() + 2 && &body[..ICC_PROFILE.len()] == ICC_PROFILE
-        {
-            trace!("ICC Profile present");
-            let rest = &body[ICC_PROFILE.len()..];
-            let seq_no = rest[0];
-            let num_markers = rest[1];
+        let payload =
+            if body.len() > ICC_PROFILE.len() + 2 && &body[..ICC_PROFILE.len()] == ICC_PROFILE {
+                trace!("ICC Profile present");
+                let rest = &body[ICC_PROFILE.len()..];
+                let seq_no = rest[0];
+                let num_markers = rest[1];
 
-            // Mirrors libjpeg-turbo jdicc.c: reject num_markers == 0
-            // and seq_no out of [1, num_markers]. No artificial cap on
-            // num_markers — the field is a u8 so 255 is the natural limit.
-            if num_markers == 0 {
-                return Err(DecodeErrors::Format(format!(
-                    "ICC profile claims {num_markers} chunks (must be >= 1)"
-                )));
-            }
-            if seq_no == 0 || seq_no > num_markers {
-                return Err(DecodeErrors::Format(format!(
-                    "ICC chunk seq_no {seq_no} out of range for {num_markers} chunks"
-                )));
-            }
-
-            let data = rest[2..].to_vec();
-            App2Payload::IccChunk(ICCChunk {
-                seq_no,
-                num_markers,
-                data
-            })
-        } else if body.len() > HDR_META.len() && &body[..HDR_META.len()] == HDR_META {
-            trace!("Gain Map metadata found");
-            let rest = &body[HDR_META.len()..];
-            match rest.len() {
-                4 => {
-                    // If gain map metadata length == 4 the body is just version words.
-                    App2Payload::GainMap(GainMapInfo { data: Vec::new() })
+                // Mirrors libjpeg-turbo jdicc.c: reject num_markers == 0
+                // and seq_no out of [1, num_markers]. No artificial cap on
+                // num_markers — the field is a u8 so 255 is the natural limit.
+                if num_markers == 0 {
+                    return Err(DecodeErrors::Format(format!(
+                        "ICC profile claims {num_markers} chunks (must be >= 1)"
+                    )));
                 }
-                n if n > 4 => App2Payload::GainMap(GainMapInfo {
-                    data: rest.to_vec()
-                }),
-                _ => App2Payload::Unknown
-            }
-        } else if body.len() > MPF_DATA.len() && &body[..MPF_DATA.len()] == MPF_DATA {
-            trace!("MPF Signature present");
-            // Compute body start position on-demand (only MPF needs it).
-            // After with_marker_body read the payload, the stream sits at
-            // body_start + body.len(); subtract to recover the origin.
-            let body_start_pos = decoder.stream.position()? - body.len() as u64;
-            let mpf_offset = body_start_pos + MPF_DATA.len() as u64;
-            let data = body[MPF_DATA.len()..].to_vec();
-            App2Payload::Mpf { offset: mpf_offset, data }
-        } else {
-            App2Payload::Unknown
-        };
+                if seq_no == 0 || seq_no > num_markers {
+                    return Err(DecodeErrors::Format(format!(
+                        "ICC chunk seq_no {seq_no} out of range for {num_markers} chunks"
+                    )));
+                }
+
+                let data = rest[2..].to_vec();
+                App2Payload::IccChunk(ICCChunk {
+                    seq_no,
+                    num_markers,
+                    data,
+                })
+            } else if body.len() > HDR_META.len() && &body[..HDR_META.len()] == HDR_META {
+                trace!("Gain Map metadata found");
+                let rest = &body[HDR_META.len()..];
+                match rest.len() {
+                    4 => {
+                        // If gain map metadata length == 4 the body is just version words.
+                        App2Payload::GainMap(GainMapInfo { data: Vec::new() })
+                    }
+                    n if n > 4 => App2Payload::GainMap(GainMapInfo {
+                        data: rest.to_vec(),
+                    }),
+                    _ => App2Payload::Unknown,
+                }
+            } else if body.len() > MPF_DATA.len() && &body[..MPF_DATA.len()] == MPF_DATA {
+                trace!("MPF Signature present");
+                // Compute body start position on-demand (only MPF needs it).
+                // After with_marker_body read the payload, the stream sits at
+                // body_start + body.len(); subtract to recover the origin.
+                let body_start_pos = decoder.stream.position()? - body.len() as u64;
+                let mpf_offset = body_start_pos + MPF_DATA.len() as u64;
+                let data = body[MPF_DATA.len()..].to_vec();
+                App2Payload::Mpf {
+                    offset: mpf_offset,
+                    data,
+                }
+            } else {
+                App2Payload::Unknown
+            };
 
         // Commit phase.
         match payload {
@@ -771,7 +841,7 @@ pub(crate) fn parse_app2<T: ZByteReaderTrait>(
 fn un_zig_zag<T>(a: &[T]) -> [i32; 64]
 where
     T: Default + Copy,
-    i32: core::convert::From<T>
+    i32: core::convert::From<T>,
 {
     let mut output = [i32::default(); 64];
 

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -507,58 +507,6 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
             }
         }
 
-        // A.2.3 (Interleaved order).
-        //
-        // Scans of only one component are never interleaved. For all other scans the order of
-        // blocks within the MCU depends on the sample definitions from the header. There's as many
-        // vertical and horizontal samples in the scan as defined for the component.
-        //
-        // B.2.1 (High-level syntax)
-        //
-        // This clarifies that for progressive images only the first scan with DC components is
-        // allowed to be interleaved. All other scans with other components are not to be
-        // interleaved, implying those can not contain multiple subsampled components.
-        if scan_subsampled && ns > 1 {
-            let mut idx_block = 0;
-
-            for i in 0..ns {
-                let k = z_order[i as usize];
-                let component = &image.components[usize::from(k)];
-
-                for j in 0..component.vertical_sample {
-                    for i in 0..component.horizontal_sample {
-                        image.scan_blocks[idx_block] = ScanBlock {
-                            component: k,
-                            horizontal: i as u8,
-                            vertical: j as u8,
-                        };
-
-                        idx_block += 1;
-                    }
-                }
-            }
-
-            if idx_block > 10 {
-                return Err(DecodeErrors::SofError(format!(
-                    "Invalid scan with {:?} components, must be at most 10",
-                    idx_block,
-                )));
-            }
-
-            image.num_scan_blocks = idx_block as u8;
-        } else {
-            for i in 0..ns {
-                let component = z_order[usize::from(i)];
-                image.scan_blocks[usize::from(i)] = ScanBlock {
-                    component,
-                    horizontal: 0,
-                    vertical: 0,
-                };
-            }
-
-            image.num_scan_blocks = ns;
-        }
-
         // Spectral parameters.
         let spec_start = cursor.read_u8()?;
         let spec_end = cursor.read_u8()?;
@@ -608,6 +556,70 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
         image.succ_low = succ_low;
 
         trace!("Ss={spec_start}, Se={spec_end} Ah={succ_high} Al={succ_low}");
+
+        // A.2.3 (Interleaved order).
+        //
+        // Scans of only one component are never interleaved. For all other scans the order of
+        // blocks within the MCU depends on the sample definitions from the header. There's as many
+        // vertical and horizontal samples in the scan as defined for the component.
+        //
+        // B.2.1 (High-level syntax)
+        //
+        // This clarifies that for progressive images only the first scan with DC components is
+        // allowed to be interleaved. All other scans with other components are not to be
+        // interleaved, implying those can not contain multiple subsampled components.
+
+        // NOTE: not sure about comparing number of scans to components. It's an internal choice
+        // that we're using a different buffer in these cases but how would that influence the MCU
+        // order of scans that are present? It's not clear from the ITU T.81 specification.
+        let is_image_progressive =
+            usize::from(image.num_scans) != image.components.len();
+
+        if ns > 1 && !is_image_progressive {
+            let mut idx_block = 0;
+
+            for i in 0..ns {
+                let k = z_order[i as usize];
+                let component = &image.components[usize::from(k)];
+
+                for j in 0..component.vertical_sample {
+                    for i in 0..component.horizontal_sample {
+                        image.scan_blocks[idx_block] = ScanBlock {
+                            component: k,
+                            horizontal: i as u8,
+                            vertical: j as u8,
+                        };
+
+                        idx_block += 1;
+                    }
+                }
+            }
+
+            if idx_block > 10 {
+                return Err(DecodeErrors::SofError(format!(
+                    "Invalid scan with {:?} components, must be at most 10",
+                    idx_block,
+                )));
+            }
+
+            image.num_scan_blocks = idx_block as u8;
+        } else {
+            for i in 0..ns {
+                let component = z_order[usize::from(i)];
+                image.scan_blocks[usize::from(i)] = ScanBlock {
+                    component,
+                    horizontal: 0,
+                    vertical: 0,
+                };
+            }
+
+            image.num_scan_blocks = ns;
+        }
+
+        trace!(
+            "Blocks per MCU: {:?}",
+            &image.scan_blocks[..image.num_scan_blocks as usize]
+        );
 
         Ok(())
     })

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -594,6 +594,15 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     fn inner_decode_mcu_width<const PROGRESSIVE: bool, B: BitStream>(
         &mut self, context: &mut McuWidthContext<'_, B>,
     ) -> Result<McuContinuation, DecodeErrors> {
+        #[derive(Clone, Copy, Default)]
+        struct McuBlockCtx {
+            component: usize,
+            // Constant offset for all MCU's (in this row).
+            buffer_offset: usize,
+            // Scaling offset per MCU in this row.
+            mcu_stride: usize,
+        }
+
         // Destructure the context into local bindings up front. Reading the
         // hot loop through `context.<field>` keeps the optimizer from
         // treating the per-field mutable borrows as `noalias` and was
@@ -606,6 +615,35 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let tmp: &mut [i32; 64] = &mut *context.tmp;
         let stream: &mut B = &mut *context.stream;
         let progressive: &mut [Vec<i16>; MAX_COMPONENTS] = &mut *context.progressive;
+
+        // Calculate loop constants for all MCU blocks.
+        let mut mcu_ctx = [McuBlockCtx::default(); 10];
+        for (block, ctx) in self.scan_blocks[..usize::from(self.num_scan_blocks)]
+            .iter()
+            .zip(&mut mcu_ctx)
+        {
+            let component = &self.components[block.component];
+            ctx.component = block.component;
+
+            ctx.buffer_offset = if PROGRESSIVE {
+                let offset = mcu_row
+                    .checked_mul(component.width_stride)
+                    .and_then(|x| x.checked_mul(8))
+                    .ok_or(DecodeErrors::FormatStatic("Overflow"))?;
+
+                // Small stopgap for https://github.com/etemesi254/zune-image/issues/362
+                if offset >= progressive[block.component].len() {
+                    return Err(DecodeErrors::FormatStatic("Would panic on slice iteration"));
+                }
+
+                offset
+            } else {
+                (usize::from(block.vertical) * component.width_stride * 8)
+                    + (usize::from(block.horizontal) * 8)
+            };
+
+            ctx.mcu_stride = if PROGRESSIVE { 8 } else { component.horizontal_sample * 8 };
+        }
 
         let z_order = self.z_order;
         let z_scans = &z_order[..usize::from(self.num_scans)];
@@ -641,14 +679,13 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         for j in start_col..scan_du_width {
             // iterate over components
-            for part in &self.scan_blocks[..usize::from(self.num_scan_blocks)] {
-                let k = part.component;
+            for part in &mcu_ctx[..usize::from(self.num_scan_blocks)] {
                 // we made this loop body massive due to several different paths that depend on
                 // static conditions. Note we (potentially) call into other functions so the
                 // compiler will not unroll anything here anyways. The gains from separating
                 // differently optimized loop bodies are much greater than a single additional jump
                 // here.
-                let component = &mut self.components[k];
+                let component = &mut self.components[part.component];
 
                 let (dc_table, ac_table) = B::get_dc_ac_tables(
                     &mut self.entropy_tables,
@@ -658,33 +695,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
                 let qt_table = &component.quantization_table;
                 let channel = if PROGRESSIVE {
-                    let offset = mcu_row
-                        .checked_mul(component.width_stride)
-                        .and_then(|x| x.checked_mul(8))
-                        .ok_or(DecodeErrors::FormatStatic("Overflow"))?;
-                    // Small stopgap for https://github.com/etemesi254/zune-image/issues/362
-                    if offset >= progressive[k].len() {
-                        return Err(DecodeErrors::FormatStatic("Would panic on slice iteration"));
-                    }
-                    &mut progressive[k][offset..]
+                    &mut progressive[part.component]
                 } else {
                     &mut component.raw_coeff
                 };
 
                 let component_samples_needed = component.needed;
-
-                // If image is interleaved iterate over scan components,
-                // otherwise if it-s non-interleaved, these routines iterate in
-                // trivial scanline order(Y,Cb,Cr)
-                //
-                // Turn the bounds into a compile time constant for a common special case. This
-                // allows the compiler to unroll the loop and then do a bunch of interleaving.
-                //
-                // For PROGRESSIVE (non-interleaved), we iterate data units directly so
-                // h_samp/v_samp loops run exactly once.
-                let v_samp = usize::from(part.vertical);
-                let h_samp = usize::from(part.horizontal);
-
                 let result = if component_samples_needed {
                     // Fill the array with zeroes, decode_mcu_block expects
                     // a zero based array. Clobber is in zig-zag order though.
@@ -747,25 +763,15 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     // tmp was only written partially, note that len is in ZigZag order.
                     clobber_more_than_4x4 = len > 10;
 
-                    let idct_position = if PROGRESSIVE {
-                        // For non-interleaved, j indexes data units directly
-                        j * 8
-                    } else {
-                        // derived from stb and rewritten for my tastes
-                        let c2 = v_samp * 8;
-                        let c3 = ((j * component.horizontal_sample) + h_samp) * 8;
-
-                        component.width_stride * c2 + c3
-                    };
-
+                    let idct_position = part.buffer_offset + part.mcu_stride * j;
                     let idct_pos = channel.get_mut(idct_position..).unwrap();
 
+                    //  call idct.
                     if len <= 1 {
                         (self.idct_1x1_func)(tmp, idct_pos, component.width_stride);
                     } else if len <= 10 {
                         (self.idct_4x4_func)(tmp, idct_pos, component.width_stride);
                     } else {
-                        //  call idct.
                         (self.idct_func)(tmp, idct_pos, component.width_stride);
                     }
                 }

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -645,6 +645,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             ctx.mcu_stride = if PROGRESSIVE { 8 } else { component.horizontal_sample * 8 };
         }
 
+        for block in &mut mcu_ctx[..usize::from(self.num_scan_blocks)] {
+            block.buffer_offset += block.mcu_stride * start_col;
+        }
+
         let z_order = self.z_order;
         let z_scans = &z_order[..usize::from(self.num_scans)];
 
@@ -679,7 +683,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         for j in start_col..scan_du_width {
             // iterate over components
-            for part in &mcu_ctx[..usize::from(self.num_scan_blocks)] {
+            for part in &mut mcu_ctx[..usize::from(self.num_scan_blocks)] {
                 // we made this loop body massive due to several different paths that depend on
                 // static conditions. Note we (potentially) call into other functions so the
                 // compiler will not unroll anything here anyways. The gains from separating
@@ -763,7 +767,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     // tmp was only written partially, note that len is in ZigZag order.
                     clobber_more_than_4x4 = len > 10;
 
-                    let idct_position = part.buffer_offset + part.mcu_stride * j;
+                    // Each block is accessed exactly once in each iteration over the MCU row. Thus
+                    // each time the offset just gets one larger based on the stride.
+                    let idct_position = part.buffer_offset;
+                    part.buffer_offset += part.mcu_stride;
                     let idct_pos = channel.get_mut(idct_position..).unwrap();
 
                     //  call idct.

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -584,31 +584,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     fn decode_mcu_width<const PROGRESSIVE: bool, B: BitStream>(
         &mut self, context: &mut McuWidthContext<'_, B>,
     ) -> Result<McuContinuation, DecodeErrors> {
-        let is_one_by_one = !self.scan_subsampled;
-
-        // The definition of MCU depends on the sampling factor of involved scans. When components
-        // have different factors then each Minimal-Coding-Unit is the least common multiple such
-        // that we have an integer number of blocks from each component. But the decoding of these
-        // components differs from it otherwise, we need an inner loop with a dynamic amount of
-        // coefficients per component, whereas otherwise we have exactly one block of coefficients
-        // encoded for each component in the bitstream order.
-        //
-        // We statically specialize on this to improve code generation of the common case a little
-        // bit. We could also special case common sub-sampling cases but be mindful of code bloat.
-        if is_one_by_one {
-            self.inner_decode_mcu_width::<PROGRESSIVE, false, B>(context)
-        } else {
-            self.inner_decode_mcu_width::<PROGRESSIVE, true, B>(context)
-        }
+        self.inner_decode_mcu_width::<PROGRESSIVE, B>(context)
     }
 
     // Inline-never ensures we do get this function optimize on its own, into two different
     // versions, without the optimizer tripping up over the complexity that comes with the
-    // constant folding. And constant folding is quite important for performance here as
-    // when `not SAMPLED` then the inner loop has exactly one iteration per component in
-    // the scan. The difference was ~1% or a bit more.
+    // constant folding.
     #[allow(clippy::too_many_lines)]
-    fn inner_decode_mcu_width<const PROGRESSIVE: bool, const SAMPLED: bool, B: BitStream>(
+    fn inner_decode_mcu_width<const PROGRESSIVE: bool, B: BitStream>(
         &mut self, context: &mut McuWidthContext<'_, B>,
     ) -> Result<McuContinuation, DecodeErrors> {
         // Destructure the context into local bindings up front. Reading the
@@ -658,7 +641,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         for j in start_col..scan_du_width {
             // iterate over components
-            for &k in z_scans {
+            for part in &self.scan_blocks[..usize::from(self.num_scan_blocks)] {
+                let k = part.component;
                 // we made this loop body massive due to several different paths that depend on
                 // static conditions. Note we (potentially) call into other functions so the
                 // compiler will not unroll anything here anyways. The gains from separating
@@ -698,98 +682,91 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 //
                 // For PROGRESSIVE (non-interleaved), we iterate data units directly so
                 // h_samp/v_samp loops run exactly once.
-                let v_step =
-                    if SAMPLED && !PROGRESSIVE { 0..component.vertical_sample } else { 0..1 };
+                let v_samp = usize::from(part.vertical);
+                let h_samp = usize::from(part.horizontal);
 
-                for v_samp in v_step {
-                    let h_step =
-                        if SAMPLED && !PROGRESSIVE { 0..component.horizontal_sample } else { 0..1 };
+                let result = if component_samples_needed {
+                    // Fill the array with zeroes, decode_mcu_block expects
+                    // a zero based array. Clobber is in zig-zag order though.
+                    // Writing consecutive entries is basically free in terms
+                    // of memory throughput so we opt for a larger power of
+                    // two which lets the compiler turn this into a repeated
+                    // write of a zeroed vector register, which does not have
+                    // any branches, instead of a more difficult pattern where
+                    // we attempt to overwrite exactly one coefficient.
+                    let clobber_len = if clobber_more_than_4x4 { 64 } else { 32 };
 
-                    for h_samp in h_step {
-                        let result = if component_samples_needed {
-                            // Fill the array with zeroes, decode_mcu_block expects
-                            // a zero based array. Clobber is in zig-zag order though.
-                            // Writing consecutive entries is basically free in terms
-                            // of memory throughput so we opt for a larger power of
-                            // two which lets the compiler turn this into a repeated
-                            // write of a zeroed vector register, which does not have
-                            // any branches, instead of a more difficult pattern where
-                            // we attempt to overwrite exactly one coefficient.
-                            let clobber_len = if clobber_more_than_4x4 { 64 } else { 32 };
+                    tmp[..clobber_len].fill(0);
 
-                            tmp[..clobber_len].fill(0);
+                    stream.decode_mcu_block(
+                        &mut self.stream,
+                        dc_table,
+                        ac_table,
+                        qt_table,
+                        tmp,
+                        &mut component.dc_pred,
+                        &mut component.dc_diff,
+                    )
+                } else {
+                    // We do not touch tmp so there is no need to reset it.
+                    stream.discard_mcu_block(
+                        &mut self.stream,
+                        dc_table,
+                        ac_table,
+                        &mut component.dc_diff,
+                    )
+                };
 
-                            stream.decode_mcu_block(
-                                &mut self.stream,
-                                dc_table,
-                                ac_table,
-                                qt_table,
-                                tmp,
-                                &mut component.dc_pred,
-                                &mut component.dc_diff,
-                            )
-                        } else {
-                            // We do not touch tmp so there is no need to reset it.
-                            stream.discard_mcu_block(
-                                &mut self.stream,
-                                dc_table,
-                                ac_table,
-                                &mut component.dc_diff,
-                            )
-                        };
+                // If an error occurs we can either propagate it
+                // as an error or print it and call terminate.
+                //
+                // This allows even corrupt images to render something,
+                // even if its bad, matching browsers.
+                //
+                // See example in https://github.com/etemesi254/zune-image/issues/293
+                let Ok(len) = result else {
+                    let err = result.err().unwrap();
+                    // Always propagate ExhaustedData for incremental
+                    // decoding support — the caller can retry with more
+                    // data.
+                    if err.is_recoverable_eof() {
+                        return Err(err);
+                    }
+                    if self.stream.eof()? {
+                        return Err(DecodeErrors::ExhaustedData);
+                    }
+                    return if self.options.strict_mode() {
+                        Err(err)
+                    } else {
+                        error!("{}", err);
+                        Ok(McuContinuation::Terminate)
+                    };
+                };
 
-                        // If an error occurs we can either propagate it
-                        // as an error or print it and call terminate.
-                        //
-                        // This allows even corrupt images to render something,
-                        // even if its bad, matching browsers.
-                        //
-                        // See example in https://github.com/etemesi254/zune-image/issues/293
-                        let Ok(len) = result else {
-                            let err = result.err().unwrap();
-                            // Always propagate ExhaustedData for incremental
-                            // decoding support — the caller can retry with more
-                            // data.
-                            if err.is_recoverable_eof() {
-                                return Err(err);
-                            }
-                            if self.stream.eof()? {
-                                return Err(DecodeErrors::ExhaustedData);
-                            }
-                            return if self.options.strict_mode() {
-                                Err(err)
-                            } else {
-                                error!("{}", err);
-                                Ok(McuContinuation::Terminate)
-                            };
-                        };
+                if component_samples_needed {
+                    // tmp was only written partially, note that len is in ZigZag order.
+                    clobber_more_than_4x4 = len > 10;
 
-                        if component_samples_needed {
-                            // tmp was only written partially, note that len is in ZigZag order.
-                            clobber_more_than_4x4 = len > 10;
+                    let idct_position = if PROGRESSIVE {
+                        // For non-interleaved, j indexes data units directly
+                        j * 8
+                    } else {
+                        // derived from stb and rewritten for my tastes
+                        let c2 = v_samp * 8;
+                        let c3 = ((j * component.horizontal_sample) + h_samp) * 8;
 
-                            let idct_position = if PROGRESSIVE {
-                                // For non-interleaved, j indexes data units directly
-                                j * 8
-                            } else {
-                                // derived from stb and rewritten for my tastes
-                                let c2 = v_samp * 8;
-                                let c3 = ((j * component.horizontal_sample) + h_samp) * 8;
+                        component.width_stride * c2 + c3
+                    };
 
-                                component.width_stride * c2 + c3
-                            };
+                    let idct_pos = channel.get_mut(idct_position..).unwrap();
 
-                            let idct_pos = channel.get_mut(idct_position..).unwrap();
-
-                            if len <= 1 {
-                                (self.idct_1x1_func)(tmp, idct_pos, component.width_stride);
-                            } else if len <= 10 {
-                                (self.idct_4x4_func)(tmp, idct_pos, component.width_stride);
-                            } else {
-                                //  call idct.
-                                (self.idct_func)(tmp, idct_pos, component.width_stride);
-                            }
-                        }
+                    if len <= 1 {
+                        (self.idct_1x1_func)(tmp, idct_pos, component.width_stride);
+                    } else if len <= 10 {
+                        (self.idct_4x4_func)(tmp, idct_pos, component.width_stride);
+                    } else {
+                        //  call idct.
+                        (self.idct_func)(tmp, idct_pos, component.width_stride);
                     }
                 }
             }


### PR DESCRIPTION
Build a list of blocks in their iteration order, instead of by scan order and deeply nested loops. This mainly helps progressive images due to constant folding (a comment touched on this) but it still simplifies the indexing structure since we no longer have the offset calculation happening during decoding but rather collapse it into a simple `base + stride * j_mcu` that can be updated while iterating.

While implementing this I noticed we're not actually enforcing a section of the specification found in B.2.1 (High-level syntax) where non-DC scans *must not* contain more than one component and thus never should run the mcu-order case. Since that is itself another special case I'm going to investigate if this would benefit from a specialized method or not; and what images may be affected. Maybe some corrupted images actually rely on this being enforced in a particular way.

Opening this as a draft since the main point here is to benchmark, this is a speedup primarily even though it also simplifies logic (in my opinion anyways).