### PR TITLE
Rewrite progressive AC refinement

### DIFF
--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -922,21 +922,42 @@ impl BitStream for BitStreamHuffman {
     }
     #[allow(clippy::too_many_lines, clippy::op_ref)]
     fn decode_mcu_ac_refine<T>(
-        &mut self, reader: &mut ZReader<T>, table: &mut HuffmanTable, block: &mut [i16; 64]
+        &mut self, reader: &mut ZReader<T>, table: &mut HuffmanTable, block: &mut [i16; 64],
     ) -> Result<bool, DecodeErrors>
     where
-        T: ZByteReaderTrait
+        T: ZByteReaderTrait,
     {
         let bit = self.successive_low_mask;
+        debug_assert!(bit > 0, "One bit in low mask set");
 
-        let mut k = self.spec_start;
         let (mut symbol, mut r);
 
-        if self.eob_run == 0 {
-            'no_eob: loop {
-                // Decode a coefficient from the bit stream
+        // We always know how many zeros *not* to initialize. For within an EOB run, that's all
+        // remaining zeroes of the spectral band. We never iterate 127 coefficients so this is a
+        // safe upper bound.
+        const NZ_EOB_VAL: i8 = 127;
+        let mut nz: i8;
+        let mut was_eob_run = false;
+
+        // `symbol` is used to initialize an indicated zero coefficient, but control flow is not
+        // hierarchical (and dependent on iteration being less than 127 items) so this is a default
+        // for soundness purposes.
+        symbol = 0;
+
+        if self.eob_run > 0 {
+            was_eob_run = true;
+            // FIXME: fast path for entirely zeroes?
+
+            nz = NZ_EOB_VAL;
+        } else {
+            nz = -1;
+        }
+
+        for k in self.spec_start..=self.spec_end {
+            if nz < 0 {
                 self.refill(reader)?;
 
+                // We need our next instructions, decode a symbol and so on.
                 symbol = self.peek_bits::<HUFF_LOOKAHEAD>();
                 symbol = table.lookup[symbol as usize];
 
@@ -947,17 +968,33 @@ impl BitStream for BitStreamHuffman {
 
                 if symbol == 0 {
                     if r != 15 {
-                        // EOB run is 2^r + bits
+                        // This indicates the start of an EOBRUN.
+                        // EOB run is 2^r + bits.
                         self.eob_run = 1 << r;
                         self.eob_run += self.get_bits(r as u8);
-                        // EOB runs are handled by the eob logic
-                        break 'no_eob;
+                        was_eob_run = true;
+                        nz = NZ_EOB_VAL;
+                    } else {
+                        // This indicates a zero-fill.
+                        nz = 15;
+                        symbol = 0;
                     }
                 } else {
-                    // libjpeg-turbo also doesn't return an error here, so let's also warn.
+                    // libjpeg-turbo also doesn't return an error here, so let's also only warn.
                     if symbol != 1 {
                         warn!("Bad Huffman code, corrupt JPEG?");
                     }
+
+                    if self.bits_left < 1 {
+                        self.refill(reader)?;
+                    }
+
+                    if self.bits_left < 1 && self.marker.is_some() {
+                        return Err(DecodeErrors::Format(
+                            "Marker found where not expected in refine bit".to_string(),
+                        ));
+                    }
+
                     // get sign bit
                     // We assume we have enough bits, which should be correct for sane images
                     // since we refill by 32 above
@@ -966,91 +1003,47 @@ impl BitStream for BitStreamHuffman {
                     } else {
                         symbol = i32::from(-bit);
                     }
+
+                    nz = r as i8;
+                }
+            }
+
+            let coefficient = &mut block[UN_ZIGZAG[k as usize] & 63];
+
+            if *coefficient == 0 {
+                // We have hit either the end of a ZRL or R_ZZ run. Find out which was decoded by
+                // inspecting `symbol`. This tells us if this is an assignment or just the last to
+                // skip.
+                if nz == 0 && symbol != 0 {
+                    // This is a coefficient to initialize.
+                    *coefficient = symbol as i16;
                 }
 
-                // Advance over already nonzero coefficients  appending
-                // correction bits to the non-zeroes.
-                // A correction bit is 1 if the absolute value of the coefficient must be increased
+                nz -= 1;
+            } else {
+                if self.bits_left < 1 {
+                    // refill at the last possible moment
+                    self.refill(reader)?;
+                }
 
-                if k <= self.spec_end {
-                    'advance_nonzero: loop {
-                        let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
+                if self.bits_left < 1 && self.marker.is_some() {
+                    return Err(DecodeErrors::Format(
+                        "Marker found where not expected in refine bit".to_string(),
+                    ));
+                }
 
-                        if *coefficient != 0 {
-                            if self.bits_left < 1 {
-                                self.refill(reader)?;
-                                if self.bits_left < 1 && self.marker.is_some() {
-                                    return Err(DecodeErrors::Format(
-                                        "Marker found where not expected in refine bit".to_string()
-                                    ));
-                                }
-                            }
-                            if self.get_bit() == 1 && (*coefficient & bit) == 0 {
-                                if *coefficient > 0 {
-                                    *coefficient = coefficient.wrapping_add(bit);
-                                } else {
-                                    *coefficient = coefficient.wrapping_sub(bit);
-                                }
-                            }
-                        } else {
-                            r -= 1;
-
-                            if r < 0 {
-                                // reached target zero coefficient.
-                                break 'advance_nonzero;
-                            }
-                        }
-
-                        if k == self.spec_end {
-                            break 'advance_nonzero;
-                        }
-
-                        k += 1;
+                if self.get_bit() == 1 && (*coefficient & bit) == 0 {
+                    if *coefficient > 0 {
+                        *coefficient = coefficient.wrapping_add(bit);
+                    } else {
+                        *coefficient = coefficient.wrapping_sub(bit);
                     }
-                }
-
-                if symbol != 0 {
-                    let pos = UN_ZIGZAG[k as usize & 63];
-                    // output new non-zero coefficient.
-                    block[pos & 63] = symbol as i16;
-                }
-
-                k += 1;
-
-                if k > self.spec_end {
-                    break 'no_eob;
                 }
             }
         }
-        if self.eob_run > 0 {
-            // only run if block does not consists of purely zeroes
-            // changing this to iter_any makes perf regress by 10%
-            //   time:   [+10.836% +11.589% +12.376%] (p = 0.00 < 0.05)
-            if &block[1..] != &[0; 63] {
-                self.refill(reader)?;
 
-                while k <= self.spec_end {
-                    let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
-
-                    if *coefficient != 0 && self.get_bit() == 1 {
-                        // check if we already modified it, if so do nothing, otherwise
-                        // append the correction bit.
-                        if (*coefficient & bit) == 0 {
-                            if *coefficient >= 0 {
-                                *coefficient = coefficient.wrapping_add(bit);
-                            } else {
-                                *coefficient = coefficient.wrapping_sub(bit);
-                            }
-                        }
-                    }
-                    if self.bits_left < 1 {
-                        // refill at the last possible moment
-                        self.refill(reader)?;
-                    }
-                    k += 1;
-                }
-            }
-            // count a block completed in EOB run
+        // Update after all potential errors.
+        if was_eob_run {
             self.eob_run -= 1;
         }
 

--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -931,7 +931,7 @@ impl BitStream for BitStreamHuffman {
         debug_assert!(bit > 0, "One bit in low mask set");
 
         let mut k = self.spec_start;
-        let spec_bound = if self.eob_run == 0 { self.spec_end }  else { 0 };
+        let spec_bound = if self.eob_run == 0 { self.spec_end } else { 0 };
 
         // We always know how many zeros *not* to initialize. For within an EOB run, that's all
         // remaining zeroes of the spectral band. We never iterate 127 coefficients so this is a
@@ -956,7 +956,9 @@ impl BitStream for BitStreamHuffman {
                     self.eob_run = 1 << r;
                     self.eob_run += self.get_bits(r as u8);
                     break 'non_eob;
-                } else /* r == 15 && symbol == 0 */ {
+                } else
+                /* r == 15 && symbol == 0 */
+                {
                     // This indicates a zero-fill.run
                     // NOTE: it also implies there's going to another coefficient.
                     // Before encoding it checks `K ≥ EOB` and we'd get an EOB (i.e. indication of
@@ -967,10 +969,6 @@ impl BitStream for BitStreamHuffman {
                 // libjpeg-turbo also doesn't return an error here, so let's also only warn.
                 if symbol != 1 {
                     warn!("Bad Huffman code, corrupt JPEG?");
-                }
-
-                if self.bits_left < 1 {
-                    self.refill(reader)?;
                 }
 
                 if self.bits_left < 1 && self.marker.is_some() {
@@ -987,6 +985,15 @@ impl BitStream for BitStreamHuffman {
                 } else {
                     symbol = i32::from(-bit);
                 }
+
+                // The encoding says there are `r` more zeros to be skipped, and then the zero to be
+                // initialized by the symbol bit, all which must occur before the end of the block.
+                // Our current index says this only leaves the last coefficient as the target for
+                // this operation. And that implies the block was finished with no EOBRUN.
+                if k + r as u8 == self.spec_end {
+                    block[UN_ZIGZAG[self.spec_end as usize & 63] & 63] = symbol as i16;
+                    break 'non_eob;
+                }
             }
 
             loop {
@@ -996,14 +1003,18 @@ impl BitStream for BitStreamHuffman {
                     // We have hit either the end of a ZRL or R_ZZ run. Find out which was decoded by
                     // inspecting `symbol`. This tells us if this is an assignment or just the last to
                     // skip.
-                    if r == 0 && symbol != 0 {
-                        // This is a coefficient to initialize.
-                        *coefficient = symbol as i16;
+                    if r == 0 {
+                        if symbol != 0 {
+                            // This is a coefficient to initialize.
+                            *coefficient = symbol as i16;
+                        }
                     }
 
                     r -= 1;
 
                     if r < 0 {
+                        // If we're doe with this zero-fill or coefficient initialization, advance the
+                        // index but keeping the check against `r` in this branch.
                         k += 1;
                         break;
                     }

--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -930,31 +930,15 @@ impl BitStream for BitStreamHuffman {
         let bit = self.successive_low_mask;
         debug_assert!(bit > 0, "One bit in low mask set");
 
-        let (mut symbol, mut r);
+        let mut k = self.spec_start;
 
-        // We always know how many zeros *not* to initialize. For within an EOB run, that's all
-        // remaining zeroes of the spectral band. We never iterate 127 coefficients so this is a
-        // safe upper bound.
-        const NZ_EOB_VAL: i8 = 127;
-        let mut nz: i8;
-        let mut was_eob_run = false;
+        if self.eob_run == 0 {
+            // We always know how many zeros *not* to initialize. For within an EOB run, that's all
+            // remaining zeroes of the spectral band. We never iterate 127 coefficients so this is a
+            // safe upper bound.
+            let (mut symbol, mut r);
 
-        // `symbol` is used to initialize an indicated zero coefficient, but control flow is not
-        // hierarchical (and dependent on iteration being less than 127 items) so this is a default
-        // for soundness purposes.
-        symbol = 0;
-
-        if self.eob_run > 0 {
-            was_eob_run = true;
-            // FIXME: fast path for entirely zeroes?
-
-            nz = NZ_EOB_VAL;
-        } else {
-            nz = -1;
-        }
-
-        for k in self.spec_start..=self.spec_end {
-            if nz < 0 {
+            'non_eob: while k <= self.spec_end {
                 self.refill(reader)?;
 
                 // We need our next instructions, decode a symbol and so on.
@@ -972,12 +956,9 @@ impl BitStream for BitStreamHuffman {
                         // EOB run is 2^r + bits.
                         self.eob_run = 1 << r;
                         self.eob_run += self.get_bits(r as u8);
-                        was_eob_run = true;
-                        nz = NZ_EOB_VAL;
-                    } else {
+                        break;
+                    } else /* r == 15 && symbol == 0 */ {
                         // This indicates a zero-fill.
-                        nz = 15;
-                        symbol = 0;
                     }
                 } else {
                     // libjpeg-turbo also doesn't return an error here, so let's also only warn.
@@ -1003,47 +984,78 @@ impl BitStream for BitStreamHuffman {
                     } else {
                         symbol = i32::from(-bit);
                     }
-
-                    nz = r as i8;
-                }
-            }
-
-            let coefficient = &mut block[UN_ZIGZAG[k as usize] & 63];
-
-            if *coefficient == 0 {
-                // We have hit either the end of a ZRL or R_ZZ run. Find out which was decoded by
-                // inspecting `symbol`. This tells us if this is an assignment or just the last to
-                // skip.
-                if nz == 0 && symbol != 0 {
-                    // This is a coefficient to initialize.
-                    *coefficient = symbol as i16;
                 }
 
-                nz -= 1;
-            } else {
-                if self.bits_left < 1 {
-                    // refill at the last possible moment
-                    self.refill(reader)?;
-                }
+                loop {
+                    let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
 
-                if self.bits_left < 1 && self.marker.is_some() {
-                    return Err(DecodeErrors::Format(
-                        "Marker found where not expected in refine bit".to_string(),
-                    ));
-                }
+                    if *coefficient == 0 {
+                        // We have hit either the end of a ZRL or R_ZZ run. Find out which was decoded by
+                        // inspecting `symbol`. This tells us if this is an assignment or just the last to
+                        // skip.
+                        if r == 0 && symbol != 0 {
+                            // This is a coefficient to initialize.
+                            *coefficient = symbol as i16;
+                        }
 
-                if self.get_bit() == 1 && (*coefficient & bit) == 0 {
-                    if *coefficient > 0 {
-                        *coefficient = coefficient.wrapping_add(bit);
+                        r -= 1;
+
+                        if r < 0 {
+                            k += 1;
+                            break;
+                        }
                     } else {
-                        *coefficient = coefficient.wrapping_sub(bit);
+                        if self.bits_left < 1 {
+                            // refill at the last possible moment
+                            self.refill(reader)?;
+                        }
+
+                        if self.get_bit() == 1 && (*coefficient & bit) == 0 {
+                            if *coefficient > 0 {
+                                *coefficient = coefficient.wrapping_add(bit);
+                            } else {
+                                *coefficient = coefficient.wrapping_sub(bit);
+                            }
+                        }
+                    }
+
+                    k += 1;
+
+                    if k > self.spec_end {
+                        break 'non_eob;
                     }
                 }
             }
         }
 
-        // Update after all potential errors.
-        if was_eob_run {
+        if self.eob_run > 0 {
+            // only run if block does not consists of purely zeroes
+            // changing this to iter_any makes perf regress by 10%
+            //   time:   [+10.836% +11.589% +12.376%] (p = 0.00 < 0.05)
+            if &block[1..] != &[0; 63] {
+                self.refill(reader)?;
+
+                for k in k..=self.spec_end {
+                    let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
+
+                    if *coefficient != 0 && self.get_bit() == 1 {
+                        // check if we already modified it, if so do nothing, otherwise
+                        // append the correction bit.
+                        if (*coefficient & bit) == 0 {
+                            if *coefficient >= 0 {
+                                *coefficient = coefficient.wrapping_add(bit);
+                            } else {
+                                *coefficient = coefficient.wrapping_sub(bit);
+                            }
+                        }
+                    }
+                    if self.bits_left < 1 {
+                        // refill at the last possible moment
+                        self.refill(reader)?;
+                    }
+                }
+            }
+
             self.eob_run -= 1;
         }
 

--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -1044,7 +1044,16 @@ impl BitStream for BitStreamHuffman {
             // only run if block does not consists of purely zeroes
             // changing this to iter_any makes perf regress by 10%
             //   time:   [+10.836% +11.589% +12.376%] (p = 0.00 < 0.05)
-            if &block[1..] != &[0; 63] {
+            //
+            // we can reduce the amount of total memory loads by trading against some comparisons if
+            // the spectral end can bound the index in UN_ZIGZAG order.
+            let have_any_nz_heuristic = if self.spec_end < 19 {
+                &block[1..33] != &[0; 32]
+            } else {
+                &block[1..] != &[0; 63]
+            };
+
+            if have_any_nz_heuristic {
                 self.refill(reader)?;
 
                 while k <= self.spec_end {

--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -931,100 +931,97 @@ impl BitStream for BitStreamHuffman {
         debug_assert!(bit > 0, "One bit in low mask set");
 
         let mut k = self.spec_start;
-        let spec_bound = self.spec_end;
+        let spec_bound = if self.eob_run == 0 { self.spec_end }  else { 0 };
 
-        if self.eob_run == 0 {
-            // We always know how many zeros *not* to initialize. For within an EOB run, that's all
-            // remaining zeroes of the spectral band. We never iterate 127 coefficients so this is a
-            // safe upper bound.
+        // We always know how many zeros *not* to initialize. For within an EOB run, that's all
+        // remaining zeroes of the spectral band. We never iterate 127 coefficients so this is a
+        // safe upper bound.
+        'non_eob: while k <= spec_bound {
             let (mut symbol, mut r);
+            self.refill(reader)?;
 
-            'non_eob: while k <= spec_bound {
-                self.refill(reader)?;
+            // We need our next instructions, decode a symbol and so on.
+            symbol = self.peek_bits::<HUFF_LOOKAHEAD>();
+            symbol = table.lookup[symbol as usize];
 
-                // We need our next instructions, decode a symbol and so on.
-                symbol = self.peek_bits::<HUFF_LOOKAHEAD>();
-                symbol = table.lookup[symbol as usize];
+            decode_huff!(self, symbol, table);
 
-                decode_huff!(self, symbol, table);
+            r = symbol >> 4;
+            symbol &= 15;
 
-                r = symbol >> 4;
-                symbol &= 15;
+            if symbol == 0 {
+                if r != 15 {
+                    // This indicates the start of an EOBRUN.
+                    // EOB run is 2^r + bits.
+                    self.eob_run = 1 << r;
+                    self.eob_run += self.get_bits(r as u8);
+                    break;
+                } else /* r == 15 && symbol == 0 */ {
+                    // This indicates a zero-fill.
+                }
+            } else {
+                // libjpeg-turbo also doesn't return an error here, so let's also only warn.
+                if symbol != 1 {
+                    warn!("Bad Huffman code, corrupt JPEG?");
+                }
 
-                if symbol == 0 {
-                    if r != 15 {
-                        // This indicates the start of an EOBRUN.
-                        // EOB run is 2^r + bits.
-                        self.eob_run = 1 << r;
-                        self.eob_run += self.get_bits(r as u8);
+                if self.bits_left < 1 {
+                    self.refill(reader)?;
+                }
+
+                if self.bits_left < 1 && self.marker.is_some() {
+                    return Err(DecodeErrors::Format(
+                        "Marker found where not expected in refine bit".to_string(),
+                    ));
+                }
+
+                // get sign bit
+                // We assume we have enough bits, which should be correct for sane images
+                // since we refill by 32 above
+                if self.get_bit() == 1 {
+                    symbol = i32::from(bit);
+                } else {
+                    symbol = i32::from(-bit);
+                }
+            }
+
+            loop {
+                let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
+
+                if *coefficient == 0 {
+                    // We have hit either the end of a ZRL or R_ZZ run. Find out which was decoded by
+                    // inspecting `symbol`. This tells us if this is an assignment or just the last to
+                    // skip.
+                    if r == 0 && symbol != 0 {
+                        // This is a coefficient to initialize.
+                        *coefficient = symbol as i16;
+                    }
+
+                    r -= 1;
+
+                    if r < 0 {
+                        k += 1;
                         break;
-                    } else /* r == 15 && symbol == 0 */ {
-                        // This indicates a zero-fill.
                     }
                 } else {
-                    // libjpeg-turbo also doesn't return an error here, so let's also only warn.
-                    if symbol != 1 {
-                        warn!("Bad Huffman code, corrupt JPEG?");
-                    }
-
                     if self.bits_left < 1 {
+                        // refill at the last possible moment
                         self.refill(reader)?;
                     }
 
-                    if self.bits_left < 1 && self.marker.is_some() {
-                        return Err(DecodeErrors::Format(
-                            "Marker found where not expected in refine bit".to_string(),
-                        ));
-                    }
-
-                    // get sign bit
-                    // We assume we have enough bits, which should be correct for sane images
-                    // since we refill by 32 above
-                    if self.get_bit() == 1 {
-                        symbol = i32::from(bit);
-                    } else {
-                        symbol = i32::from(-bit);
+                    if self.get_bit() == 1 && (*coefficient & bit) == 0 {
+                        if *coefficient > 0 {
+                            *coefficient = coefficient.wrapping_add(bit);
+                        } else {
+                            *coefficient = coefficient.wrapping_sub(bit);
+                        }
                     }
                 }
 
-                loop {
-                    let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
+                k += 1;
 
-                    if *coefficient == 0 {
-                        // We have hit either the end of a ZRL or R_ZZ run. Find out which was decoded by
-                        // inspecting `symbol`. This tells us if this is an assignment or just the last to
-                        // skip.
-                        if r == 0 && symbol != 0 {
-                            // This is a coefficient to initialize.
-                            *coefficient = symbol as i16;
-                        }
-
-                        r -= 1;
-
-                        if r < 0 {
-                            k += 1;
-                            break;
-                        }
-                    } else {
-                        if self.bits_left < 1 {
-                            // refill at the last possible moment
-                            self.refill(reader)?;
-                        }
-
-                        if self.get_bit() == 1 && (*coefficient & bit) == 0 {
-                            if *coefficient > 0 {
-                                *coefficient = coefficient.wrapping_add(bit);
-                            } else {
-                                *coefficient = coefficient.wrapping_sub(bit);
-                            }
-                        }
-                    }
-
-                    k += 1;
-
-                    if k > spec_bound {
-                        break 'non_eob;
-                    }
+                if k > spec_bound {
+                    break 'non_eob;
                 }
             }
         }
@@ -1036,7 +1033,7 @@ impl BitStream for BitStreamHuffman {
             if &block[1..] != &[0; 63] {
                 self.refill(reader)?;
 
-                while k <= spec_bound {
+                while k <= self.spec_end {
                     let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
 
                     if *coefficient != 0 && self.get_bit() == 1 {

--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -931,6 +931,7 @@ impl BitStream for BitStreamHuffman {
         debug_assert!(bit > 0, "One bit in low mask set");
 
         let mut k = self.spec_start;
+        let spec_bound = self.spec_end;
 
         if self.eob_run == 0 {
             // We always know how many zeros *not* to initialize. For within an EOB run, that's all
@@ -938,7 +939,7 @@ impl BitStream for BitStreamHuffman {
             // safe upper bound.
             let (mut symbol, mut r);
 
-            'non_eob: while k <= self.spec_end {
+            'non_eob: while k <= spec_bound {
                 self.refill(reader)?;
 
                 // We need our next instructions, decode a symbol and so on.
@@ -1021,7 +1022,7 @@ impl BitStream for BitStreamHuffman {
 
                     k += 1;
 
-                    if k > self.spec_end {
+                    if k > spec_bound {
                         break 'non_eob;
                     }
                 }
@@ -1035,7 +1036,7 @@ impl BitStream for BitStreamHuffman {
             if &block[1..] != &[0; 63] {
                 self.refill(reader)?;
 
-                for k in k..=self.spec_end {
+                while k <= spec_bound {
                     let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
 
                     if *coefficient != 0 && self.get_bit() == 1 {
@@ -1049,10 +1050,13 @@ impl BitStream for BitStreamHuffman {
                             }
                         }
                     }
+
                     if self.bits_left < 1 {
                         // refill at the last possible moment
                         self.refill(reader)?;
                     }
+
+                    k += 1;
                 }
             }
 

--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -196,13 +196,14 @@ pub(crate) trait BitStream {
 
     fn decode_mcu_ac_first<T>(
         &mut self, reader: &mut ZReader<T>, ac_table: &mut Self::ACEntropyTable,
-        block: &mut [i16; 64]
+        block: &mut [i16; 64], mask: &mut u64,
     ) -> Result<bool, DecodeErrors>
     where
         T: ZByteReaderTrait;
 
     fn decode_mcu_ac_refine<T>(
-        &mut self, reader: &mut ZReader<T>, table: &mut Self::ACEntropyTable, block: &mut [i16; 64]
+        &mut self, reader: &mut ZReader<T>, table: &mut Self::ACEntropyTable,
+        block: &mut [i16; 64], mask: &mut u64,
     ) -> Result<bool, DecodeErrors>
     where
         T: ZByteReaderTrait;
@@ -864,7 +865,8 @@ impl BitStream for BitStreamHuffman {
     }
 
     fn decode_mcu_ac_first<T>(
-        &mut self, reader: &mut ZReader<T>, ac_table: &mut HuffmanTable, block: &mut [i16; 64]
+        &mut self, reader: &mut ZReader<T>, ac_table: &mut HuffmanTable,
+        block: &mut [i16; 64], mask: &mut u64,
     ) -> Result<bool, DecodeErrors>
     where
         T: ZByteReaderTrait
@@ -888,6 +890,7 @@ impl BitStream for BitStreamHuffman {
                 // fast ac path
                 k += ((fac >> 4) & 15) as usize; // run
                 block[UN_ZIGZAG[min(k, 63)] & 63] = (fac >> 8).wrapping_mul(bit); // value
+                *mask |= u64::from((fac >> 8) != 0) << min(k, 63);
                 self.drop_bits((fac & 15) as u8);
                 k += 1;
             } else {
@@ -901,6 +904,7 @@ impl BitStream for BitStreamHuffman {
                     r = self.get_bits(symbol as u8);
                     symbol = huff_extend(r, symbol);
                     block[UN_ZIGZAG[k & 63] & 63] = (symbol as i16).wrapping_mul(bit);
+                    *mask |= u64::from(symbol != 0) << (k & 63);
                     k += 1;
                 } else {
                     if r != 15 {
@@ -922,7 +926,8 @@ impl BitStream for BitStreamHuffman {
     }
     #[allow(clippy::too_many_lines, clippy::op_ref)]
     fn decode_mcu_ac_refine<T>(
-        &mut self, reader: &mut ZReader<T>, table: &mut HuffmanTable, block: &mut [i16; 64],
+        &mut self, reader: &mut ZReader<T>, table: &mut HuffmanTable,
+        block: &mut [i16; 64], mask: &mut u64,
     ) -> Result<bool, DecodeErrors>
     where
         T: ZByteReaderTrait,
@@ -931,6 +936,9 @@ impl BitStream for BitStreamHuffman {
         debug_assert!(bit > 0, "One bit in low mask set");
 
         let mut k = self.spec_start;
+        let mut non_zero_mask = (*mask) >> k;
+        let mut init_mask = 0;
+
         let spec_bound = if self.eob_run == 0 { self.spec_end } else { 0 };
 
         // We always know how many zeros *not* to initialize. For within an EOB run, that's all
@@ -992,14 +1000,16 @@ impl BitStream for BitStreamHuffman {
                 // this operation. And that implies the block was finished with no EOBRUN.
                 if k + r as u8 == self.spec_end {
                     block[UN_ZIGZAG[self.spec_end as usize & 63] & 63] = symbol as i16;
+                    init_mask |= 1 << self.spec_end;
                     break 'non_eob;
                 }
             }
 
             loop {
                 let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
+                debug_assert_eq!(*coefficient == 0, (non_zero_mask & 0b1) == 0);
 
-                if *coefficient == 0 {
+                if (non_zero_mask & 0b1) == 0 {
                     // We have hit either the end of a ZRL or R_ZZ run. Find out which was decoded by
                     // inspecting `symbol`. This tells us if this is an assignment or just the last to
                     // skip.
@@ -1007,6 +1017,7 @@ impl BitStream for BitStreamHuffman {
                         if symbol != 0 {
                             // This is a coefficient to initialize.
                             *coefficient = symbol as i16;
+                            init_mask |= 1 << k;
                         }
                     }
 
@@ -1016,6 +1027,7 @@ impl BitStream for BitStreamHuffman {
                         // If we're doe with this zero-fill or coefficient initialization, advance the
                         // index but keeping the check against `r` in this branch.
                         k += 1;
+                        non_zero_mask >>= 1;
                         break;
                     }
                 } else {
@@ -1034,6 +1046,7 @@ impl BitStream for BitStreamHuffman {
                 }
 
                 k += 1;
+                non_zero_mask >>= 1;
 
                 // NOTE: in a valid bitstream we can assume this to only happen after the case
                 // `coefficient ! 0`, (corresponding to the nodes:
@@ -1053,24 +1066,20 @@ impl BitStream for BitStreamHuffman {
 
         if self.eob_run > 0 {
             // only run if block does not consists of purely zeroes
-            // changing this to iter_any makes perf regress by 10%
-            //   time:   [+10.836% +11.589% +12.376%] (p = 0.00 < 0.05)
-            //
-            // we can reduce the amount of total memory loads by trading against some comparisons if
-            // the spectral end can bound the index in UN_ZIGZAG order.
-            let have_any_nz_heuristic = if self.spec_end < 19 {
-                &block[1..33] != &[0; 32]
-            } else {
-                &block[1..] != &[0; 63]
-            };
+            let have_any_nz_heuristic = (non_zero_mask << (63 - (self.spec_end - k))) != 0;
+            debug_assert!(
+                have_any_nz_heuristic || (k as usize..=self.spec_end as usize).all(|k| block[UN_ZIGZAG[k as usize]] == 0),
+                "{non_zero_mask} for {k}..{}", self.spec_end,
+            );
 
             if have_any_nz_heuristic {
                 self.refill(reader)?;
 
                 while k <= self.spec_end {
                     let coefficient = &mut block[UN_ZIGZAG[k as usize & 63] & 63];
+                    debug_assert_eq!(*coefficient == 0, (non_zero_mask & 0b1) == 0);
 
-                    if *coefficient != 0 && self.get_bit() == 1 {
+                    if (non_zero_mask & 0b1) != 0 && self.get_bit() == 1 {
                         // check if we already modified it, if so do nothing, otherwise
                         // append the correction bit.
                         if (*coefficient & bit) == 0 {
@@ -1088,12 +1097,14 @@ impl BitStream for BitStreamHuffman {
                     }
 
                     k += 1;
+                    non_zero_mask >>= 1;
                 }
             }
 
             self.eob_run -= 1;
         }
 
+        *mask |= init_mask;
         return Ok(true);
     }
 

--- a/crates/zune-jpeg/src/bitstream.rs
+++ b/crates/zune-jpeg/src/bitstream.rs
@@ -955,9 +955,13 @@ impl BitStream for BitStreamHuffman {
                     // EOB run is 2^r + bits.
                     self.eob_run = 1 << r;
                     self.eob_run += self.get_bits(r as u8);
-                    break;
+                    break 'non_eob;
                 } else /* r == 15 && symbol == 0 */ {
-                    // This indicates a zero-fill.
+                    // This indicates a zero-fill.run
+                    // NOTE: it also implies there's going to another coefficient.
+                    // Before encoding it checks `K ≥ EOB` and we'd get an EOB (i.e. indication of
+                    // the number of zero-coefficients) if that would hold. Thus, k < EOB (the last
+                    // index of a magnitude-1 coefficient in this block).
                 }
             } else {
                 // libjpeg-turbo also doesn't return an error here, so let's also only warn.
@@ -1020,6 +1024,16 @@ impl BitStream for BitStreamHuffman {
 
                 k += 1;
 
+                // NOTE: in a valid bitstream we can assume this to only happen after the case
+                // `coefficient ! 0`, (corresponding to the nodes:
+                //
+                // - `Encode_R_ZZ(K), `Append_BR_bits`
+                // - `K = Se` -> Yes
+                //
+                // in figure G.7 (in ITU t81, section G1.3.2). If we had hit the other bound, this
+                // would have been encoded as an EOBRUN instead.
+                // FIXME: do we want to diagnose this or utilize it for optimization (avoiding an
+                // attack DOS vector though)?
                 if k > spec_bound {
                     break 'non_eob;
                 }

--- a/crates/zune-jpeg/src/bitstream_arith.rs
+++ b/crates/zune-jpeg/src/bitstream_arith.rs
@@ -877,7 +877,7 @@ impl BitStream for BitStreamArithmetic {
     }
 
     fn decode_mcu_ac_first<T>(
-        &mut self, reader: &mut ZReader<T>, ac_table: &mut ArithACTables, block: &mut [i16; 64],
+        &mut self, reader: &mut ZReader<T>, ac_table: &mut ArithACTables, block: &mut [i16; 64], _mask: &mut u64,
     ) -> Result<bool, DecodeErrors>
     where
         T: ZByteReaderTrait,
@@ -923,7 +923,7 @@ impl BitStream for BitStreamArithmetic {
 
     #[allow(clippy::too_many_lines, clippy::op_ref)]
     fn decode_mcu_ac_refine<T>(
-        &mut self, reader: &mut ZReader<T>, ac_table: &mut ArithACTables, block: &mut [i16; 64],
+        &mut self, reader: &mut ZReader<T>, ac_table: &mut ArithACTables, block: &mut [i16; 64], _mask: &mut u64,
     ) -> Result<bool, DecodeErrors>
     where
         T: ZByteReaderTrait,

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -347,13 +347,13 @@ pub struct JpegDecoder<T> {
     /// coefficient buffers for completed scans. The inner `Vec`s are reused
     /// across `decode_into` calls; capacity is reclaimed only when the decoder
     /// is dropped.
-    pub(crate) progressive_mcus_buffer: [Vec<i16>; MAX_COMPONENTS],
+    pub(crate) progressive_mcus_buffer: [ProgressiveBufferData; MAX_COMPONENTS],
     /// Active progressive scan scratch buffers.
     ///
     /// Storage is retained across EOF or cancellation so retries can reuse its
     /// capacity. Safe first-DC scans also keep its contents so a later retry can
     /// resume from a fine checkpoint without committing partial scan data.
-    pub(crate) progressive_scan_buffer: [Vec<i16>; MAX_COMPONENTS],
+    pub(crate) progressive_scan_buffer: [ProgressiveBufferData; MAX_COMPONENTS],
     /// Number of progressive scans committed into `progressive_mcus_buffer`.
     pub(crate) progressive_completed_scans: usize,
     /// Number of committed progressive scans currently rendered as preview
@@ -399,6 +399,13 @@ pub struct JpegDecoder<T> {
     /// and store the real height; if it never arrives, decoding returns an
     /// error.
     pub(crate) expects_dnl: bool
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct ProgressiveBufferData {
+    pub(crate) mcu: Vec<i16>,
+    /// Initialization mask of AC components.
+    pub(crate) init_mask: Vec<u64>,
 }
 
 impl<T> JpegDecoder<T>
@@ -710,8 +717,8 @@ where
             mcu_checkpoints_enabled:     false,
             incremental_mode:            false,
             scan_decode_attempted:       false,
-            progressive_mcus_buffer:     core::array::from_fn(|_| Vec::new()),
-            progressive_scan_buffer: core::array::from_fn(|_| Vec::new()),
+            progressive_mcus_buffer:     core::array::from_fn(|_| ProgressiveBufferData::default()),
+            progressive_scan_buffer:     core::array::from_fn(|_| ProgressiveBufferData::default()),
             progressive_completed_scans: 0,
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -69,9 +69,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // on `self`. The buffer is put back on return and survives across
         // `decode_into` retries, which is what lets scan checkpoints stay
         // allocation-free.
-        let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
+        let mut progressive_mcus = self.progressive_mcus_buffer.each_mut().map(|buf| core::mem::take(&mut buf.mcu));
         let result = self.decode_mcu_ycbcr_baseline_inner::<B>(pixels, &mut progressive_mcus);
-        self.progressive_mcus_buffer = progressive_mcus;
+        for (buf, mcu) in self.progressive_mcus_buffer.iter_mut().zip(progressive_mcus) {
+            buf.mcu = mcu;
+        }
         result
     }
 

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -652,25 +652,21 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
         let component_buffer_data = &mut buffer[k];
+        let width_stride = self.components[k].width_stride / 8;
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        let lines = component_buffer_data.chunks_exact_mut(64 * width_stride);
+
+        for line in lines.take(mcu_height) {
             if cancel.is_cancelled() {
                 return Err(DecodeErrors::Cancelled);
             }
-            for j in 0..mcu_width {
+
+            for data in line.as_chunks_mut::<64>().0 {
                 if *stream.eob_run() > 0 {
                     // handle EOB runs here.
                     *stream.eob_run() -= 1;
                 } else {
-                    let start = 64 * (j + i * (self.components[k].width_stride / 8));
-
-                    let data: &mut [i16; 64] = component_buffer_data
-                        .get_mut(start..start + 64)
-                        .ok_or(DecodeErrors::FormatStatic("Slice to Small"))?
-                        .try_into()
-                        .unwrap();
-
                     let ac_table = B::get_ac_table(&mut self.entropy_tables, ac_pos)?;
                     if !stream.decode_mcu_ac_first(&mut self.stream, ac_table, data)? {
                         // Arithmetic bad-code termination is scan-wide, matching
@@ -695,18 +691,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let width_stride = self.components[k].width_stride / 8;
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        for i in 0..mcu_height {
+        let lines = component_buffer_data.chunks_exact_mut(64 * width_stride);
+
+        for line in lines.take(mcu_height) {
             if cancel.is_cancelled() {
                 return Err(DecodeErrors::Cancelled);
             }
-            for j in 0..mcu_width {
-                let start = 64 * (j + i * width_stride);
-                let data: &mut [i16; 64] = component_buffer_data
-                    .get_mut(start..start + 64)
-                    .ok_or(DecodeErrors::FormatStatic("Slice to Small"))?
-                    .try_into()
-                    .unwrap();
 
+            for data in line.as_chunks_mut::<64>().0 {
                 let ac_table = B::get_ac_table(&mut self.entropy_tables, ac_pos)?;
                 stream.decode_mcu_ac_refine(&mut self.stream, ac_table, data)?;
 

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -655,24 +655,25 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
-        let component_buffer_data = &mut buffer[k].mcu;
+        let component_buffer_data = &mut buffer[k];
         let width_stride = self.components[k].width_stride / 8;
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        let lines = component_buffer_data.chunks_exact_mut(64 * width_stride);
+        let lines = component_buffer_data.mcu.chunks_exact_mut(64 * width_stride);
+        let masks = component_buffer_data.init_mask.chunks_exact_mut(width_stride);
 
-        for line in lines.take(mcu_height) {
+        for (line, masks) in lines.take(mcu_height).zip(masks) {
             if cancel.is_cancelled() {
                 return Err(DecodeErrors::Cancelled);
             }
 
-            for data in line.as_chunks_mut::<64>().0 {
+            for (data, mask) in line.as_chunks_mut::<64>().0.iter_mut().zip(masks) {
                 if *stream.eob_run() > 0 {
                     // handle EOB runs here.
                     *stream.eob_run() -= 1;
                 } else {
                     let ac_table = B::get_ac_table(&mut self.entropy_tables, ac_pos)?;
-                    if !stream.decode_mcu_ac_first(&mut self.stream, ac_table, data)? {
+                    if !stream.decode_mcu_ac_first(&mut self.stream, ac_table, data, mask)? {
                         // Arithmetic bad-code termination is scan-wide, matching
                         // libjpeg's no-op handling for the remaining MCUs.
                         return Ok(());
@@ -691,20 +692,21 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
-        let component_buffer_data = &mut buffer[k].mcu;
+        let component_buffer_data = &mut buffer[k];
         let width_stride = self.components[k].width_stride / 8;
 
         let mut cancel = self.cancel_debounced(mcu_width);
-        let lines = component_buffer_data.chunks_exact_mut(64 * width_stride);
+        let lines = component_buffer_data.mcu.chunks_exact_mut(64 * width_stride);
+        let masks = component_buffer_data.init_mask.chunks_exact_mut(width_stride);
 
-        for line in lines.take(mcu_height) {
+        for (line, masks) in lines.take(mcu_height).zip(masks) {
             if cancel.is_cancelled() {
                 return Err(DecodeErrors::Cancelled);
             }
 
-            for data in line.as_chunks_mut::<64>().0 {
+            for (data, mask) in line.as_chunks_mut::<64>().0.iter_mut().zip(masks) {
                 let ac_table = B::get_ac_table(&mut self.entropy_tables, ac_pos)?;
-                stream.decode_mcu_ac_refine(&mut self.stream, ac_table, data)?;
+                stream.decode_mcu_ac_refine(&mut self.stream, ac_table, data, mask)?;
 
                 self.todo -= 1;
                 self.handle_rst_main(stream)?;

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -9,7 +9,6 @@
 //!Routines for progressive decoding
 
 use alloc::string::ToString;
-use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::cmp::min;
 
@@ -19,7 +18,7 @@ use zune_core::log::{error, trace, warn};
 
 use crate::bitstream::BitStream;
 use crate::components::SampleRatios;
-use crate::decoder::{JpegDecoder, ProgressiveFineCheckpoint, MAX_COMPONENTS};
+use crate::decoder::{JpegDecoder,ProgressiveFineCheckpoint, MAX_COMPONENTS, ProgressiveBufferData};
 use crate::errors::DecodeErrors;
 use crate::headers::parse_sos;
 use crate::marker::Marker;
@@ -68,12 +67,12 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         clippy::too_many_lines
     )]
     fn decode_mcu_ycbcr_progressive_inner<B: BitStream>(
-        &mut self, pixels: &mut [u8], block: &mut [Vec<i16>; MAX_COMPONENTS],
-        scan_block: &mut [Vec<i16>; MAX_COMPONENTS]
+        &mut self, pixels: &mut [u8], block: &mut [ProgressiveBufferData; MAX_COMPONENTS],
+        scan_block: &mut [ProgressiveBufferData; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
         let mut mcu_height;
-        let mut mcu_width;
+        let mcu_width;
 
         if self.input_colorspace == ColorSpace::Luma && self.is_interleaved {
             warn!("Grayscale image with down-sampled component, resetting component details");
@@ -110,18 +109,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             self.coeff = 2;
         }
 
-        mcu_width *= 64;
-
         if self.progressive_scan_checkpoint().is_none() {
             self.progressive_completed_scans = 0;
         }
         for (i, comp) in self.components.iter().enumerate() {
             let len = mcu_width * comp.vertical_sample * comp.horizontal_sample * mcu_height;
-            if block[i].len() != len {
-                block[i].clear();
-                block[i].resize(len, 0);
+
+            if block[i].mcu.len() != len * 64 {
+                block[i].mcu.clear();
+                block[i].mcu.resize(64 * len, 0);
+                block[i].init_mask.clear();
+                block[i].init_mask.resize(len, 0);
             } else if self.progressive_completed_scans == 0 {
-                block[i].fill(0);
+                block[i].mcu.fill(0);
+                block[i].init_mask.fill(0);
             }
         }
 
@@ -245,8 +246,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn decode_progressive_scan<B: BitStream>(
-        &mut self, stream: &mut B, block: &mut [Vec<i16>; MAX_COMPONENTS],
-        scan_block: &mut [Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        &mut self, stream: &mut B, block: &mut [ProgressiveBufferData; MAX_COMPONENTS],
+        scan_block: &mut [ProgressiveBufferData; MAX_COMPONENTS], pixels: &mut [u8],
         use_scratch_coefficients: bool
     ) -> Result<bool, DecodeErrors> {
         if !use_scratch_coefficients {
@@ -272,14 +273,17 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         for idx in 0..MAX_COMPONENTS {
             if !touched_components[idx] {
-                scan_block[idx].clear();
+                scan_block[idx].mcu.clear();
+                scan_block[idx].init_mask.clear();
                 continue;
             }
 
             if fine_resume.is_none() {
-                scan_block[idx].clear();
-                scan_block[idx].extend_from_slice(&block[idx]);
-            } else if scan_block[idx].len() != block[idx].len() {
+                scan_block[idx].mcu.clear();
+                scan_block[idx].mcu.extend_from_slice(&block[idx].mcu);
+                scan_block[idx].init_mask.clear();
+                scan_block[idx].init_mask.extend_from_slice(&block[idx].init_mask);
+            } else if scan_block[idx].mcu.len() != block[idx].mcu.len() {
                 return Err(DecodeErrors::FormatStatic(
                     "Progressive resume scratch buffer has invalid length"
                 ));
@@ -355,7 +359,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn decode_progressive_scan_direct<B: BitStream>(
-        &mut self, stream: &mut B, block: &mut [Vec<i16>; MAX_COMPONENTS]
+        &mut self, stream: &mut B, block: &mut [ProgressiveBufferData; MAX_COMPONENTS]
     ) -> Result<bool, DecodeErrors> {
         let result = self.parse_entropy_coded_data(stream, block, None);
 
@@ -392,7 +396,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn handle_progressive_inter_scan_error(
-        &mut self, error: DecodeErrors, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        &mut self, error: DecodeErrors, block: &[ProgressiveBufferData; MAX_COMPONENTS], pixels: &mut [u8],
         preserve_completed_scans: bool
     ) -> Result<(), DecodeErrors> {
         if matches!(error, DecodeErrors::Cancelled) {
@@ -422,7 +426,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn finish_progressive_partial(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8]
+        &mut self, block: &[ProgressiveBufferData; MAX_COMPONENTS], pixels: &mut [u8]
     ) -> Result<(), DecodeErrors> {
         if self.progressive_completed_scans == 0 {
             self.pixels_decoded = 0;
@@ -487,7 +491,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// once instead of read-modify-writing refinement data.
     #[allow(clippy::too_many_lines, clippy::cast_sign_loss)]
     fn parse_entropy_coded_data<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        &mut self, stream: &mut B, buffer: &mut [ProgressiveBufferData; MAX_COMPONENTS],
         fine_resume: Option<&ProgressiveFineCheckpoint>,
     ) -> Result<(), DecodeErrors> {
         self.reset_prog_params(stream);
@@ -581,7 +585,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_dc_first_non_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        &mut self, stream: &mut B, buffer: &mut [ProgressiveBufferData; MAX_COMPONENTS], k: usize,
         resume_position: Option<(usize, usize)>,
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
@@ -597,7 +601,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             let start_col = if i == resume_row { resume_col } else { 0 };
             for j in start_col..mcu_width {
                 let start = 64 * (j + i * width_stride);
-                let dc_pred_opt: Option<&mut i16> = buffer[k].get_mut(start);
+                let dc_pred_opt: Option<&mut i16> = buffer[k].mcu.get_mut(start);
 
                 if let Some(dc_pred) = dc_pred_opt {
                     let dc_table = B::get_dc_table(&mut self.entropy_tables, dc_pos)?;
@@ -621,7 +625,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_dc_refine_non_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        &mut self, stream: &mut B, buffer: &mut [ProgressiveBufferData; MAX_COMPONENTS], k: usize,
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let width_stride = self.components[k].width_stride / 8;
@@ -634,7 +638,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
             for j in 0..mcu_width {
                 let start = 64 * (j + i * width_stride);
-                let dc_pred_id: Option<&mut i16> = component_buffer.get_mut(start);
+                let dc_pred_id: Option<&mut i16> = component_buffer.mcu.get_mut(start);
 
                 if let Some(dc_pred) = dc_pred_id {
                     stream.decode_prog_dc_refine(&mut self.stream, dc_pred)?;
@@ -647,11 +651,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_ac_first_non_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        &mut self, stream: &mut B, buffer: &mut [ProgressiveBufferData; MAX_COMPONENTS], k: usize,
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
-        let component_buffer_data = &mut buffer[k];
+        let component_buffer_data = &mut buffer[k].mcu;
         let width_stride = self.components[k].width_stride / 8;
 
         let mut cancel = self.cancel_debounced(mcu_width);
@@ -683,11 +687,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_ac_refine_non_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        &mut self, stream: &mut B, buffer: &mut [ProgressiveBufferData; MAX_COMPONENTS], k: usize,
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
-        let component_buffer_data = &mut buffer[k];
+        let component_buffer_data = &mut buffer[k].mcu;
         let width_stride = self.components[k].width_stride / 8;
 
         let mut cancel = self.cancel_debounced(mcu_width);
@@ -710,7 +714,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_dc_first_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        &mut self, stream: &mut B, buffer: &mut [ProgressiveBufferData; MAX_COMPONENTS],
         resume_position: Option<(usize, usize)>,
     ) -> Result<(), DecodeErrors> {
         let mut cancel = self.cancel_debounced(self.mcu_x);
@@ -733,7 +737,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             let y2 = i * component.vertical_sample + v_samp;
                             let position = 64 * (x2 + y2 * component.width_stride / 8);
 
-                            let Some(data) = buffer[n].get_mut(position) else {
+                            let Some(data) = buffer[n].mcu.get_mut(position) else {
                                 return Err(DecodeErrors::FormatStatic("Invalid image"));
                             };
 
@@ -756,7 +760,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_dc_refine_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        &mut self, stream: &mut B, buffer: &mut [ProgressiveBufferData; MAX_COMPONENTS],
     ) -> Result<(), DecodeErrors> {
         let mut cancel = self.cancel_debounced(self.mcu_x);
         for i in 0..self.mcu_y {
@@ -774,7 +778,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             let y2 = i * component.vertical_sample + v_samp;
                             let position = 64 * (x2 + y2 * component.width_stride / 8);
 
-                            let Some(data) = buffer[n].get_mut(position) else {
+                            let Some(data) = buffer[n].mcu.get_mut(position) else {
                                 return Err(DecodeErrors::FormatStatic("Invalid image"));
                             };
 
@@ -892,7 +896,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::needless_range_loop, clippy::cast_sign_loss)]
     fn finish_progressive_decoding(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        &mut self, block: &[ProgressiveBufferData; MAX_COMPONENTS], pixels: &mut [u8],
     ) -> Result<(), DecodeErrors> {
         // Rendering replaces the caller's output row by row. Until every row
         // succeeds, the buffer may contain a mix of preview generations and
@@ -987,11 +991,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 //
                 // For interleaved images, this gives us the exact pixels comprising a whole MCU
                 // block
-                let step = block[position].len() / mcu_height;
+                let step = block[position].mcu.len() / mcu_height;
                 // where we will be reading our pixels from.
                 let start = i * step;
 
-                let slice = &block[position][start..start + step];
+                let slice = &block[position].mcu[start..start + step];
 
                 let temp_channel = &mut component.raw_coeff;
 
@@ -1182,7 +1186,7 @@ mod tests {
                 let options = DecoderOptions::default().set_strict_mode(strict);
                 let mut direct = JpegDecoder::new_with_options(ZCursor::new(data), options);
                 direct.decode().unwrap();
-                let reference = direct.progressive_mcus_buffer[0].clone();
+                let reference = direct.progressive_mcus_buffer[0].mcu.clone();
                 assert_eq!(reference.len(), 16 * 64, "{name}");
                 assert_eq!(coefficient_hash(&reference), LIBJPEG_COEFFICIENT_HASH, "{name}");
                 for (block, natural_index, expected) in [
@@ -1217,7 +1221,7 @@ mod tests {
                         assert!(result.unwrap_err().is_recoverable_eof());
                     }
                     assert_eq!(decoder.decoded_scans(), Some(scan_count));
-                    let actual = &decoder.progressive_mcus_buffer[0];
+                    let actual = &decoder.progressive_mcus_buffer[0].mcu;
                     assert_eq!(actual.len(), reference.len());
 
                     let mut known = [false; 64];


### PR DESCRIPTION
The main cost in its tight loop is zero-tests against spectral coefficients to decide if they will get an additional bit decoded or to use the huffman coded data. Firstly, the loop there was written in an obscure way so I straightened it out in a way that clarifies that each coefficient is visited once.

Secondly, and importantly for performance, we can perform the zero-check far more efficiently with the help of a mask that remembers which coefficients have been initialized already by their position. This avoids countless `i16`-sized reads for a single `u64` register / stack value. The mask is updated when an AC initialization, i.e. the first bit of a magnitude-1 coefficient, is encountered. This also avoids a previously costly (as per comment in code) check for the EOB run portion of each block. The compression switches to a different loop when there are no further coefficients to initialize, which avoids a bunch of instructions. We also want to avoid unecessary refills and other checks and so optimize when only 0s are left which would not consume any bits from the stream. This was previously a rough comparison against the block as UNZIGZAG is costly. Since the mask is in spectral order however we can now do some simple arithmetic.

Result: ~1.7x performance in some progressive benchmarks (on my laptop with slower memory).

-----

I've played around quite a bit with the AC refinement loop during the rewrite, see some intermediate commits, but then converged to roughly a similar structure as on `dev` anyways. Those can be squashed if you'd like.

Also, this was started before the fine restart commits appeared on `dev` and I'm not entirely sure if I'm following the intent of the code here.