### PR TITLE
JpegDecoder: Suspend progressive Huffman decoding at MCU boundaries

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -107,3 +107,19 @@ Caches (sum of all):
 ```
 
 Benchmark results found in [Benchmark Results](./benchmark-results.md)
+
+### Incremental JPEG retry cost
+
+`decode_jpeg` measures zune-jpeg work across three recoverable EOF results and
+a final successful retry. Run the focused group with:
+
+```shell
+cargo bench -p zune-benches --bench decode_jpeg -- "jpeg: Repeated incremental retry cost"
+```
+
+The baseline case resumes from its latest completed MCU row. The progressive
+cases measure first-DC and AC-refinement scans resuming from their latest
+completed MCU transaction. Correctness tests separately assert each checkpoint
+boundary. This group does not compare suspension against mozjpeg because its
+Rust API does not expose a suspending source manager; the other progressive
+decode groups retain the one-shot zune-jpeg/mozjpeg comparison.

--- a/benchmarks/benches/decode_jpeg.rs
+++ b/benchmarks/benches/decode_jpeg.rs
@@ -403,6 +403,162 @@ fn decode_streaming_mode(c: &mut Criterion) {
     });
 }
 
+#[derive(Clone, Copy)]
+struct ProgressiveScanRange {
+    data_start: usize,
+    data_end:   usize,
+    spec_start: u8,
+    spec_end:   u8,
+    succ_high:  u8
+}
+
+fn jpeg_markers(data: &[u8]) -> Vec<(usize, u8, Option<usize>)> {
+    // Keep this standalone benchmark helper aligned with the equivalent
+    // fixture scanner in zune-jpeg/tests/incremental.rs.
+    let mut markers = Vec::new();
+    let mut offset = 0;
+    while offset + 1 < data.len() {
+        if data[offset] != 0xFF {
+            offset += 1;
+            continue;
+        }
+        let code = data[offset + 1];
+        if code == 0xFF || code == 0x00 {
+            offset += 1;
+            continue;
+        }
+        if code == 0xD8 || code == 0xD9 || (0xD0..=0xD7).contains(&code) {
+            markers.push((offset, code, None));
+            offset += 2;
+            continue;
+        }
+        if offset + 3 >= data.len() {
+            break;
+        }
+        let length = usize::from(u16::from_be_bytes([data[offset + 2], data[offset + 3]]));
+        if length < 2 || offset + 2 + length > data.len() {
+            break;
+        }
+        markers.push((offset, code, Some(length)));
+        offset += 2 + length;
+    }
+    markers
+}
+
+fn progressive_scan_ranges(data: &[u8]) -> Vec<ProgressiveScanRange> {
+    let markers = jpeg_markers(data);
+    markers
+        .iter()
+        .enumerate()
+        .filter_map(|(index, (offset, code, length))| {
+            if *code != 0xDA {
+                return None;
+            }
+            let length = length.expect("SOS must have a length");
+            let payload = offset + 4;
+            let components = usize::from(data[payload]);
+            let params = payload + 1 + 2 * components;
+            let data_start = offset + 2 + length;
+            let data_end = markers
+                .iter()
+                .skip(index + 1)
+                .find_map(|(next_offset, next_code, _)| {
+                    (!((0xD0..=0xD7).contains(next_code))).then_some(*next_offset)
+                })
+                .unwrap_or(data.len());
+            let successive = data[params + 2];
+            Some(ProgressiveScanRange {
+                data_start,
+                data_end,
+                spec_start: data[params],
+                spec_end: data[params + 1],
+                succ_high: successive >> 4
+            })
+        })
+        .collect()
+}
+
+fn repeated_limits(start: usize, end: usize) -> [usize; 3] {
+    assert!(end > start + 3, "scan range is too small for repeated retries");
+    let length = end - start;
+    [start + length / 4, start + length / 2, start + length * 3 / 4]
+}
+
+fn decode_with_repeated_growth(data: &[u8], limits: &[usize]) -> Vec<u8> {
+    let first_limit = *limits.first().expect("at least one retry limit is required");
+    let limit = Rc::new(Cell::new(first_limit));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
+    decoder.decode_headers().expect("headers must fit before the first retry limit");
+    let mut output = vec![0; decoder.output_buffer_size().unwrap()];
+
+    for visible in limits {
+        limit.set(*visible);
+        let error = decoder
+            .decode_into(&mut output)
+            .expect_err("each partial visibility limit must stop at recoverable EOF");
+        assert!(error.is_recoverable_eof(), "got: {error:?}");
+    }
+
+    limit.set(data.len());
+    decoder
+        .decode_into(&mut output)
+        .expect("full input must complete after repeated retries");
+    output
+}
+
+/// Measures total wall-clock work across three EOF/retry cycles plus the final
+/// successful decode. This zune-only group measures retry work; the progressive
+/// decode groups above provide one-shot zune-jpeg/mozjpeg comparisons.
+fn decode_repeated_retry_cost(c: &mut Criterion) {
+    let baseline = read(
+        sample_path().join("test-images/jpeg/benchmarks/speed_bench_hv_subsampling.jpg")
+    )
+    .unwrap();
+    let baseline_start = baseline
+        .windows(2)
+        .position(|window| window == [0xFF, 0xDA])
+        .expect("baseline fixture must contain SOS");
+    let baseline_sos_length = usize::from(u16::from_be_bytes([
+        baseline[baseline_start + 2],
+        baseline[baseline_start + 3]
+    ]));
+    let baseline_entropy_start = baseline_start + 2 + baseline_sos_length;
+    let baseline_limits = repeated_limits(baseline_entropy_start, baseline.len() - 2);
+
+    let progressive = read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_prog.jpg"))
+        .unwrap();
+    let scans = progressive_scan_ranges(&progressive);
+    let dc_first = scans
+        .iter()
+        .find(|scan| scan.spec_start == 0 && scan.spec_end == 0 && scan.succ_high == 0)
+        .expect("progressive fixture must contain a first-DC scan");
+    let ac_refinement = scans
+        .iter()
+        .find(|scan| scan.spec_start > 0 && scan.succ_high > 0)
+        .expect("progressive fixture must contain an AC-refinement scan");
+    let dc_limits = repeated_limits(dc_first.data_start, dc_first.data_end);
+    let ac_refinement_limits =
+        repeated_limits(ac_refinement.data_start, ac_refinement.data_end);
+
+    let mut group = c.benchmark_group("jpeg: Repeated incremental retry cost");
+    group.bench_function("baseline row checkpoints", |b| {
+        b.iter(|| black_box(decode_with_repeated_growth(&baseline, &baseline_limits)))
+    });
+    group.bench_function("progressive first-DC MCU checkpoints", |b| {
+        b.iter(|| black_box(decode_with_repeated_growth(&progressive, &dc_limits)))
+    });
+    group.bench_function("progressive AC-refinement MCU checkpoints", |b| {
+        b.iter(|| {
+            black_box(decode_with_repeated_growth(
+                &progressive,
+                &ac_refinement_limits
+            ))
+        })
+    });
+}
+
 criterion_group!(name=benches;
       config={
       let c = Criterion::default();
@@ -412,6 +568,7 @@ criterion_group!(name=benches;
     decode_hv_samp,criterion_benchmark_grayscale,
     decode_hv_samp_prog,decode_h_samp_prog,decode_no_samp_prog,decode_v_samp_prog,
     decode_no_samp_opts,
-    decode_restart_full,decode_restart_resume,decode_streaming_mode);
+    decode_restart_full,decode_restart_resume,decode_streaming_mode,
+    decode_repeated_retry_cost);
 
 criterion_main!(benches);

--- a/crates/zune-jpeg/README.md
+++ b/crates/zune-jpeg/README.md
@@ -54,6 +54,12 @@ bodies, including baseline multi-SOS / non-interleaved images. Those images may
 still report no stable output rows until the later component scans have been
 decoded and final assembly has run.
 
+Progressive Huffman scans checkpoint after each completed MCU. DC-first,
+DC-refinement, AC-first, and AC-refinement scans therefore resume without
+reapplying an incomplete MCU. Arithmetic entropy decoding does not support an
+equivalent state snapshot, so progressive arithmetic retries replay from the
+current scan start.
+
 Scan checkpoints store only scalar resume state: stream position, next MCU
 row/column, restart countdown, SOS parameters, DC predictors, and bitstream
 state. Coefficients for already-decoded component scans stay on the decoder

--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -117,6 +117,7 @@ pub(crate) struct HuffmanBitstreamState {
     pub(crate) buffer:         u64,
     pub(crate) aligned_buffer: u64,
     pub(crate) bits_left:      u8,
+    pub(crate) reader_position: usize,
     pub(crate) marker:         Option<Marker>,
     pub(crate) overread_by:    usize,
     pub(crate) seen_eoi:       bool,
@@ -225,6 +226,14 @@ pub(crate) trait BitStream {
     /// Tell us the bits left the two buffer
     fn bits_left(&self) -> u8;
 
+    /// Absolute source position corresponding to the buffered entropy state.
+    fn checkpoint_position(&self) -> Option<usize> {
+        None
+    }
+
+    /// Initialize the entropy source position at a scan or restart boundary.
+    fn set_checkpoint_position(&mut self, _position: usize) {}
+
     /// Whether this bitstream type supports per-MCU checkpoint/restore.
     /// Huffman coding supports it; arithmetic coding does not (the A/C/CT
     /// registers are coupled to statistical context tables).
@@ -257,6 +266,8 @@ pub(crate) struct BitStreamHuffman {
     aligned_buffer:      u64,
     /// Tell us the bits left the two buffer
     bits_left:           u8,
+    /// Absolute reader position after bytes prefetched into the bit buffer.
+    reader_position:     usize,
     /// Did we find a marker(RST/EOF) during decoding?
     marker:              Option<Marker>,
     /// An i16 with the bit corresponding to successive_low set to 1, others 0.
@@ -463,6 +474,7 @@ impl BitStream for BitStreamHuffman {
             buffer:              0,
             aligned_buffer:      0,
             bits_left:           0,
+            reader_position:     0,
             marker:              None,
             successive_low_mask: 1,
             spec_start:          0,
@@ -482,6 +494,7 @@ impl BitStream for BitStreamHuffman {
             buffer:              0,
             aligned_buffer:      0,
             bits_left:           0,
+            reader_position:     0,
             marker:              None,
             successive_low_mask: 1i16 << al,
             spec_start:          spec_start,
@@ -514,6 +527,16 @@ impl BitStream for BitStreamHuffman {
     }
 
     #[inline(always)]
+    fn checkpoint_position(&self) -> Option<usize> {
+        Some(self.reader_position)
+    }
+
+    #[inline(always)]
+    fn set_checkpoint_position(&mut self, position: usize) {
+        self.reader_position = position;
+    }
+
+    #[inline(always)]
     fn supports_mcu_checkpoint() -> bool {
         true
     }
@@ -524,6 +547,7 @@ impl BitStream for BitStreamHuffman {
             buffer:         self.buffer,
             aligned_buffer: self.aligned_buffer,
             bits_left:      self.bits_left,
+            reader_position: self.reader_position,
             marker:         self.marker,
             overread_by:    self.overread_by,
             seen_eoi:       self.seen_eoi,
@@ -536,6 +560,7 @@ impl BitStream for BitStreamHuffman {
         self.buffer = state.buffer;
         self.aligned_buffer = state.aligned_buffer;
         self.bits_left = state.bits_left;
+        self.reader_position = state.reader_position;
         self.marker = state.marker;
         self.overread_by = state.overread_by;
         self.seen_eoi = state.seen_eoi;
@@ -578,6 +603,7 @@ impl BitStream for BitStreamHuffman {
             ($buffer:expr,$byte:expr,$bits_left:expr) => {
                 // read a byte from the stream
                 $byte = u64::from(reader.read_u8());
+                self.reader_position += 1;
                 self.overread_by += usize::from(reader.eof()?);
                 // append to the buffer
                 // JPEG is a MSB type buffer so that means we append this
@@ -589,11 +615,13 @@ impl BitStream for BitStreamHuffman {
                 if $byte == 0xff {
                     // read next byte
                     let mut next_byte = u64::from(reader.read_u8());
+                    self.reader_position += 1;
                     // Byte snuffing, if we encounter byte snuff, we skip the byte
                     if next_byte != 0x00 {
                         // skip that byte we read
                         while next_byte == 0xFF {
                             next_byte = u64::from(reader.read_u8());
+                            self.reader_position += 1;
                         }
 
                         if next_byte != 0x00 {
@@ -657,6 +685,7 @@ impl BitStream for BitStreamHuffman {
             // byte at a time read
 
             if let Ok(bytes) = reader.read_fixed_bytes_or_error::<4>() {
+                self.reader_position += 4;
                 // we have 4 bytes to spare, read the 4 bytes into a temporary buffer
                 // create buffer
                 let msb_buf = u32::from_be_bytes(bytes);
@@ -670,6 +699,7 @@ impl BitStream for BitStreamHuffman {
                 }
 
                 reader.rewind(4)?;
+                self.reader_position -= 4;
             }
             // This serves two reasons,
             // 1: Make clippy shut up
@@ -856,8 +886,13 @@ impl BitStream for BitStreamHuffman {
             }
         }
 
-        if self.get_bit() == 1 {
-            *block = block.wrapping_add(self.successive_low_mask);
+        let bit = self.successive_low_mask;
+        if self.get_bit() == 1 && (*block & bit) == 0 {
+            if *block >= 0 {
+                *block = block.wrapping_add(bit);
+            } else {
+                *block = block.wrapping_sub(bit);
+            }
         }
 
         Ok(())

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -48,6 +48,8 @@ use crate::upsampler::{
 
 /// Maximum components
 pub(crate) const MAX_COMPONENTS: usize = 4;
+#[cfg(feature = "arith")]
+pub(crate) const MAX_ARITHMETIC_TABLES: usize = 16;
 
 /// Maximum image dimensions supported.
 pub(crate) const MAX_DIMENSIONS: usize = 1 << 27;
@@ -98,9 +100,10 @@ pub(crate) struct ScanDecodeState {
 
 /// Saved state at the start of a progressive scan.
 ///
-/// Progressive refinement scans update existing coefficients in place, so a
-/// retry must restart at a scan boundary using only completed scans. The
-/// coefficient buffers themselves stay on `JpegDecoder`.
+/// This is the fallback retry boundary when an entropy decoder cannot safely
+/// checkpoint an individual MCU. Progressive Huffman scans use
+/// `ProgressiveFineCheckpoint`; arithmetic scans replay from this boundary.
+/// Completed-scan coefficient buffers stay on `JpegDecoder`.
 #[derive(Clone)]
 pub(crate) struct ProgressiveScanCheckpoint {
     pub(crate) stream_position: usize,
@@ -110,11 +113,11 @@ pub(crate) struct ProgressiveScanCheckpoint {
     pub(crate) completed_scans: usize
 }
 
-/// Saved state inside a progressive scan when mid-scan resume is safe.
+/// Saved state at a completed progressive Huffman MCU boundary.
 ///
-/// This is only recorded for first DC scans. Those coefficients are assigned
-/// once, so keeping the active scan scratch buffer across EOF and resuming from
-/// a later MCU boundary cannot double-apply refinement data.
+/// Coefficient changes for the next MCU are committed transactionally, so the
+/// active scan scratch buffer can survive EOF across every progressive scan
+/// type without exposing or double-applying an incomplete MCU.
 #[derive(Clone)]
 pub(crate) struct ProgressiveFineCheckpoint {
     pub(crate) stream_position:  usize,
@@ -234,10 +237,10 @@ pub(crate) struct EntropyTables {
     pub(crate) ac_huffman:    [Option<HuffmanTable>; MAX_COMPONENTS],
     /// Arithmetic coding initial conditioning parameters and statistics (has a default value)
     #[cfg(feature = "arith")]
-    pub(crate) dc_arithmetic: [ArithDCTables; MAX_COMPONENTS],
+    pub(crate) dc_arithmetic: [ArithDCTables; MAX_ARITHMETIC_TABLES],
     /// Arithmetic coding initial conditioning parameters and statistics  (has a default value)
     #[cfg(feature = "arith")]
-    pub(crate) ac_arithmetic: [ArithACTables; MAX_COMPONENTS]
+    pub(crate) ac_arithmetic: [ArithACTables; MAX_ARITHMETIC_TABLES]
 }
 
 /// A JPEG Decoder Instance.
@@ -351,8 +354,8 @@ pub struct JpegDecoder<T> {
     /// Active progressive scan scratch buffers.
     ///
     /// Storage is retained across EOF or cancellation so retries can reuse its
-    /// capacity. Safe first-DC scans also keep its contents so a later retry can
-    /// resume from a fine checkpoint without committing partial scan data.
+    /// capacity. Huffman scans also keep completed MCU transactions so a later
+    /// retry can resume from a fine checkpoint without exposing partial data.
     pub(crate) progressive_scan_buffer: [Vec<i16>; MAX_COMPONENTS],
     /// Number of progressive scans committed into `progressive_mcus_buffer`.
     pub(crate) progressive_completed_scans: usize,
@@ -408,7 +411,7 @@ where
     // Mark the current stream position as a safe resume point at a marker
     // boundary; on a future retry decode_headers_internal will seek here
     // instead of restarting from SOI.
-    fn stream_position(&mut self) -> Result<usize, DecodeErrors> {
+    pub(crate) fn stream_position(&mut self) -> Result<usize, DecodeErrors> {
         let position = self.stream.position()?;
         usize::try_from(position).map_err(|_| {
             DecodeErrors::FormatStatic("Stream position does not fit in usize")
@@ -520,43 +523,53 @@ where
     }
 
     pub(crate) fn checkpoint_progressive_fine_scan(
-        &mut self, mcu_row: usize, mcu_col: usize, bitstream_state: BitstreamStateSnapshot
-    ) -> Result<(), DecodeErrors> {
-        let stream_position = self.stream_position()?;
-        let append_snapshot = HeaderAppendStateSnapshot::capture(self);
-        let sos_snapshot = self.capture_sos_params();
+        &mut self, stream_position: usize, mcu_row: usize, mcu_col: usize,
+        bitstream_state: BitstreamStateSnapshot
+    ) {
         let dc_predictions = core::array::from_fn(|idx| {
             self.components
                 .get(idx)
                 .map_or((0, 0), |component| (component.dc_pred, component.dc_diff))
         });
+        let needs_allocation = self
+            .scan_state
+            .as_deref()
+            .is_some_and(|state| state.progressive_fine_checkpoint.is_none());
+        let snapshots = needs_allocation.then(|| {
+            (
+                HeaderAppendStateSnapshot::capture(self),
+                self.capture_sos_params()
+            )
+        });
 
         if let Some(state) = self.scan_state.as_mut() {
-            state.progressive_fine_checkpoint = Some(Box::new(ProgressiveFineCheckpoint {
-                stream_position,
-                append_snapshot,
-                sos_snapshot,
-                completed_scans: self.progressive_completed_scans,
-                displayed_scans: self.progressive_displayed_scans,
-                mcu_row,
-                mcu_col,
-                todo: self.todo,
-                dc_predictions,
-                bitstream_state
-            }));
+            if let Some(checkpoint) = state.progressive_fine_checkpoint.as_deref_mut() {
+                checkpoint.stream_position = stream_position;
+                checkpoint.mcu_row = mcu_row;
+                checkpoint.mcu_col = mcu_col;
+                checkpoint.todo = self.todo;
+                checkpoint.dc_predictions = dc_predictions;
+                checkpoint.bitstream_state = bitstream_state;
+            } else if let Some((append_snapshot, sos_snapshot)) = snapshots {
+                state.progressive_fine_checkpoint = Some(Box::new(ProgressiveFineCheckpoint {
+                    stream_position,
+                    append_snapshot,
+                    sos_snapshot,
+                    completed_scans: self.progressive_completed_scans,
+                    displayed_scans: self.progressive_displayed_scans,
+                    mcu_row,
+                    mcu_col,
+                    todo: self.todo,
+                    dc_predictions,
+                    bitstream_state
+                }));
+            }
         }
-        Ok(())
     }
 
     pub(crate) fn invalidate_progressive_scan_checkpoint(&mut self) {
         if let Some(state) = self.scan_state.as_mut() {
             state.progressive_checkpoint = None;
-            state.progressive_fine_checkpoint = None;
-        }
-    }
-
-    pub(crate) fn invalidate_progressive_fine_checkpoint(&mut self) {
-        if let Some(state) = self.scan_state.as_mut() {
             state.progressive_fine_checkpoint = None;
         }
     }
@@ -654,19 +667,9 @@ where
                 dc_huffman: [None, None, None, None],
                 ac_huffman: [None, None, None, None],
                 #[cfg(feature = "arith")]
-                dc_arithmetic: [
-                    ArithDCTables::default(),
-                    ArithDCTables::default(),
-                    ArithDCTables::default(),
-                    ArithDCTables::default()
-                ],
+                dc_arithmetic: [ArithDCTables::default(); MAX_ARITHMETIC_TABLES],
                 #[cfg(feature = "arith")]
-                ac_arithmetic: [
-                    ArithACTables::default(),
-                    ArithACTables::default(),
-                    ArithACTables::default(),
-                    ArithACTables::default()
-                ]
+                ac_arithmetic: [ArithACTables::default(); MAX_ARITHMETIC_TABLES]
             },
             components:        vec![],
             // Interleaved information
@@ -886,9 +889,10 @@ where
     /// Return whether incremental mode is enabled.
     ///
     /// Incremental mode makes scan EOF recoverable in non-strict mode and
-    /// records per-row checkpoints during the first scan decode attempt,
-    /// allowing a later retry to resume from the latest stable row instead of
-    /// replaying from scan start.
+    /// records checkpoints during the first scan decode attempt. Baseline
+    /// Huffman scans checkpoint by row, while progressive Huffman scans
+    /// checkpoint after each completed MCU. Arithmetic progressive scans replay
+    /// from the current scan start.
     ///
     /// It is disabled by default so one-shot decoding keeps the lowest
     /// overhead path.
@@ -902,7 +906,17 @@ where
     /// Call this before the first `decode_into` scan attempt. When enabled,
     /// scan EOF is recoverable and decoding can be retried with more input.
     /// Otherwise, non-strict decoding returns best-effort output on scan EOF.
-    /// Strict mode always treats scan EOF as an error. The default is `false`.
+    /// Strict mode always treats scan EOF as an error. Baseline Huffman scans
+    /// save row checkpoints on the first attempt, while progressive Huffman scans
+    /// save completed-MCU checkpoints, and all progressive scans decode through
+    /// scratch coefficient storage so completed scans can be rendered as
+    /// previews if that first attempt reaches EOF.
+    ///
+    /// The default is `false`. A first-attempt one-shot progressive decode then
+    /// updates its existing coefficient buffers directly and does not clone them.
+    /// Incremental mode clones only the coefficient buffers touched by the active
+    /// progressive scan. After any previous scan decode attempt, later attempts
+    /// enable the same preservation automatically so retries remain idempotent.
     pub fn set_incremental_mode(&mut self, enabled: bool) {
         self.incremental_mode = enabled;
     }
@@ -1292,8 +1306,8 @@ where
     // dropped) so this remains atomic for resumability purposes: an EOF mid-
     // payload surfaces before any decoder state is mutated.
     fn skip_marker_payload(&mut self) -> Result<(), DecodeErrors> {
-        with_marker_body(self, |_, _body| {
-            warn!("Skipping {} bytes", _body.body().len());
+        with_marker_body(self, |_, body| {
+            warn!("Skipping {} bytes", body.body().len());
             Ok(())
         })
     }

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -20,6 +20,8 @@ use zune_core::log::{trace, warn};
 
 use crate::components::{Components, SampleRatios};
 use crate::decoder::{ExtendedXmpSegment, GainMapInfo, ICCChunk, JpegDecoder, MAX_COMPONENTS};
+#[cfg(feature = "arith")]
+use crate::decoder::MAX_ARITHMETIC_TABLES;
 use crate::errors::DecodeErrors;
 use crate::huffman::HuffmanTable;
 use crate::misc::{SOFMarkers, UN_ZIGZAG};
@@ -218,9 +220,10 @@ where
             let dc_or_ac = (ht_info >> 4) & 0xF;
             let index = (ht_info & 0xF) as usize;
 
-            if index >= MAX_COMPONENTS {
+            if index >= MAX_ARITHMETIC_TABLES {
                 return Err(DecodeErrors::ArithmeticDecode(format!(
-                    "Invalid DAC index {index}, expected between 0 and 3"
+                    "Invalid DAC index {index}, expected between 0 and {}",
+                    MAX_ARITHMETIC_TABLES - 1
                 )));
             }
 
@@ -493,6 +496,17 @@ pub(crate) fn parse_sos<T: ZByteReaderTrait>(
             // top 4 bits contain dc huffman destination table
             // lower four bits contain ac huffman destination table
             let y = cursor.read_u8()?;
+
+            if !image.is_arithmetic {
+                let dc_table = usize::from(y >> 4);
+                let ac_table = usize::from(y & 0x0F);
+                if dc_table >= MAX_COMPONENTS || ac_table >= MAX_COMPONENTS {
+                    return Err(DecodeErrors::SosError(format!(
+                        "Invalid Huffman table selectors DC={dc_table}, AC={ac_table}; expected 0-{}",
+                        MAX_COMPONENTS - 1
+                    )));
+                }
+            }
 
             let mut j = 0;
             while j < image.info.components {

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -64,6 +64,12 @@
 //! still report no stable output rows until the later component scans have been
 //! decoded and final assembly has run.
 //!
+//! Progressive Huffman scans checkpoint after each completed MCU. DC-first,
+//! DC-refinement, AC-first, and AC-refinement scans therefore resume without
+//! reapplying an incomplete MCU. Arithmetic entropy decoding does not support an
+//! equivalent state snapshot, so progressive arithmetic retries replay from the
+//! current scan start.
+//!
 //! Scan checkpoints store only scalar resume state: stream position, next MCU
 //! row/column, restart countdown, SOS parameters, DC predictors, and bitstream
 //! state. Coefficients for already-decoded component scans stay on the decoder

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -17,7 +17,7 @@ use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::colorspace::ColorSpace;
 use zune_core::log::{error, trace, warn};
 
-use crate::bitstream::BitStream;
+use crate::bitstream::{BitStream, BitstreamStateSnapshot};
 use crate::components::SampleRatios;
 use crate::decoder::{JpegDecoder, ProgressiveFineCheckpoint, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
@@ -26,7 +26,13 @@ use crate::marker::Marker;
 use crate::mcu::DCT_BLOCK;
 use crate::misc::{calculate_padded_width, setup_component_params};
 
-const PROGRESSIVE_CHECKPOINT_ROW_INTERVAL: usize = 8;
+#[derive(Clone, Copy)]
+struct ProgressiveMcuTransaction {
+    stream_position: usize,
+    todo:            usize,
+    dc_predictions:  [(i32, i32); MAX_COMPONENTS],
+    bitstream_state: BitstreamStateSnapshot
+}
 
 impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// Decode a progressive image
@@ -46,7 +52,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     )]
     #[inline(never)]
     pub(crate) fn decode_mcu_ycbcr_progressive<B: BitStream>(
-        &mut self, pixels: &mut [u8],
+        &mut self, pixels: &mut [u8]
     ) -> Result<(), DecodeErrors> {
         // Move the coefficient buffers out so scan helpers can borrow `self`
         // while receiving the buffers separately.
@@ -54,7 +60,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut scan_block = core::mem::take(&mut self.progressive_scan_buffer);
         let result =
             self.decode_mcu_ycbcr_progressive_inner::<B>(pixels, &mut block, &mut scan_block);
-        if matches!(&result, Err(error) if error.is_recoverable_eof() || matches!(error, DecodeErrors::Cancelled)) {
+        if matches!(&result, Err(error) if error.is_recoverable_eof() || matches!(error, DecodeErrors::Cancelled))
+        {
             self.progressive_scan_buffer = scan_block;
         }
         self.progressive_mcus_buffer = block;
@@ -134,7 +141,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             block,
             scan_block,
             pixels,
-            preserve_progressive_scans,
+            preserve_progressive_scans
         )? {
             return self.finish_progressive_decoding(block, pixels);
         }
@@ -175,7 +182,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         self.succ_high,
                         self.succ_low,
                         self.spec_start,
-                        self.spec_end,
+                        self.spec_end
                     );
                     if !self.decode_progressive_scan(
                         &mut stream,
@@ -293,16 +300,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 return Err(e);
             }
             if e.is_recoverable_eof() && self.scan_eof_is_error() {
-                if fine_resume.is_some() {
-                    self.invalidate_progressive_fine_checkpoint();
-                }
                 self.finish_progressive_partial(block, pixels)?;
                 return Err(e);
             }
             if self.stream.eof()? && self.scan_eof_is_error() {
-                if fine_resume.is_some() {
-                    self.invalidate_progressive_fine_checkpoint();
-                }
                 self.finish_progressive_partial(block, pixels)?;
                 return Err(DecodeErrors::ExhaustedData);
             }
@@ -317,17 +318,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     core::mem::swap(&mut block[idx], &mut scan_block[idx]);
                 }
             }
-            if fine_resume.is_some() {
-                self.invalidate_progressive_fine_checkpoint();
-            }
             self.invalidate_progressive_scan_checkpoint();
             return Ok(false);
         }
         if stream.overread_by() > 0 {
             if self.scan_eof_is_error() {
-                if fine_resume.is_some() {
-                    self.invalidate_progressive_fine_checkpoint();
-                }
                 self.finish_progressive_partial(block, pixels)?;
                 return Err(DecodeErrors::ExhaustedData);
             }
@@ -336,9 +331,6 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 if touched_components[idx] {
                     core::mem::swap(&mut block[idx], &mut scan_block[idx]);
                 }
-            }
-            if fine_resume.is_some() {
-                self.invalidate_progressive_fine_checkpoint();
             }
             self.invalidate_progressive_scan_checkpoint();
             return Ok(false);
@@ -453,11 +445,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     #[inline]
     fn progressive_fine_checkpoints_enabled<B: BitStream>(&self) -> bool {
-        self.mcu_checkpoints_enabled
-            && B::supports_mcu_checkpoint()
-            && self.spec_start == 0
-            && self.spec_end == 0
-            && self.succ_high == 0
+        self.mcu_checkpoints_enabled && B::supports_mcu_checkpoint()
     }
 
     fn progressive_fine_resume<B: BitStream>(&self) -> Option<ProgressiveFineCheckpoint> {
@@ -468,27 +456,71 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
     }
 
-    fn checkpoint_progressive_dc_first_row<B: BitStream>(
-        &mut self, stream: &B, next_mcu_row: usize,
-    ) -> Result<(), DecodeErrors> {
-        if next_mcu_row % PROGRESSIVE_CHECKPOINT_ROW_INTERVAL == 0
-            && self.progressive_fine_checkpoints_enabled::<B>()
-            && stream.overread_by() == 0
-        {
-            self.checkpoint_progressive_fine_scan(next_mcu_row, 0, stream.snapshot_state())?;
+    fn progressive_mcu_transaction<B: BitStream>(
+        &self, stream: &B
+    ) -> Option<ProgressiveMcuTransaction> {
+        if !self.progressive_fine_checkpoints_enabled::<B>() || stream.overread_by() != 0 {
+            return None;
         }
-        Ok(())
+        Some(ProgressiveMcuTransaction {
+            stream_position: stream.checkpoint_position()?,
+            todo:            self.todo,
+            dc_predictions:  if self.spec_start == 0 && self.succ_high == 0 {
+                core::array::from_fn(|idx| {
+                    self.components
+                        .get(idx)
+                        .map_or((0, 0), |component| (component.dc_pred, component.dc_diff))
+                })
+            } else {
+                [(0, 0); MAX_COMPONENTS]
+            },
+            bitstream_state: stream.snapshot_state()
+        })
+    }
+
+    fn suspend_progressive_mcu<B: BitStream>(
+        &mut self, stream: &mut B, transaction: Option<ProgressiveMcuTransaction>, mcu_row: usize,
+        mcu_col: usize, error: DecodeErrors
+    ) -> DecodeErrors {
+        if let Some(transaction) = transaction {
+            stream.restore_snapshot(transaction.bitstream_state);
+            self.todo = transaction.todo;
+            for (idx, component) in self.components.iter_mut().take(MAX_COMPONENTS).enumerate() {
+                let (dc_pred, dc_diff) = transaction.dc_predictions[idx];
+                component.dc_pred = dc_pred;
+                component.dc_diff = dc_diff;
+            }
+            self.checkpoint_progressive_fine_scan(
+                transaction.stream_position,
+                mcu_row,
+                mcu_col,
+                transaction.bitstream_state
+            );
+        }
+        error
+    }
+
+    fn checkpoint_progressive_current<B: BitStream>(
+        &mut self, stream: &B, mcu_row: usize, mcu_col: usize
+    ) {
+        if let Some(transaction) = self.progressive_mcu_transaction(stream) {
+            self.checkpoint_progressive_fine_scan(
+                transaction.stream_position,
+                mcu_row,
+                mcu_col,
+                transaction.bitstream_state
+            );
+        }
     }
 
     /// Parse a progressive scan's entropy-coded data into `buffer`.
     ///
-    /// Unsafe progressive scans always start at MCU `(0, 0)`. First DC scans
-    /// may resume from a saved MCU boundary because they assign coefficients
-    /// once instead of read-modify-writing refinement data.
+    /// Huffman scans may resume from a saved MCU boundary. Each MCU commits its
+    /// coefficient updates only after entropy and restart handling succeed.
     #[allow(clippy::too_many_lines, clippy::cast_sign_loss)]
     fn parse_entropy_coded_data<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
-        fine_resume: Option<&ProgressiveFineCheckpoint>,
+        fine_resume: Option<&ProgressiveFineCheckpoint>
     ) -> Result<(), DecodeErrors> {
         self.reset_prog_params(stream);
         if let Some(checkpoint) = fine_resume {
@@ -499,6 +531,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 comp.dc_pred = dc_pred;
                 comp.dc_diff = dc_diff;
             }
+        } else if self.progressive_fine_checkpoints_enabled::<B>() {
+            stream.set_checkpoint_position(self.stream_position()?);
         }
 
         if usize::from(self.num_scans) > self.input_colorspace.num_components() {
@@ -513,7 +547,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // Safety checks
             if self.spec_end != 0 && self.spec_start == 0 {
                 return Err(DecodeErrors::FormatStatic(
-                    "Can't merge DC and AC corrupt jpeg",
+                    "Can't merge DC and AC corrupt jpeg"
                 ));
             }
 
@@ -527,22 +561,27 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // Dispatch depending on type
             if self.spec_start == 0 {
                 if self.succ_high == 0 {
-                    let resume_position = fine_resume.map(|checkpoint| {
-                        (checkpoint.mcu_row, checkpoint.mcu_col)
-                    });
+                    let resume_position =
+                        fine_resume.map(|checkpoint| (checkpoint.mcu_row, checkpoint.mcu_col));
                     self.parse_dc_first_non_interleaved(stream, buffer, k, resume_position)?;
                 } else {
-                    self.parse_dc_refine_non_interleaved(stream, buffer, k)?;
+                    let resume_position =
+                        fine_resume.map(|checkpoint| (checkpoint.mcu_row, checkpoint.mcu_col));
+                    self.parse_dc_refine_non_interleaved(stream, buffer, k, resume_position)?;
                 }
             } else if self.succ_high == 0 {
-                self.parse_ac_first_non_interleaved(stream, buffer, k)?;
+                let resume_position =
+                    fine_resume.map(|checkpoint| (checkpoint.mcu_row, checkpoint.mcu_col));
+                self.parse_ac_first_non_interleaved(stream, buffer, k, resume_position)?;
             } else {
-                self.parse_ac_refine_non_interleaved(stream, buffer, k)?;
+                let resume_position =
+                    fine_resume.map(|checkpoint| (checkpoint.mcu_row, checkpoint.mcu_col));
+                self.parse_ac_refine_non_interleaved(stream, buffer, k, resume_position)?;
             }
         } else {
             if self.spec_end != 0 {
                 return Err(DecodeErrors::HuffmanDecode(
-                    "Can't merge dc and AC corrupt jpeg".to_string(),
+                    "Can't merge dc and AC corrupt jpeg".to_string()
                 ));
             }
 
@@ -559,12 +598,13 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             if self.succ_high == 0 {
-                let resume_position = fine_resume.map(|checkpoint| {
-                    (checkpoint.mcu_row, checkpoint.mcu_col)
-                });
+                let resume_position =
+                    fine_resume.map(|checkpoint| (checkpoint.mcu_row, checkpoint.mcu_col));
                 self.parse_dc_first_interleaved(stream, buffer, resume_position)?;
             } else {
-                self.parse_dc_refine_interleaved(stream, buffer)?;
+                let resume_position =
+                    fine_resume.map(|checkpoint| (checkpoint.mcu_row, checkpoint.mcu_col));
+                self.parse_dc_refine_interleaved(stream, buffer, resume_position)?;
             }
         }
         Ok(())
@@ -582,64 +622,93 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_dc_first_non_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
-        resume_position: Option<(usize, usize)>,
+        resume_position: Option<(usize, usize)>
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
-        let dc_pos = self.components[k].dc_huff_table % MAX_COMPONENTS;
+        let dc_pos = self.components[k].dc_huff_table;
         let width_stride = self.components[k].width_stride / 8;
         let (resume_row, resume_col) = resume_position.unwrap_or((0, 0));
 
         let mut cancel = self.cancel_debounced(mcu_width);
         for i in resume_row..mcu_height {
+            let start_col = if i == resume_row { resume_col } else { 0 };
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_current(stream, i, start_col);
                 return Err(DecodeErrors::Cancelled);
             }
-            let start_col = if i == resume_row { resume_col } else { 0 };
             for j in start_col..mcu_width {
+                let transaction = self.progressive_mcu_transaction(stream);
                 let start = 64 * (j + i * width_stride);
-                let dc_pred_opt: Option<&mut i16> = buffer[k].get_mut(start);
-
-                if let Some(dc_pred) = dc_pred_opt {
+                if let Some(dc_pred) = buffer[k].get_mut(start) {
                     let dc_table = B::get_dc_table(&mut self.entropy_tables, dc_pos)?;
                     let component = &mut self.components[k];
 
-                    stream.decode_prog_dc_first(
+                    if let Err(error) = stream.decode_prog_dc_first(
                         &mut self.stream,
                         dc_table,
                         dc_pred,
                         &mut component.dc_pred,
-                        &mut component.dc_diff,
-                    )?;
+                        &mut component.dc_diff
+                    ) {
+                        return Err(self.suspend_progressive_mcu(stream, transaction, i, j, error));
+                    }
+                    if stream.overread_by() > 0 {
+                        return Err(self.suspend_progressive_mcu(
+                            stream,
+                            transaction,
+                            i,
+                            j,
+                            DecodeErrors::ExhaustedData
+                        ));
+                    }
 
-                    self.todo -= 1;
-                    self.handle_rst_main(stream)?;
+                    if let Err(error) = self.finish_progressive_mcu(stream) {
+                        return Err(self.suspend_progressive_mcu(stream, transaction, i, j, error));
+                    }
                 }
             }
-            self.checkpoint_progressive_dc_first_row::<B>(stream, i + 1)?;
         }
         Ok(())
     }
 
     fn parse_dc_refine_non_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        resume_position: Option<(usize, usize)>
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let width_stride = self.components[k].width_stride / 8;
-        let component_buffer = &mut buffer[k];
+        let (resume_row, resume_col) = resume_position.unwrap_or((0, 0));
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        for i in resume_row..mcu_height {
+            let start_col = if i == resume_row { resume_col } else { 0 };
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_current(stream, i, start_col);
                 return Err(DecodeErrors::Cancelled);
             }
-            for j in 0..mcu_width {
+            for j in start_col..mcu_width {
+                let transaction = self.progressive_mcu_transaction(stream);
                 let start = 64 * (j + i * width_stride);
-                let dc_pred_id: Option<&mut i16> = component_buffer.get_mut(start);
-
-                if let Some(dc_pred) = dc_pred_id {
-                    stream.decode_prog_dc_refine(&mut self.stream, dc_pred)?;
-                    self.todo -= 1;
-                    self.handle_rst_main(stream)?;
+                if let Some(dc_pred) = buffer[k].get_mut(start) {
+                    let mut decoded_dc = *dc_pred;
+                    if let Err(error) =
+                        stream.decode_prog_dc_refine(&mut self.stream, &mut decoded_dc)
+                    {
+                        return Err(self.suspend_progressive_mcu(stream, transaction, i, j, error));
+                    }
+                    if stream.overread_by() > 0 {
+                        return Err(self.suspend_progressive_mcu(
+                            stream,
+                            transaction,
+                            i,
+                            j,
+                            DecodeErrors::ExhaustedData
+                        ));
+                    }
+                    if let Err(error) = self.finish_progressive_mcu(stream) {
+                        return Err(self.suspend_progressive_mcu(stream, transaction, i, j, error));
+                    }
+                    *dc_pred = decoded_dc;
                 }
             }
         }
@@ -648,39 +717,85 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_ac_first_non_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        resume_position: Option<(usize, usize)>
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
-        let component_buffer_data = &mut buffer[k];
+        let width_stride = self.components[k].width_stride / 8;
+        let (resume_row, resume_col) = resume_position.unwrap_or((0, 0));
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        for i in resume_row..mcu_height {
+            let start_col = if i == resume_row { resume_col } else { 0 };
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_current(stream, i, start_col);
                 return Err(DecodeErrors::Cancelled);
             }
-            for j in 0..mcu_width {
+            for j in start_col..mcu_width {
+                let transaction = self.progressive_mcu_transaction(stream);
                 if *stream.eob_run() > 0 {
                     // handle EOB runs here.
                     *stream.eob_run() -= 1;
                 } else {
-                    let start = 64 * (j + i * (self.components[k].width_stride / 8));
-
-                    let data: &mut [i16; 64] = component_buffer_data
+                    let start = 64 * (j + i * width_stride);
+                    let data: &mut [i16; 64] = buffer[k]
                         .get_mut(start..start + 64)
                         .ok_or(DecodeErrors::FormatStatic("Slice to Small"))?
                         .try_into()
                         .unwrap();
+                    let original = transaction.map(|_| *data);
 
                     let ac_table = B::get_ac_table(&mut self.entropy_tables, ac_pos)?;
-                    if !stream.decode_mcu_ac_first(&mut self.stream, ac_table, data)? {
+                    let decoded = match stream.decode_mcu_ac_first(
+                        &mut self.stream,
+                        ac_table,
+                        data
+                    ) {
+                        Ok(decoded) => decoded,
+                        Err(error) => {
+                            if let Some(original) = original {
+                                *data = original;
+                            }
+                            return Err(self.suspend_progressive_mcu(
+                                stream,
+                                transaction,
+                                i,
+                                j,
+                                error
+                            ));
+                        }
+                    };
+                    if !decoded {
                         // Arithmetic bad-code termination is scan-wide, matching
                         // libjpeg's no-op handling for the remaining MCUs.
                         return Ok(());
                     }
+                    if stream.overread_by() > 0 {
+                        if let Some(original) = original {
+                            *data = original;
+                        }
+                        return Err(self.suspend_progressive_mcu(
+                            stream,
+                            transaction,
+                            i,
+                            j,
+                            DecodeErrors::ExhaustedData
+                        ));
+                    }
+                }
+                if stream.overread_by() > 0 {
+                    return Err(self.suspend_progressive_mcu(
+                        stream,
+                        transaction,
+                        i,
+                        j,
+                        DecodeErrors::ExhaustedData
+                    ));
                 }
 
-                self.todo -= 1;
-                self.handle_rst_main(stream)?;
+                if let Err(error) = self.finish_progressive_mcu(stream) {
+                    return Err(self.suspend_progressive_mcu(stream, transaction, i, j, error));
+                }
             }
         }
         Ok(())
@@ -688,30 +803,70 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_ac_refine_non_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        resume_position: Option<(usize, usize)>
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
-        let component_buffer_data = &mut buffer[k];
         let width_stride = self.components[k].width_stride / 8;
+        let (resume_row, resume_col) = resume_position.unwrap_or((0, 0));
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        for i in resume_row..mcu_height {
+            let start_col = if i == resume_row { resume_col } else { 0 };
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_current(stream, i, start_col);
                 return Err(DecodeErrors::Cancelled);
             }
-            for j in 0..mcu_width {
+            for j in start_col..mcu_width {
+                let transaction = self.progressive_mcu_transaction(stream);
                 let start = 64 * (j + i * width_stride);
-                let data: &mut [i16; 64] = component_buffer_data
+                let data: &mut [i16; 64] = buffer[k]
                     .get_mut(start..start + 64)
                     .ok_or(DecodeErrors::FormatStatic("Slice to Small"))?
                     .try_into()
                     .unwrap();
+                let original = transaction.map(|_| *data);
 
                 let ac_table = B::get_ac_table(&mut self.entropy_tables, ac_pos)?;
-                stream.decode_mcu_ac_refine(&mut self.stream, ac_table, data)?;
+                let decoded = match stream.decode_mcu_ac_refine(&mut self.stream, ac_table, data) {
+                    Ok(decoded) => decoded,
+                    Err(error) => {
+                        if let Some(original) = original {
+                            *data = original;
+                        }
+                        return Err(self.suspend_progressive_mcu(
+                            stream,
+                            transaction,
+                            i,
+                            j,
+                            error
+                        ));
+                    }
+                };
+                if !decoded {
+                    // Arithmetic bad-code termination is scan-wide, matching
+                    // libjpeg's no-op handling for the remaining MCUs.
+                    return Ok(());
+                }
+                if stream.overread_by() > 0 {
+                    if let Some(original) = original {
+                        *data = original;
+                    }
+                    return Err(self.suspend_progressive_mcu(
+                        stream,
+                        transaction,
+                        i,
+                        j,
+                        DecodeErrors::ExhaustedData
+                    ));
+                }
 
-                self.todo -= 1;
-                self.handle_rst_main(stream)?;
+                if let Err(error) = self.finish_progressive_mcu(stream) {
+                    if let Some(original) = original {
+                        *data = original;
+                    }
+                    return Err(self.suspend_progressive_mcu(stream, transaction, i, j, error));
+                }
             }
         }
         Ok(())
@@ -719,16 +874,18 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn parse_dc_first_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
-        resume_position: Option<(usize, usize)>,
+        resume_position: Option<(usize, usize)>
     ) -> Result<(), DecodeErrors> {
         let mut cancel = self.cancel_debounced(self.mcu_x);
         let (resume_row, resume_col) = resume_position.unwrap_or((0, 0));
         for i in resume_row..self.mcu_y {
+            let start_col = if i == resume_row { resume_col } else { 0 };
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_current(stream, i, start_col);
                 return Err(DecodeErrors::Cancelled);
             }
-            let start_col = if i == resume_row { resume_col } else { 0 };
             for j in start_col..self.mcu_x {
+                let transaction = self.progressive_mcu_transaction(stream);
                 for k in 0..self.num_scans {
                     let n = self.z_order[k as usize];
                     let component = &mut self.components[n];
@@ -745,33 +902,64 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 return Err(DecodeErrors::FormatStatic("Invalid image"));
                             };
 
-                            stream.decode_prog_dc_first(
+                            if let Err(error) = stream.decode_prog_dc_first(
                                 &mut self.stream,
                                 huff_table,
                                 data,
                                 &mut component.dc_pred,
-                                &mut component.dc_diff,
-                            )?;
+                                &mut component.dc_diff
+                            ) {
+                                return Err(self.suspend_progressive_mcu(
+                                    stream,
+                                    transaction,
+                                    i,
+                                    j,
+                                    error
+                                ));
+                            }
+                            if stream.overread_by() > 0 {
+                                return Err(self.suspend_progressive_mcu(
+                                    stream,
+                                    transaction,
+                                    i,
+                                    j,
+                                    DecodeErrors::ExhaustedData
+                                ));
+                            }
                         }
                     }
                 }
-                self.todo -= 1;
-                self.handle_rst_main(stream)?;
+                if stream.overread_by() > 0 {
+                    return Err(self.suspend_progressive_mcu(
+                        stream,
+                        transaction,
+                        i,
+                        j,
+                        DecodeErrors::ExhaustedData
+                    ));
+                }
+                if let Err(error) = self.finish_progressive_mcu(stream) {
+                    return Err(self.suspend_progressive_mcu(stream, transaction, i, j, error));
+                }
             }
-            self.checkpoint_progressive_dc_first_row::<B>(stream, i + 1)?;
         }
         Ok(())
     }
 
     fn parse_dc_refine_interleaved<B: BitStream>(
         &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        resume_position: Option<(usize, usize)>
     ) -> Result<(), DecodeErrors> {
         let mut cancel = self.cancel_debounced(self.mcu_x);
-        for i in 0..self.mcu_y {
+        let (resume_row, resume_col) = resume_position.unwrap_or((0, 0));
+        for i in resume_row..self.mcu_y {
+            let start_col = if i == resume_row { resume_col } else { 0 };
             if cancel.is_cancelled() {
+                self.checkpoint_progressive_current(stream, i, start_col);
                 return Err(DecodeErrors::Cancelled);
             }
-            for j in 0..self.mcu_x {
+            for j in start_col..self.mcu_x {
+                let transaction = self.progressive_mcu_transaction(stream);
                 for k in 0..self.num_scans {
                     let n = self.z_order[k as usize];
                     let component = &self.components[n];
@@ -785,34 +973,55 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             let Some(data) = buffer[n].get_mut(position) else {
                                 return Err(DecodeErrors::FormatStatic("Invalid image"));
                             };
+                            let mut decoded_dc = *data;
 
-                            stream.decode_prog_dc_refine(&mut self.stream, data)?;
+                            if let Err(error) =
+                                stream.decode_prog_dc_refine(&mut self.stream, &mut decoded_dc)
+                            {
+                                return Err(self.suspend_progressive_mcu(
+                                    stream,
+                                    transaction,
+                                    i,
+                                    j,
+                                    error
+                                ));
+                            }
+                            if stream.overread_by() > 0 {
+                                return Err(self.suspend_progressive_mcu(
+                                    stream,
+                                    transaction,
+                                    i,
+                                    j,
+                                    DecodeErrors::ExhaustedData
+                                ));
+                            }
+                            *data = decoded_dc;
                         }
                     }
                 }
-                self.todo -= 1;
-
-                // Progressive does not record per-RST checkpoints —
-                // refine scans do read-modify-write on `buffer` and
-                // mid-scan resume would re-apply partial deltas. On
-                // EOF the decoder falls back to scan-start replay.
-                self.handle_rst_main(stream)?;
+                if stream.overread_by() > 0 {
+                    return Err(self.suspend_progressive_mcu(
+                        stream,
+                        transaction,
+                        i,
+                        j,
+                        DecodeErrors::ExhaustedData
+                    ));
+                }
+                if let Err(error) = self.finish_progressive_mcu(stream) {
+                    return Err(self.suspend_progressive_mcu(stream, transaction, i, j, error));
+                }
             }
         }
         Ok(())
     }
 
-    /// Handle an RST marker mid-scan, if one is due. Used by the progressive
-    /// scan decoder, which does not record per-RST checkpoints and therefore
-    /// does not need to know whether a marker was actually consumed.
-    ///
-    /// The baseline decoder, which does checkpoint, calls
-    /// [`Self::handle_rst_main_with_status`] instead.
-    #[allow(clippy::used_underscore_binding)]
-    pub(crate) fn handle_rst_main<B: BitStream>(
-        &mut self, stream: &mut B,
-    ) -> Result<(), DecodeErrors> {
-        self.handle_rst_main_inner(stream).map(|_| ())
+    fn finish_progressive_mcu<B: BitStream>(&mut self, stream: &mut B) -> Result<(), DecodeErrors> {
+        self.todo -= 1;
+        if self.handle_rst_main_with_status(stream)? {
+            stream.set_checkpoint_position(self.stream_position()?);
+        }
+        Ok(())
     }
 
     fn handle_rst_main_inner<B: BitStream>(
@@ -832,7 +1041,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // if no marker and we are to reset RST, look for the marker, this matches
             // libjpeg-turbo behaviour and allows us to decode images in
             // https://github.com/etemesi254/zune-image/issues/261
-            let _start = self.stream.position()?;
+            let start = self.stream.position()?;
             // skip bytes until we find marker
             let marker = get_marker(&mut self.stream, stream);
 
@@ -844,13 +1053,13 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // until that point
             match marker {
                 Ok(marker) => {
-                    let _end = self.stream.position()?;
+                    let end = self.stream.position()?;
                     handled_restart = matches!(marker, Marker::RST(_));
                     *stream.marker() = Some(marker);
                     // NB some warnings may be false positives.
                     warn!(
                         "{} Extraneous bytes before marker {:?}",
-                        _end - _start,
+                        end - start,
                         marker
                     );
                 }
@@ -891,7 +1100,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// the two formulations could disagree — `todo == 0`, no marker, no
     /// interval — is unreachable.
     pub(crate) fn handle_rst_main_with_status<B: BitStream>(
-        &mut self, stream: &mut B,
+        &mut self, stream: &mut B
     ) -> Result<bool, DecodeErrors> {
         let was_due = self.todo == 0;
         let handled_restart = self.handle_rst_main_inner(stream)?;
@@ -900,7 +1109,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::needless_range_loop, clippy::cast_sign_loss)]
     fn finish_progressive_decoding(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8]
     ) -> Result<(), DecodeErrors> {
         // Rendering replaces the caller's output row by row. Until every row
         // succeeds, the buffer may contain a mix of preview generations and
@@ -957,7 +1166,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // components.
             if min(
                 self.options.jpeg_get_out_colorspace().num_components() - 1,
-                pos,
+                pos
             ) == pos
                 || self.input_colorspace == ColorSpace::YCCK
                 || self.input_colorspace == ColorSpace::CMYK
@@ -1020,7 +1229,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         // See https://github.com/etemesi254/zune-image/issues/262 sample 3.
                         let Some(qt_slice) = slice.get(start..start + 64) else {
                             return Err(DecodeErrors::FormatStatic(
-                                "Invalid slice , would panic, invalid image",
+                                "Invalid slice , would panic, invalid image"
                             ));
                         };
                         // dequantize
@@ -1055,7 +1264,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 width,
                 padded_width,
                 &mut pixels_written,
-                &mut upsampler_scratch_space,
+                &mut upsampler_scratch_space
             )?;
         }
 
@@ -1088,10 +1297,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 ///
 /// This reads until it gets a marker or end of file is encountered
 pub fn get_marker<T, B: BitStream>(
-    reader: &mut ZReader<T>, stream: &mut B,
+    reader: &mut ZReader<T>, stream: &mut B
 ) -> Result<Marker, DecodeErrors>
 where
-    T: ZByteReaderTrait,
+    T: ZByteReaderTrait
 {
     if let Some(marker) = stream.marker().take() {
         return Ok(marker);
@@ -1300,7 +1509,7 @@ mod tests {
             0x3f, 0x21, 0xf1, 0x1f, 0xff, 0xda, 0x00, 0x08, 0x01, 0x01, 0x00, 0x03, 0x3f, 0x10,
             0xd2, 0x57, 0xa9, 0xa4, 0xd2, 0x7f, 0xff, 0xda, 0x00, 0x08, 0x01, 0x02, 0x00, 0x03,
             0x3f, 0x10, 0xb3, 0xff, 0xda, 0x00, 0x08, 0x01, 0x03, 0x00, 0x03, 0x3f, 0x10, 0xfa,
-            0x8f, 0xff, 0xd9,
+            0x8f, 0xff, 0xd9
         ];
 
         let mut decoder = JpegDecoder::new(ZCursor::new(JPEG));
@@ -1353,7 +1562,7 @@ mod tests {
             248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248,
             248, 248, 248, 248, 248, 248, 248, 255, 192, 0, 17, 8, 0, 32, 0, 32, 3, 1, 34, 0, 2,
             17, 1, 3, 17, 1, 255, 196, 0, 24, 0, 1, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            2, 0, 126, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 198,
+            2, 0, 126, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 198
         ]);
         let mut decoder = JpegDecoder::new(data);
         decoder.decode().unwrap();

--- a/crates/zune-jpeg/tests/arithmetic_progressive.rs
+++ b/crates/zune-jpeg/tests/arithmetic_progressive.rs
@@ -139,3 +139,57 @@ fn corresponding_progressive_huffman_orders_are_unchanged() {
     );
     assert_eq!(arithmetic_ascending, arithmetic_descending);
 }
+
+#[test]
+fn arithmetic_conditioning_table_fifteen_decodes() {
+    let original = include_bytes!("../../../test-images/jpeg/arith/seq.jpg");
+    let expected = decode(original, true);
+    let mut table_fifteen = original.to_vec();
+
+    let dac = table_fifteen
+        .windows(2)
+        .position(|bytes| bytes == [0xFF, 0xCC])
+        .expect("fixture must contain a DAC marker");
+    let dac_len = usize::from(u16::from_be_bytes([
+        table_fifteen[dac + 2],
+        table_fifteen[dac + 3]
+    ]));
+    let mut moved_entries = 0;
+    for entry in table_fifteen[dac + 4..dac + 2 + dac_len].chunks_exact_mut(2) {
+        if entry[0] & 0x0F == 0 {
+            entry[0] |= 0x0F;
+            moved_entries += 1;
+        }
+    }
+    assert_eq!(moved_entries, 2, "fixture must define DC and AC table 0");
+
+    let sos = table_fifteen
+        .windows(2)
+        .position(|bytes| bytes == [0xFF, 0xDA])
+        .expect("fixture must contain an SOS marker");
+    assert_eq!(table_fifteen[sos + 4], 3, "fixture must have three scan components");
+    assert_eq!(table_fifteen[sos + 5], 1, "first scan component must have ID 1");
+    assert_eq!(table_fifteen[sos + 6], 0, "component 1 must initially use table 0");
+    table_fifteen[sos + 6] = 0xFF;
+
+    assert_eq!(decode(&table_fifteen, true), expected);
+
+    let progressive = include_bytes!(
+        "../../../test-images/jpeg/arith/progressive_parity/arith_spectral_all.jpg"
+    );
+    let expected = decode(progressive, true);
+    let mut table_fifteen = progressive.to_vec();
+    let sos_offsets: Vec<_> = table_fifteen
+        .windows(2)
+        .enumerate()
+        .filter_map(|(offset, bytes)| (bytes == [0xFF, 0xDA]).then_some(offset))
+        .collect();
+    assert_eq!(sos_offsets.len(), 64, "fixture must contain 64 progressive scans");
+    for sos in sos_offsets {
+        assert_eq!(table_fifteen[sos + 4], 1, "fixture scans must have one component");
+        assert_eq!(table_fifteen[sos + 6], 0, "fixture scans must initially use table 0");
+        table_fifteen[sos + 6] = 0xFF;
+    }
+
+    assert_eq!(decode(&table_fifteen, true), expected);
+}

--- a/crates/zune-jpeg/tests/cancel.rs
+++ b/crates/zune-jpeg/tests/cancel.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use std::{cell::{Cell, RefCell}, io::{BufRead, Read, Seek, SeekFrom}, rc::Rc};
 
 use zune_core::bytestream::ZCursor;
+use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::{CancelCheck, JpegDecoder, NeverCancel};
 
@@ -330,6 +331,47 @@ fn metadata_marker_cancellation_commits_once() {
 }
 
 #[test]
+fn progressive_edge_trigger_cancellation_is_reported() {
+    for strict in [false, true] {
+        for incremental in [false, true] {
+            let options = DecoderOptions::default().set_strict_mode(strict);
+            let mut decoder = JpegDecoder::new_with_options(ZCursor::new(PROGRESSIVE), options);
+            decoder.decode_headers().unwrap();
+            decoder.set_incremental_mode(incremental);
+            decoder.set_cancel_interval(1);
+            decoder.set_cancel(cancel_once_at(0));
+            let mut output = vec![0; decoder.output_buffer_size().unwrap()];
+
+            let error = decoder.decode_into(&mut output).unwrap_err();
+            assert!(matches!(error, DecodeErrors::Cancelled));
+        }
+    }
+}
+
+#[test]
+fn progressive_cancellation_retry_matches_oneshot() {
+    let expected = JpegDecoder::new(ZCursor::new(PROGRESSIVE)).decode().unwrap();
+
+    // Poll cancellation after eight decoded rows, proving the latest MCU
+    // checkpoint and its matching scratch coefficients survive retry.
+    for (incremental, cancel_poll) in [(false, 0), (true, 8)] {
+        let mut decoder = JpegDecoder::new(ZCursor::new(PROGRESSIVE));
+        decoder.decode_headers().unwrap();
+        decoder.set_incremental_mode(incremental);
+        decoder.set_cancel_interval(1);
+        decoder.set_cancel(cancel_once_at(cancel_poll));
+        let mut output = vec![0; decoder.output_buffer_size().unwrap()];
+
+        let error = decoder.decode_into(&mut output).unwrap_err();
+        assert!(matches!(error, DecodeErrors::Cancelled));
+
+        decoder.set_cancel(NeverCancel);
+        decoder.decode_into(&mut output).unwrap();
+        assert_eq!(output, expected, "incremental={incremental}");
+    }
+}
+
+#[test]
 fn progressive_fine_cancellation_resume_uses_checkpoint() {
     let expected = JpegDecoder::new(ZCursor::new(PROGRESSIVE_RESTART)).decode().unwrap();
     let first_scan_start = sos_data_start(PROGRESSIVE_RESTART, 0);
@@ -390,7 +432,7 @@ fn progressive_inter_scan_marker_cancellation_retries() {
 }
 
 #[test]
-fn progressive_unsafe_scan_cancellation_retries() {
+fn progressive_ac_scan_cancellation_retries() {
     let expected = JpegDecoder::new(ZCursor::new(SMALL_PROGRESSIVE)).decode().unwrap();
     let unsafe_scan_start = ac_first_scan_start(SMALL_PROGRESSIVE, 1);
     let limit = Rc::new(Cell::new(SMALL_PROGRESSIVE.len()));

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -1281,7 +1281,7 @@ fn progressive_non_strict_scratch_path_matches_direct_path() {
     );
 
     let mut corrupt = original.to_vec();
-    corrupt[huffman_selector] = 0xFF;
+    corrupt[huffman_selector] = 0x33;
 
     let strict_error = decode_with_mode(&corrupt, true, true)
         .expect_err("strict mode must reject the missing Huffman table");
@@ -1297,6 +1297,46 @@ fn progressive_non_strict_scratch_path_matches_direct_path() {
         "progressive non-strict scratch/direct parity",
         corrupt.len()
     );
+}
+
+#[test]
+fn progressive_invalid_huffman_selectors_do_not_alias_table_three() {
+    let original = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
+    let mut table_three = original.to_vec();
+    let first_sos = sos_marker_offset(&table_three, 0);
+    let first_dc_dht = list_jpeg_markers(&table_three)
+        .into_iter()
+        .find_map(|(offset, code, _)| {
+            (code == 0xC4 && table_three.get(offset + 4) == Some(&0)).then_some(offset)
+        })
+        .expect("fixture must define DC Huffman table 0 before its first scan");
+
+    table_three[first_dc_dht + 4] = 3;
+    table_three[first_sos + 6] = 3 << 4;
+    decode_with_mode(&table_three, false, true)
+        .expect("control image using DC Huffman table 3 must decode");
+
+    table_three[first_sos + 6] = 15 << 4;
+    let mut decoder = JpegDecoder::new(ZCursor::new(&table_three));
+    let error = decoder
+        .decode_headers()
+        .expect_err("invalid DC Huffman selector must fail during SOS parsing");
+    assert!(
+        matches!(error, DecodeErrors::SosError(_)),
+        "invalid selector returned {error:?}"
+    );
+    assert!(!error.is_recoverable_eof(), "invalid selector returned {error:?}");
+
+    table_three[first_sos + 6] = (3 << 4) | 15;
+    let mut decoder = JpegDecoder::new(ZCursor::new(&table_three));
+    let error = decoder
+        .decode_headers()
+        .expect_err("invalid AC Huffman selector must fail during SOS parsing");
+    assert!(
+        matches!(error, DecodeErrors::SosError(_)),
+        "invalid selector returned {error:?}"
+    );
+    assert!(!error.is_recoverable_eof(), "invalid selector returned {error:?}");
 }
 
 #[test]
@@ -1405,7 +1445,7 @@ fn progressive_dc_first_resume_uses_fine_checkpoint() {
 }
 
 #[test]
-fn progressive_repeated_dc_eof_falls_back_to_scan_boundary() {
+fn progressive_repeated_dc_eof_keeps_latest_mcu_checkpoint() {
     let name = "synthetic_image_repeated_dc_eof";
     let data = include_bytes!("../../../test-images/jpeg/synthetic_image.jpg");
     let expected = decode_oneshot(data);
@@ -1443,20 +1483,28 @@ fn progressive_repeated_dc_eof_falls_back_to_scan_boundary() {
     limit.set(data.len());
     decoder.decode_into(&mut out).expect("full input should finish");
     assert_pixels_match(&out, &expected, name, data.len());
-    assert_eq!(
-        seek_log.borrow()[0],
-        first_scan.data_start,
-        "a repeated EOF after fine resume should fall back to the scan boundary"
+    let latest_fine_seek = seek_log.borrow()[0];
+    assert!(
+        latest_fine_seek >= fine_seek && latest_fine_seek < second_sos_offset,
+        "a repeated EOF should retain or advance the fine checkpoint; \
+         prior={fine_seek}, latest={latest_fine_seek}"
     );
 }
 
 #[test]
-fn progressive_unsafe_scans_replay_from_scan_boundary() {
+fn progressive_huffman_transactional_scans_resume_from_mcu_checkpoint() {
     let data = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
     let expected = decode_oneshot(data);
     let scans = progressive_sos_scans(data);
 
     for (name, scan_index) in [
+        (
+            "dc_refine",
+            scans
+                .iter()
+                .position(|scan| scan.spec_start == 0 && scan.succ_high > 0)
+                .expect("fixture must contain a DC refinement scan")
+        ),
         (
             "ac_first",
             scans
@@ -1508,12 +1556,53 @@ fn progressive_unsafe_scans_replay_from_scan_boundary() {
         let first_seek = seeks
             .first()
             .copied()
-            .expect("retry should seek to active scan boundary");
-        assert_eq!(
-            first_seek, scan.data_start,
-            "{name}: unsafe progressive scan must replay from scan boundary"
+            .expect("retry should seek to an active scan MCU checkpoint");
+        assert!(
+            first_seek > scan.data_start && first_seek < scan_end,
+            "{name}: progressive Huffman scan must resume inside entropy data; \
+             scan_start={}, seek={first_seek}, scan_end={scan_end}",
+            scan.data_start
         );
     }
+
+    let data = include_bytes!("../../../test-images/jpeg/progressive_restart_420.jpg");
+    let expected = decode_oneshot(data);
+    let scans = progressive_sos_scans(data);
+    let scan_index = scans
+        .iter()
+        .position(|scan| scan.components > 1 && scan.spec_start == 0 && scan.succ_high > 0)
+        .expect("fixture must contain an interleaved DC refinement scan");
+    let scan = scans[scan_index];
+    let scan_end = if scan_index + 1 < scans.len() {
+        sos_marker_offset(data, scan_index + 1)
+    } else {
+        data.len()
+    };
+    let cutoff = (scan.data_start + 64).min(scan_end - 1);
+    let limit = Rc::new(Cell::new(cutoff));
+    let seek_log = Rc::new(RefCell::new(Vec::new()));
+    let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
+    let mut decoder = JpegDecoder::new(cursor);
+    decoder.set_incremental_mode(true);
+
+    decoder.decode_headers().expect("headers should be visible at cutoff");
+    let mut out = vec![0u8; decoder.output_buffer_size().unwrap()];
+    let error = decoder
+        .decode_into(&mut out)
+        .expect_err("truncated interleaved DC refinement should be recoverable");
+    assert!(error.is_recoverable_eof(), "got {error:?}");
+
+    seek_log.borrow_mut().clear();
+    limit.set(data.len());
+    decoder
+        .decode_into(&mut out)
+        .expect("full input should resume interleaved DC refinement");
+    assert_pixels_match(&out, &expected, "dc_refine_interleaved", data.len());
+    let first_seek = seek_log.borrow()[0];
+    assert!(
+        first_seek > scan.data_start && first_seek < scan_end,
+        "interleaved DC refinement must resume inside entropy data"
+    );
 }
 
 #[test]
@@ -2032,6 +2121,7 @@ fn sos_marker_offset(data: &[u8], sos_index: usize) -> usize {
 #[derive(Clone, Copy)]
 struct ProgressiveSosScan {
     data_start: usize,
+    components: u8,
     spec_start: u8,
     spec_end:   u8,
     succ_high:  u8
@@ -2051,6 +2141,7 @@ fn progressive_sos_scans(data: &[u8]) -> Vec<ProgressiveSosScan> {
             let successive = data[params + 2];
             Some(ProgressiveSosScan {
                 data_start: offset + 2 + length,
+                components: data[payload],
                 spec_start: data[params],
                 spec_end:   data[params + 1],
                 succ_high:  successive >> 4


### PR DESCRIPTION
## Summary

Complete fine-grained suspension and retry support for progressive Huffman JPEG
decoding by making each MCU transaction atomic.

This is a follow-up to:

- #401, which added progressive scan commit/rollback semantics and preview
  reporting;
- #420, which added bounded fine-grained resume for progressive Huffman
  first-DC scans.

After this PR, every progressive Huffman scan type can resume from the latest
completed MCU:

- DC first;
- DC refinement;
- AC first;
- AC refinement;
- interleaved DC first and refinement scans.

## Transaction model

Before decoding an eligible Huffman MCU, the decoder captures:

- the physical compressed-stream position;
- Huffman bit-buffer state;
- latched marker, EOF, and overread state;
- EOB-run state;
- restart countdown;
- per-component DC predictors.

State is committed only after entropy decoding and restart handling complete.

DC refinement is applied idempotently. AC first and AC refinement preserve the
original coefficient block and restore it if the MCU suspends. This is
functionally equivalent to libjpeg-turbo's progressive Huffman suspension model,
while using a full-block rollback instead of its narrower newly-nonzero list.

Completed scans remain committed and available for progressive previews. An
incomplete MCU or scan is never published.

## Arithmetic decoding

Arithmetic entropy state cannot be safely snapshotted independently of its
adaptive probability tables. Progressive arithmetic scans therefore continue to
replay from the current scan start, matching libjpeg-turbo's lack of arithmetic
input suspension.

This PR also expands arithmetic conditioning-table storage and DAC validation
from 4 to all 16 JPEG-defined slots.

## Cancellation

Cancellation uses the same transaction boundaries as recoverable EOF:

- completed MCUs remain valid;
- incomplete coefficient changes are discarded;
- the same decoder and output buffer can be retried after replacing or clearing
  the cancellation callback.

## Validation

Coverage includes:

- in-scan resume for all progressive Huffman scan types;
- interleaved DC refinement;
- restart-bearing progressive images;
- repeated EOF without checkpoint regression;
- cancellation and retry;
- arithmetic scan-start fallback;
- byte-by-byte incremental decoding;
- valid arithmetic conditioning table 15;
- rejection of invalid Huffman DC and AC selectors;
- pixel parity with one-shot decoding and stored libjpeg-turbo references.

The arithmetic-enabled zune-jpeg suite passes with no failures. no-std checking,
doctests, and the JPEG benchmark target also pass.

## Performance measurement

The repeated-retry benchmark measures:

- baseline row checkpoints;
- progressive first-DC MCU checkpoints;
- progressive AC-refinement MCU checkpoints.

This group measures zune-jpeg retry work. Existing progressive decode groups
retain the one-shot zune-jpeg/mozjpeg comparison because the mozjpeg Rust API
does not expose a suspending source manager.

## Remaining parity gaps

This PR closes progressive Huffman entropy-resume parity for supported seekable
inputs. Broader libjpeg-turbo API parity still requires separate work:

- forward-only suspending source managers;
- independently driven input/output via equivalents of `jpeg_consume_input()`,
  `jpeg_start_output()`, and `jpeg_finish_output()`;
- scanline-sized output buffers instead of a persistent full-frame buffer;
- per-MCU baseline Huffman suspension, which currently checkpoints primarily by
  MCU row;
- direct comparative benchmarks for repeated suspension.

These are independent API and baseline-decoder projects rather than gaps in the
progressive Huffman transaction implemented here.