### PR TITLE
[WIP] JpegDecoder: Add pull-based raw iMCU-row output

### DIFF
--- a/benchmarks/benches/decode_jpeg.rs
+++ b/benchmarks/benches/decode_jpeg.rs
@@ -16,7 +16,7 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use zune_benches::sample_path;
 use zune_jpeg::zune_core::colorspace::ColorSpace;
 use zune_jpeg::zune_core::options::DecoderOptions;
-use zune_jpeg::JpegDecoder;
+use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
 use zune_png::zune_core::bytestream::ZCursor;
 
 fn decode_jpeg(buf: &[u8]) -> Vec<u8> {
@@ -403,6 +403,60 @@ fn decode_streaming_mode(c: &mut Criterion) {
     });
 }
 
+fn decode_jpeg_raw_pull(buf: &[u8]) -> u64 {
+    let mut decoder = JpegDecoder::new(ZCursor::new(buf));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| vec![0; strides[index] * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut checksum = 0_u64;
+
+    loop {
+        let mut planes: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+        match raw.decode_next_imcu_row(&mut planes, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    for row in 0..rows_written[index] {
+                        checksum = storage[index]
+                            [row * strides[index]..row * strides[index] + layout[index].width]
+                            .iter()
+                            .fold(checksum, |sum, byte| sum.wrapping_add(u64::from(*byte)));
+                    }
+                }
+            }
+            RawImcuRowStatus::Complete => break,
+            RawImcuRowStatus::NeedMoreInput => panic!("one-shot benchmark input suspended"),
+            _ => unreachable!(),
+        }
+    }
+    checksum
+}
+
+fn decode_raw_pull_output(c: &mut Criterion) {
+    let baseline =
+        read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_hv_subsampling.jpg"))
+            .unwrap();
+    let progressive =
+        read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_prog.jpg")).unwrap();
+    let mut group = c.benchmark_group("jpeg: raw iMCU-row output");
+
+    group.bench_function("baseline", |b| {
+        b.iter(|| black_box(decode_jpeg_raw_pull(baseline.as_slice())));
+    });
+    group.bench_function("progressive", |b| {
+        b.iter(|| black_box(decode_jpeg_raw_pull(progressive.as_slice())));
+    });
+}
+
 criterion_group!(name=benches;
       config={
       let c = Criterion::default();
@@ -412,6 +466,6 @@ criterion_group!(name=benches;
     decode_hv_samp,criterion_benchmark_grayscale,
     decode_hv_samp_prog,decode_h_samp_prog,decode_no_samp_prog,decode_v_samp_prog,
     decode_no_samp_opts,
-    decode_restart_full,decode_restart_resume,decode_streaming_mode);
+    decode_restart_full,decode_restart_resume,decode_streaming_mode,decode_raw_pull_output);
 
 criterion_main!(benches);

--- a/crates/zune-jpeg/src/bitstream_arith.rs
+++ b/crates/zune-jpeg/src/bitstream_arith.rs
@@ -563,15 +563,22 @@ impl BitStreamArithmetic {
     }
 }
 
-/// Minimal snapshot for arithmetic bitstream — only captures enough to detect
-/// whether the stream was exhausted. True per-MCU resume is not feasible for
-/// arithmetic coding due to statistical context coupling.
+/// Arithmetic bitstream registers captured at a stable pull-row boundary.
+/// Statistical contexts remain in `EntropyTables` and are preserved separately
+/// by the borrowing raw-output session.
 #[derive(Clone, Copy)]
 pub(crate) struct ArithBitstreamState {
-    pub(crate) marker:      Option<Marker>,
-    pub(crate) overread_by: usize,
-    pub(crate) seen_eoi:    bool,
-    pub(crate) eob_run:     i32
+    initialized:         bool,
+    a:                   u32,
+    c:                   u32,
+    ct:                  u8,
+    marker:              Option<Marker>,
+    successive_low_mask: i16,
+    spec_start:          u8,
+    spec_end:            u8,
+    overread_by:         usize,
+    seen_eoi:            bool,
+    eob_run:             i32
 }
 
 impl BitStream for BitStreamArithmetic {
@@ -708,19 +715,30 @@ impl BitStream for BitStreamArithmetic {
     #[inline(always)]
     fn save_state(&self) -> ArithBitstreamState {
         ArithBitstreamState {
-            marker:      self.marker,
-            overread_by: self.overread_by,
-            seen_eoi:    self.seen_eoi,
-            eob_run:     self.eob_run
+            initialized:         self.initialized,
+            a:                   self.a,
+            c:                   self.c,
+            ct:                  self.ct,
+            marker:              self.marker,
+            successive_low_mask: self.successive_low_mask,
+            spec_start:          self.spec_start,
+            spec_end:            self.spec_end,
+            overread_by:         self.overread_by,
+            seen_eoi:            self.seen_eoi,
+            eob_run:             self.eob_run
         }
     }
 
-    /// Arithmetic restore is a no-op for the A/C/CT registers — those are
-    /// only reset via `reset()` at RST/scan boundaries. This restores the
-    /// marker/EOF detection state only.
     #[inline(always)]
     fn restore_state(&mut self, state: ArithBitstreamState) {
+        self.initialized = state.initialized;
+        self.a = state.a;
+        self.c = state.c;
+        self.ct = state.ct;
         self.marker = state.marker;
+        self.successive_low_mask = state.successive_low_mask;
+        self.spec_start = state.spec_start;
+        self.spec_end = state.spec_end;
         self.overread_by = state.overread_by;
         self.seen_eoi = state.seen_eoi;
         self.eob_run = state.eob_run;

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -2137,6 +2137,9 @@ where
     ///
     /// # Examples
     ///
+    /// Decode a JPEG into raw YCbCr planes (libjpeg-turbo style) and access
+    /// individual component data:
+    ///
     /// ```no_run
     /// use zune_core::bytestream::ZCursor;
     /// use zune_jpeg::JpegDecoder;
@@ -2145,15 +2148,30 @@ where
     /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
     /// decoder.decode_headers().unwrap();
     ///
+    /// // Query the plane geometry (DCT-block-padded sizes).
     /// let layout = decoder.planar_layout().unwrap();
     /// let n = decoder.num_components().unwrap();
+    ///
+    /// // Allocate one buffer per component, sized to the full padded plane.
     /// let mut buffers: Vec<Vec<u8>> = (0..n)
     ///     .map(|i| vec![0u8; layout[i].byte_size])
     ///     .collect();
     /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
     ///
     /// decoder.decode_raw(&mut planes).unwrap();
-    /// // planes[0] = Y, planes[1] = Cb, planes[2] = Cr (for YCbCr)
+    ///
+    /// // For a 4:2:0 YCbCr image:
+    /// //   planes[0] = Y  (full resolution, padded to DCT blocks)
+    /// //   planes[1] = Cb (half resolution)
+    /// //   planes[2] = Cr (half resolution)
+    /// //
+    /// // Access a specific pixel's Y value:
+    /// let y_stride = layout[0].stride; // row pitch in bytes
+    /// let y_value = planes[0][/* row */ 10 * y_stride + /* col */ 20];
+    ///
+    /// // Identify component order for non-standard JPEGs:
+    /// let ids = decoder.component_ids().unwrap();
+    /// println!("Component order: {:?}", ids);
     /// ```
     ///
     /// # Errors
@@ -2246,8 +2264,10 @@ where
     ///
     /// # Examples
     ///
-    /// Skia-style: allocate with custom stride (e.g. GPU-aligned), decode
-    /// only the logical image area, leave padding untouched.
+    /// Skia-style: decode into GPU-aligned buffers where each row has a
+    /// power-of-two stride, then upload the planes as textures. Only the
+    /// logical image area is written; padding bytes are left untouched so
+    /// the caller can pre-fill them with a known value (e.g. for debugging).
     ///
     /// ```no_run
     /// use zune_core::bytestream::ZCursor;
@@ -2264,14 +2284,24 @@ where
     /// let strides: Vec<usize> = (0..n)
     ///     .map(|i| (layout[i].width + 63) & !63)
     ///     .collect();
+    ///
+    /// // Allocate buffers sized to logical height × custom stride.
+    /// // Only layout[i].width × layout[i].height pixels are written;
+    /// // the gap between width and stride is never touched.
     /// let mut buffers: Vec<Vec<u8>> = (0..n)
     ///     .map(|i| vec![0u8; strides[i] * layout[i].height])
     ///     .collect();
     /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
     ///
     /// decoder.decode_raw_strided(&mut planes, &strides).unwrap();
-    /// // Each planes[i] now contains the component data with the custom stride.
-    /// // Upload planes[i] to a GPU texture with row pitch = strides[i].
+    ///
+    /// // Upload each plane to a GPU texture:
+    /// for i in 0..n {
+    ///     let width = layout[i].width;
+    ///     let height = layout[i].height;
+    ///     let row_pitch = strides[i];
+    ///     // gpu.upload_texture(planes[i], width, height, row_pitch);
+    /// }
     /// ```
     ///
     /// # Errors

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -499,7 +499,14 @@ pub(crate) struct RawPlanesSink<'planes, 'buf> {
 /// skips upsampling and color conversion and returns one post-IDCT plane per
 /// JPEG component. The configured output colorspace is therefore ignored.
 pub struct RawDecodeSession<'decoder, T> {
-    decoder: &'decoder mut JpegDecoder<T>
+    decoder: &'decoder mut JpegDecoder<T>,
+    previous_incremental_mode: bool,
+}
+
+impl<T> Drop for RawDecodeSession<'_, T> {
+    fn drop(&mut self) {
+        self.decoder.incremental_mode = self.previous_incremental_mode;
+    }
 }
 
 impl<T> RawDecodeSession<'_, T>
@@ -874,6 +881,7 @@ where
         if let Some(state) = self.scan_state.as_deref_mut() {
             state.scan_checkpoint = None;
             state.progressive_checkpoint = None;
+            state.progressive_fine_checkpoint = None;
         }
     }
 
@@ -1190,7 +1198,12 @@ where
     /// pixel output or option changes until the session is dropped.
     pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
         self.clear_scan_checkpoints();
-        RawDecodeSession { decoder: self }
+        let previous_incremental_mode = self.incremental_mode;
+        self.incremental_mode = true;
+        RawDecodeSession {
+            decoder: self,
+            previous_incremental_mode,
+        }
     }
 
     /// Number of components present in the JPEG scan (1..=4).

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -2133,6 +2133,27 @@ where
     /// meaningful; trailing padding columns / rows contain
     /// implementation-defined data.
     ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    ///
+    /// let layout = decoder.planar_layout().unwrap();
+    /// let n = decoder.num_components();
+    /// let mut buffers: Vec<Vec<u8>> = (0..n)
+    ///     .map(|i| vec![0u8; layout[i].byte_size])
+    ///     .collect();
+    /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
+    ///
+    /// decoder.decode_raw(&mut planes).unwrap();
+    /// // planes[0] = Y, planes[1] = Cb, planes[2] = Cr (for YCbCr)
+    /// ```
+    ///
     /// # Errors
     /// - [`DecodeErrors::TooSmallOutput`]: a plane buffer is shorter than
     ///   its `byte_size`.
@@ -2185,7 +2206,7 @@ where
         // Raw mode writes into the plane sink; downstream pixel bookkeeping
         // only needs a placeholder slice.
         let mut sink: [u8; 0] = [];
-        let result = if self.is_arithmetic {
+        if self.is_arithmetic {
             #[cfg(feature = "arith")]
             {
                 if self.is_progressive {
@@ -2200,10 +2221,8 @@ where
             self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
         } else {
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
-        };
-
+        }
         // Guard clears `raw_planes_sink` on drop.
-        result
     }
 
     /// Decode raw planes using caller-supplied row strides.
@@ -2216,6 +2235,36 @@ where
     ///
     /// Only the logical plane area is written. Padding columns in the caller's
     /// stride and trailing DCT rows are left untouched.
+    ///
+    /// # Examples
+    ///
+    /// Skia-style: allocate with custom stride (e.g. GPU-aligned), decode
+    /// only the logical image area, leave padding untouched.
+    ///
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    ///
+    /// let layout = decoder.planar_layout().unwrap();
+    /// let n = decoder.num_components();
+    ///
+    /// // Use a 64-byte aligned stride (common for GPU upload).
+    /// let strides: Vec<usize> = (0..n)
+    ///     .map(|i| (layout[i].width + 63) & !63)
+    ///     .collect();
+    /// let mut buffers: Vec<Vec<u8>> = (0..n)
+    ///     .map(|i| vec![0u8; strides[i] * layout[i].height])
+    ///     .collect();
+    /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
+    ///
+    /// decoder.decode_raw_strided(&mut planes, &strides).unwrap();
+    /// // Each planes[i] now contains the component data with the custom stride.
+    /// // Upload planes[i] to a GPU texture with row pitch = strides[i].
+    /// ```
     ///
     /// # Errors
     /// - [`DecodeErrors::Format`] if `planes.len()` or `strides.len()`
@@ -2284,7 +2333,7 @@ where
         };
 
         let mut sink: [u8; 0] = [];
-        let result = if self.is_arithmetic {
+        if self.is_arithmetic {
             #[cfg(feature = "arith")]
             {
                 if self.is_progressive {
@@ -2299,9 +2348,7 @@ where
             self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
         } else {
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
-        };
-
-        result
+        }
     }
 
     /// Per-component [`ComponentID`] in declaration order
@@ -2383,7 +2430,11 @@ where
                     let dst_offset = (row_start + r) * target_stride;
                     let dst = plane_ptr.add(dst_offset);
                     for (i, sample) in src.iter().enumerate() {
-                        *dst.add(i) = *sample as u8;
+                        // Post-IDCT samples are already clamped to [0, 255].
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        {
+                            *dst.add(i) = *sample as u8;
+                        }
                     }
                 }
             }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -403,6 +403,8 @@ pub struct JpegDecoder<T> {
     /// capacity. Safe first-DC scans also keep its contents so a later retry can
     /// resume from a fine checkpoint without committing partial scan data.
     pub(crate) progressive_scan_buffer: [Vec<i16>; MAX_COMPONENTS],
+    /// Reusable baseline upsampling scratch retained across pull calls.
+    pub(crate) upsampler_scratch: Vec<i16>,
     /// Number of progressive scans committed into `progressive_mcus_buffer`.
     pub(crate) progressive_completed_scans: usize,
     /// Number of committed progressive scans currently rendered as preview
@@ -1461,6 +1463,7 @@ where
             scan_decode_attempted:       false,
             progressive_mcus_buffer:     core::array::from_fn(|_| Vec::new()),
             progressive_scan_buffer: core::array::from_fn(|_| Vec::new()),
+            upsampler_scratch: Vec::new(),
             progressive_completed_scans: 0,
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -29,7 +29,7 @@ use crate::bitstream::{BitstreamStateSnapshot, BitStreamHuffman};
 #[cfg(feature = "arith")]
 use crate::bitstream_arith::{ArithACTables, ArithDCTables, BitStreamArithmetic};
 use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
-use crate::components::{ComponentID, Components, SampleRatios};
+use crate::components::{Components, SampleRatios};
 use crate::errors::{DecodeErrors, UnsupportedSchemes};
 #[cfg(feature = "arith")]
 use crate::headers::parse_dac;
@@ -63,23 +63,29 @@ pub(crate) const MAX_DIMENSIONS: usize = 1 << 27;
 /// (`DCTSIZE = 8`). The logical `width`/`height` describe the meaningful
 /// sample area inside that buffer; trailing padding columns and rows
 /// contain implementation-defined data and should be ignored by the
-/// caller.
+/// caller. The sampling-factor fields preserve the exact SOF values so
+/// callers do not need to infer subsampling from rounded plane dimensions.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct PlaneInfo {
+    /// Horizontal sampling factor from the component's SOF entry.
+    pub horizontal_sampling_factor: usize,
+    /// Vertical sampling factor from the component's SOF entry.
+    pub vertical_sampling_factor:   usize,
     /// Logical component width in samples.
     /// `ceil(image_width * h_samp / h_max)`.
-    pub width:            usize,
+    pub width:                      usize,
     /// Logical component height in samples.
     /// `ceil(image_height * v_samp / v_max)`.
-    pub height:           usize,
+    pub height:                     usize,
     /// Allocated plane width (row stride) in bytes.
     /// `ceil(width / 8) * 8`.
-    pub stride:           usize,
+    pub stride:                     usize,
     /// Allocated plane height in rows.
     /// `ceil(height / 8) * 8`.
-    pub allocated_height: usize,
+    pub allocated_height:           usize,
     /// Required slice length for this plane: `stride * allocated_height`.
-    pub byte_size:        usize
+    pub byte_size:                  usize
 }
 
 /// Round `n` up to the next multiple of `align` (which must be non-zero).
@@ -480,6 +486,161 @@ pub(crate) struct RawPlanesSink<'planes, 'buf> {
     pub(crate) target_heights: [usize; MAX_COMPONENTS],
     /// Number of valid components.
     pub(crate) n_components:   usize
+}
+
+/// Exclusive borrowing session for whole-image raw component output.
+///
+/// Create a session with [`JpegDecoder::raw_output`] after decoding headers.
+/// While the session exists, its exclusive borrow prevents switching to pixel
+/// output or changing decoder options during a raw retry sequence. Entropy,
+/// MCU, checkpoint, and replay state remain owned by the borrowed decoder.
+///
+/// Unlike [`JpegDecoder::decode`] and [`JpegDecoder::decode_into`], raw output
+/// skips upsampling and color conversion and returns one post-IDCT plane per
+/// JPEG component. The configured output colorspace is therefore ignored.
+pub struct RawDecodeSession<'decoder, T> {
+    decoder: &'decoder mut JpegDecoder<T>
+}
+
+impl<T> RawDecodeSession<'_, T>
+where
+    T: ZByteReaderTrait
+{
+    /// Number of components in SOF declaration order.
+    ///
+    /// Returns `None` when headers have not been decoded yet.
+    #[must_use]
+    pub fn num_components(&self) -> Option<usize> {
+        self.decoder.raw_num_components()
+    }
+
+    /// Component selector bytes from the SOF marker, in declaration order.
+    ///
+    /// Common YCbCr files usually use `[1, 2, 3]`, while RGB files may use
+    /// `[b'R', b'G', b'B']`. Selectors are returned exactly as encoded so
+    /// callers can identify nonstandard component layouts.
+    ///
+    /// Returns `None` when headers have not been decoded yet or contain no
+    /// components.
+    #[must_use]
+    pub fn component_ids(&self) -> Option<Vec<u8>> {
+        self.decoder.raw_component_ids()
+    }
+
+    /// Per-component raw plane geometry and sampling metadata.
+    ///
+    /// Indices `0..num_components()` are populated in SOF declaration order;
+    /// trailing entries are [`PlaneInfo::default`]. The sampling-factor fields
+    /// preserve the exact SOF values, so callers can identify subsampling
+    /// without inferring it from rounded dimensions.
+    ///
+    /// ```text
+    /// width            = ceil(image_width  * h_samp / h_max)
+    /// height           = ceil(image_height * v_samp / v_max)
+    /// stride           = ceil(width  / 8) * 8
+    /// allocated_height = ceil(height / 8) * 8
+    /// byte_size        = stride * allocated_height
+    /// ```
+    ///
+    /// Returns `None` when headers have not been decoded or layout arithmetic
+    /// overflows `usize`.
+    #[must_use]
+    pub fn layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
+        self.decoder.raw_planar_layout()
+    }
+
+    /// Decode the complete image into DCT-block-padded component planes.
+    ///
+    /// Plane contents and geometry are compatible with libjpeg-turbo raw
+    /// output. This whole-image convenience method is not operationally
+    /// equivalent to one call to `jpeg_read_raw_data`, which returns one iMCU
+    /// row at a time.
+    ///
+    /// Supply one mutable plane per component in SOF declaration order. Each
+    /// plane must contain at least the corresponding [`PlaneInfo::byte_size`]
+    /// bytes from [`Self::layout`]. The configured output colorspace is
+    /// ignored. Samples within each plane's logical `width * height` area are
+    /// meaningful; trailing DCT padding is implementation-defined.
+    ///
+    /// On a recoverable EOF, call this method again on the same session after
+    /// exposing more input. Successful calls can also be replayed and produce
+    /// bit-identical planes.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    /// let mut raw = decoder.raw_output();
+    /// let layout = raw.layout().unwrap();
+    /// let count = raw.num_components().unwrap();
+    /// let mut buffers: Vec<Vec<u8>> = (0..count)
+    ///     .map(|index| vec![0; layout[index].byte_size])
+    ///     .collect();
+    /// let mut planes: Vec<&mut [u8]> =
+    ///     buffers.iter_mut().map(Vec::as_mut_slice).collect();
+    /// raw.decode_into(&mut planes).unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`DecodeErrors::TooSmallOutput`] for an undersized plane,
+    /// [`DecodeErrors::Format`] for the wrong plane count, or an error from
+    /// the underlying decode pipeline.
+    pub fn decode_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
+        self.decoder.decode_raw_into(planes)
+    }
+
+    /// Decode the complete image into component planes with caller row strides.
+    ///
+    /// Logical plane contents and geometry are compatible with libjpeg-turbo
+    /// raw output. This whole-image convenience method is not operationally
+    /// equivalent to one call to `jpeg_read_raw_data`, which returns one iMCU
+    /// row at a time. Only each plane's logical `width * height` area is
+    /// written; stride padding is left untouched.
+    ///
+    /// Supply one mutable plane and stride per component in SOF declaration
+    /// order. Each stride must be at least the corresponding logical
+    /// [`PlaneInfo::width`], and each plane must contain at least
+    /// `stride * PlaneInfo::height` bytes.
+    ///
+    /// On a recoverable EOF, call this method again on the same session after
+    /// exposing more input. Successful calls can also be replayed and produce
+    /// bit-identical logical samples.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    /// let mut raw = decoder.raw_output();
+    /// let layout = raw.layout().unwrap();
+    /// let count = raw.num_components().unwrap();
+    /// let strides: Vec<usize> = (0..count)
+    ///     .map(|index| layout[index].width.div_ceil(64) * 64)
+    ///     .collect();
+    /// let mut buffers: Vec<Vec<u8>> = (0..count)
+    ///     .map(|index| vec![0; strides[index] * layout[index].height])
+    ///     .collect();
+    /// let mut planes: Vec<&mut [u8]> =
+    ///     buffers.iter_mut().map(Vec::as_mut_slice).collect();
+    /// raw.decode_into_strided(&mut planes, &strides).unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`DecodeErrors::TooSmallOutput`] for an undersized plane,
+    /// [`DecodeErrors::Format`] for invalid plane counts or strides, or an
+    /// error from the underlying decode pipeline.
+    pub fn decode_into_strided(
+        &mut self, planes: &mut [&mut [u8]], strides: &[usize]
+    ) -> Result<(), DecodeErrors> {
+        self.decoder.decode_raw_into_strided(planes, strides)
+    }
 }
 
 impl<T> JpegDecoder<T>
@@ -1014,6 +1175,16 @@ where
         Some((decoded_output_bytes / row_stride).min(usize::from(self.height())))
     }
 
+    /// Begin an exclusive raw component-output session.
+    ///
+    /// Decode headers first when the caller needs to query
+    /// [`RawDecodeSession::layout`] or component metadata before allocating
+    /// output planes. The session borrows this decoder mutably, preventing
+    /// pixel output or option changes until the session is dropped.
+    pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
+        RawDecodeSession { decoder: self }
+    }
+
     /// Number of components present in the JPEG scan (1..=4).
     ///
     /// Valid only after [`decode_headers`](Self::decode_headers).
@@ -1022,7 +1193,7 @@ where
     /// - `Some(n)`: number of components in the input scan
     /// - `None`: headers have not been decoded yet
     #[must_use]
-    pub fn num_components(&self) -> Option<usize> {
+    fn raw_num_components(&self) -> Option<usize> {
         if self.headers_decoded {
             Some(self.components.len())
         } else {
@@ -1036,6 +1207,9 @@ where
     /// (Y, Cb, Cr for YCbCr; Y for grayscale; C, M, Y, K for CMYK; etc.).
     /// Indices `0..num_components()` are populated; trailing entries are
     /// the default zero-sized [`PlaneInfo`].
+    /// [`PlaneInfo::horizontal_sampling_factor`] and
+    /// [`PlaneInfo::vertical_sampling_factor`] expose each component's exact
+    /// SOF sampling factors.
     ///
     /// Plane dimensions are computed using the same rules as libjpeg-turbo's
     /// `jpeg_read_raw_data`:
@@ -1054,7 +1228,7 @@ where
     /// - `Some([PlaneInfo; MAX_COMPONENTS])`: per-component layout
     /// - `None`: headers have not been decoded yet, or layout overflows `usize`
     #[must_use]
-    pub fn planar_layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
+    fn raw_planar_layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
         if !self.headers_decoded || self.components.is_empty() {
             return None;
         }
@@ -1082,6 +1256,8 @@ where
             let allocated_height = round_up_pow2(comp_h, DCT_BLOCK_SIZE)?;
             let byte_size = stride.checked_mul(allocated_height)?;
             *slot = PlaneInfo {
+                horizontal_sampling_factor: comp.horizontal_sample,
+                vertical_sampling_factor: comp.vertical_sample,
                 width: comp_w,
                 height: comp_h,
                 stride,
@@ -2133,100 +2309,19 @@ where
         }
     }
 
-    /// Decode the image into per-component raw planes, skipping upsampling
-    /// and color conversion.
-    ///
-    /// Mirrors libjpeg-turbo's `jpeg_read_raw_data`: each component's
-    /// post-IDCT samples are written directly into its own plane buffer.
-    /// A 4:2:0 YCbCr image yields a full-resolution Y plane and
-    /// half-resolution Cb / Cr planes, each rounded up to DCT-block
-    /// boundaries.
-    ///
-    /// Plane order matches `self.components[i]` declaration order, i.e.
-    /// the order from the SOF marker (`[Y, Cb, Cr]` for YCbCr,
-    /// `[Y]` for grayscale, `[C, M, Y, K]` for CMYK, etc.). The configured
-    /// output colorspace is **ignored** in raw mode.
-    ///
-    /// Each `planes[i]` must be at least
-    /// [`PlaneInfo::byte_size`](`PlaneInfo::byte_size`) bytes
-    /// (`stride * allocated_height`), i.e. dimensions rounded up to
-    /// 8-sample DCT-block boundaries. For a 388×477 4:2:0 image:
-    /// `392 * 480 = 188_160` for Y and `200 * 240 = 48_000` for Cb / Cr.
-    /// See [`decode_raw_strided`](Self::decode_raw_strided) for accepting
-    /// logically-sized buffers.
-    ///
-    /// Samples within `[0, width) × [0, height)` of each plane are
-    /// meaningful; trailing padding columns / rows contain
-    /// implementation-defined data.
-    ///
-    /// # Resumability
-    ///
-    /// On a recoverable EOF (`DecodeErrors::is_recoverable_eof()`) the
-    /// decoder keeps enough state to resume; the caller can grow the input
-    /// stream and call `decode_raw` again with plane buffers sized from the
-    /// same [`planar_layout`](Self::planar_layout).
-    ///
-    /// On success the decoder keeps scan-start replay state, so a later
-    /// `decode_raw` call is well-defined and produces bit-identical planes.
-    /// Replay re-runs entropy decoding from the first SOS.
-    ///
-    /// # Examples
-    ///
-    /// Decode a JPEG into raw YCbCr planes (libjpeg-turbo style) and access
-    /// individual component data:
-    ///
-    /// ```no_run
-    /// use zune_core::bytestream::ZCursor;
-    /// use zune_jpeg::JpegDecoder;
-    ///
-    /// let data = std::fs::read("photo.jpg").unwrap();
-    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
-    /// decoder.decode_headers().unwrap();
-    ///
-    /// // Query the plane geometry (DCT-block-padded sizes).
-    /// let layout = decoder.planar_layout().unwrap();
-    /// let n = decoder.num_components().unwrap();
-    ///
-    /// // Allocate one buffer per component, sized to the full padded plane.
-    /// let mut buffers: Vec<Vec<u8>> = (0..n)
-    ///     .map(|i| vec![0u8; layout[i].byte_size])
-    ///     .collect();
-    /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
-    ///
-    /// decoder.decode_raw(&mut planes).unwrap();
-    ///
-    /// // For a 4:2:0 YCbCr image:
-    /// //   planes[0] = Y  (full resolution, padded to DCT blocks)
-    /// //   planes[1] = Cb (half resolution)
-    /// //   planes[2] = Cr (half resolution)
-    /// //
-    /// // Access a specific pixel's Y value:
-    /// let y_stride = layout[0].stride; // row pitch in bytes
-    /// let y_value = planes[0][/* row */ 10 * y_stride + /* col */ 20];
-    ///
-    /// // Identify component order for non-standard JPEGs:
-    /// let ids = decoder.component_ids().unwrap();
-    /// println!("Component order: {:?}", ids);
-    /// ```
-    ///
-    /// # Errors
-    /// - [`DecodeErrors::TooSmallOutput`]: a plane buffer is shorter than
-    ///   its `byte_size`.
-    /// - [`DecodeErrors::Format`]: `planes.len()` does not match the number
-    ///   of components.
-    /// - Any error from the underlying decode pipeline.
-    pub fn decode_raw(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
+    // Shared implementation for `RawDecodeSession::decode_into`.
+    fn decode_raw_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
         self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
         if planes.len() != n {
             return Err(DecodeErrors::Format(format!(
-                "decode_raw expected {n} plane buffer(s), got {}",
+                "RawDecodeSession::decode_into expected {n} plane buffer(s), got {}",
                 planes.len()
             )));
         }
-        let layout = self.planar_layout().ok_or(DecodeErrors::FormatStatic(
-            "planar_layout unavailable after decode_headers"
+        let layout = self.raw_planar_layout().ok_or(DecodeErrors::FormatStatic(
+            "raw layout unavailable after decode_headers"
         ))?;
         for (i, plane) in planes.iter().enumerate() {
             let need = layout[i].byte_size;
@@ -2257,78 +2352,8 @@ where
         self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
-    /// Decode raw planes using caller-supplied row strides.
-    ///
-    /// For each component `i` the caller must supply:
-    /// - `planes[i]`: a mutable byte slice of length at least
-    ///   `strides[i] * planar_layout()[i].height` bytes.
-    /// - `strides[i]`: the destination row stride in bytes. Must satisfy
-    ///   `strides[i] >= planar_layout()[i].width`.
-    ///
-    /// Only the logical plane area is written. Padding columns in the caller's
-    /// stride and trailing DCT rows are left untouched.
-    ///
-    /// # Resumability
-    ///
-    /// On a recoverable EOF (`DecodeErrors::is_recoverable_eof()`) the
-    /// decoder keeps enough state to resume; the caller can grow the input
-    /// stream and call `decode_raw_strided` again with the same plane layout.
-    ///
-    /// On success the decoder keeps scan-start replay state, so a later
-    /// `decode_raw_strided` call is well-defined and produces bit-identical
-    /// logical plane samples. Replay re-runs entropy decoding from the first
-    /// SOS.
-    ///
-    /// # Examples
-    ///
-    /// Skia-style: decode into GPU-aligned buffers where each row has a
-    /// power-of-two stride, then upload the planes as textures. Only the
-    /// logical image area is written; padding bytes are left untouched so
-    /// the caller can pre-fill them with a known value (e.g. for debugging).
-    ///
-    /// ```no_run
-    /// use zune_core::bytestream::ZCursor;
-    /// use zune_jpeg::JpegDecoder;
-    ///
-    /// let data = std::fs::read("photo.jpg").unwrap();
-    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
-    /// decoder.decode_headers().unwrap();
-    ///
-    /// let layout = decoder.planar_layout().unwrap();
-    /// let n = decoder.num_components().unwrap();
-    ///
-    /// // Use a 64-byte aligned stride (common for GPU upload).
-    /// let strides: Vec<usize> = (0..n)
-    ///     .map(|i| (layout[i].width + 63) & !63)
-    ///     .collect();
-    ///
-    /// // Allocate buffers sized to logical height × custom stride.
-    /// // Only layout[i].width × layout[i].height pixels are written;
-    /// // the gap between width and stride is never touched.
-    /// let mut buffers: Vec<Vec<u8>> = (0..n)
-    ///     .map(|i| vec![0u8; strides[i] * layout[i].height])
-    ///     .collect();
-    /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
-    ///
-    /// decoder.decode_raw_strided(&mut planes, &strides).unwrap();
-    ///
-    /// // Upload each plane to a GPU texture:
-    /// for i in 0..n {
-    ///     let width = layout[i].width;
-    ///     let height = layout[i].height;
-    ///     let row_pitch = strides[i];
-    ///     // gpu.upload_texture(planes[i], width, height, row_pitch);
-    /// }
-    /// ```
-    ///
-    /// # Errors
-    /// - [`DecodeErrors::Format`] if `planes.len()` or `strides.len()`
-    ///   doesn't match the number of components, or if any
-    ///   `strides[i] < width[i]`.
-    /// - [`DecodeErrors::TooSmallOutput`] if any plane buffer is shorter
-    ///   than `strides[i] * height[i]`.
-    /// - Any error from the underlying decode pipeline.
-    pub fn decode_raw_strided(
+    // Shared implementation for `RawDecodeSession::decode_into_strided`.
+    fn decode_raw_into_strided(
         &mut self, planes: &mut [&mut [u8]], strides: &[usize]
     ) -> Result<(), DecodeErrors> {
         self.prepare_for_scan_decode()?;
@@ -2336,18 +2361,18 @@ where
         let n = self.components.len();
         if planes.len() != n {
             return Err(DecodeErrors::Format(format!(
-                "decode_raw_strided expected {n} plane buffer(s), got {}",
+                "RawDecodeSession::decode_into_strided expected {n} plane buffer(s), got {}",
                 planes.len()
             )));
         }
         if strides.len() != n {
             return Err(DecodeErrors::Format(format!(
-                "decode_raw_strided expected {n} stride(s), got {}",
+                "RawDecodeSession::decode_into_strided expected {n} stride(s), got {}",
                 strides.len()
             )));
         }
-        let layout = self.planar_layout().ok_or(DecodeErrors::FormatStatic(
-            "planar_layout unavailable after decode_headers"
+        let layout = self.raw_planar_layout().ok_or(DecodeErrors::FormatStatic(
+            "raw layout unavailable after decode_headers"
         ))?;
         for (i, plane) in planes.iter().enumerate() {
             if strides[i] < layout[i].width {
@@ -2386,22 +2411,11 @@ where
         self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
-    /// Per-component [`ComponentID`] in declaration order
-    /// (`Y, Cb, Cr` for YCbCr; `Y` for grayscale; `Y, Cb, Cr, Q` for
-    /// 4-component scans, etc.).
-    ///
-    /// Useful when consuming the planes returned by
-    /// [`decode_raw`](Self::decode_raw) /
-    /// [`decode_raw_strided`](Self::decode_raw_strided) on non-conforming
-    /// JPEGs whose component order differs from the canonical layout.
-    ///
-    /// Valid only after [`decode_headers`](Self::decode_headers).
-    #[must_use]
-    pub fn component_ids(&self) -> Option<Vec<ComponentID>> {
+    fn raw_component_ids(&self) -> Option<Vec<u8>> {
         if !self.headers_decoded || self.components.is_empty() {
             return None;
         }
-        Some(self.components.iter().map(|c| c.component_id).collect())
+        Some(self.components.iter().map(|component| component.id).collect())
     }
 
     /// Copy one MCU stripe (`mcu_stripe_index`) of post-IDCT samples from

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -447,7 +447,9 @@ pub struct JpegDecoder<T> {
     /// scan's entropy data. The MCU decode loop will intercept that marker
     /// and store the real height; if it never arrives, decoding returns an
     /// error.
-    pub(crate) expects_dnl: bool
+    pub(crate) expects_dnl: bool,
+    /// Sequential raw iMCU-row progress shared across borrowing sessions.
+    raw_pull_state: RawPullState
 }
 
 /// Output target for one MCU decode call.
@@ -470,22 +472,105 @@ impl McuDecodeOutput<'_, '_> {
             Self::RawPlanes(_) => None
         }
     }
+
+    pub(crate) const fn requested_raw_stripe(&self) -> Option<usize> {
+        match self {
+            Self::RawPlanes(sink) => sink.requested_stripe,
+            Self::Pixels(_) => None
+        }
+    }
+
+    pub(crate) fn mark_raw_source_complete(&mut self) {
+        if let Self::RawPlanes(sink) = self {
+            sink.source_complete = true;
+        }
+    }
 }
 
 /// Caller-provided raw planar buffers for one decode call.
 pub(crate) struct RawPlanesSink<'planes, 'buf> {
     /// Caller plane buffers, one per component.
-    pub(crate) planes:         &'planes mut [&'buf mut [u8]],
+    pub(crate) planes:           &'planes mut [&'buf mut [u8]],
     /// Total byte length of each caller buffer.
-    pub(crate) lengths:        [usize; MAX_COMPONENTS],
+    pub(crate) lengths:          [usize; MAX_COMPONENTS],
     /// Bytes between successive destination rows (used for strided output).
-    pub(crate) target_strides: [usize; MAX_COMPONENTS],
+    pub(crate) target_strides:   [usize; MAX_COMPONENTS],
     /// Maximum bytes to write per destination row.
-    pub(crate) target_widths:  [usize; MAX_COMPONENTS],
+    pub(crate) target_widths:    [usize; MAX_COMPONENTS],
     /// Number of destination rows per plane.
-    pub(crate) target_heights: [usize; MAX_COMPONENTS],
+    pub(crate) target_heights:   [usize; MAX_COMPONENTS],
     /// Number of valid components.
-    pub(crate) n_components:   usize
+    pub(crate) n_components:     usize,
+    /// Pull mode requests exactly this sequential iMCU row.
+    pub(crate) requested_stripe: Option<usize>,
+    /// Logical rows copied for each component in pull mode.
+    pub(crate) rows_written:     [usize; MAX_COMPONENTS],
+    /// Whether a complete requested stripe was copied.
+    pub(crate) stripe_ready:     bool,
+    /// Whether entropy/coefficient production has completed.
+    pub(crate) source_complete:  bool
+}
+
+/// Result of requesting the next sequential raw iMCU row.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RawImcuRowStatus {
+    /// One complete iMCU row was written to the caller's planes.
+    RowReady {
+        /// Logical rows written for each component in SOF declaration order.
+        /// Entries after [`RawDecodeSession::num_components`] are zero.
+        rows_written: [usize; MAX_COMPONENTS]
+    },
+    /// The next iMCU row could not be completed with the currently visible input.
+    NeedMoreInput,
+    /// All raw component rows have been emitted.
+    Complete
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RawPullPhase {
+    Start,
+    StreamingBaseline,
+    BufferedRows,
+    Complete
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RawPullOwner {
+    None,
+    Pull,
+    WholeImage
+}
+
+struct RawPullState {
+    owner:                    RawPullOwner,
+    phase:                    RawPullPhase,
+    next_stripe:              usize,
+    entropy_tables:           Option<EntropyTables>,
+    layout:                   Option<[PlaneInfo; MAX_COMPONENTS]>,
+    rows_per_stripe:          [usize; MAX_COMPONENTS],
+    buffered_source_complete: bool
+}
+
+struct RawPullTargets {
+    lengths:        [usize; MAX_COMPONENTS],
+    strides:        [usize; MAX_COMPONENTS],
+    widths:         [usize; MAX_COMPONENTS],
+    heights:        [usize; MAX_COMPONENTS]
+}
+
+impl Default for RawPullState {
+    fn default() -> Self {
+        Self {
+            owner:                    RawPullOwner::None,
+            phase:                    RawPullPhase::Start,
+            next_stripe:              0,
+            entropy_tables:           None,
+            layout:                   None,
+            rows_per_stripe:          [0; MAX_COMPONENTS],
+            buffered_source_complete: false
+        }
+    }
 }
 
 /// Exclusive borrowing session for whole-image raw component output.
@@ -553,7 +638,301 @@ where
     /// overflows `usize`.
     #[must_use]
     pub fn layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
-        self.decoder.raw_planar_layout()
+        self.decoder
+            .raw_pull_state
+            .layout
+            .or_else(|| self.decoder.raw_planar_layout())
+    }
+
+    /// Decode the next sequential raw iMCU row into caller-provided planes.
+    ///
+    /// Each stride must be at least the corresponding logical plane width.
+    /// Each plane must be large enough for
+    /// `stride * vertical_sampling_factor * 8` bytes. The returned
+    /// `rows_written` count identifies the meaningful prefix; the final iMCU
+    /// row is clipped to the logical component height. Components that exhaust
+    /// their logical height before other components report zero rows on later
+    /// calls.
+    ///
+    /// A recoverable input suspension returns [`RawImcuRowStatus::NeedMoreInput`]
+    /// and leaves caller planes untouched. Expose more input through the same
+    /// decoder stream, then retry with the same session and plane layout. The
+    /// caller cannot select a stripe index.
+    ///
+    /// Images whose SOF height is zero and whose line count is supplied later
+    /// by a DNL marker are currently rejected because the caller-visible plane
+    /// geometry is not known when the pull sequence begins.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    /// let mut raw = decoder.raw_output();
+    /// let layout = raw.layout().unwrap();
+    /// let count = raw.num_components().unwrap();
+    /// let strides: Vec<usize> = layout[..count]
+    ///     .iter()
+    ///     .map(|plane| plane.width)
+    ///     .collect();
+    ///
+    /// loop {
+    ///     let mut storage: Vec<Vec<u8>> = layout[..count]
+    ///         .iter()
+    ///         .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+    ///         .collect();
+    ///     let mut planes: Vec<&mut [u8]> =
+    ///         storage.iter_mut().map(Vec::as_mut_slice).collect();
+    ///     match raw.decode_next_imcu_row(&mut planes, &strides).unwrap() {
+    ///         RawImcuRowStatus::RowReady { rows_written } => {
+    ///             // Consume `rows_written[index]` rows from each plane.
+    ///             let _ = rows_written;
+    ///         }
+    ///         RawImcuRowStatus::NeedMoreInput => break,
+    ///         RawImcuRowStatus::Complete => break,
+    ///         _ => unreachable!()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`DecodeErrors::Format`] for invalid plane counts or strides,
+    /// [`DecodeErrors::TooSmallOutput`] for an undersized plane, or a
+    /// non-recoverable decode error.
+    pub fn decode_next_imcu_row(
+        &mut self, planes: &mut [&mut [u8]], strides: &[usize]
+    ) -> Result<RawImcuRowStatus, DecodeErrors> {
+        self.decode_next_imcu_row_for(RawPullOwner::Pull, planes, strides)
+    }
+
+    fn decode_next_imcu_row_for(
+        &mut self, owner: RawPullOwner, planes: &mut [&mut [u8]], strides: &[usize]
+    ) -> Result<RawImcuRowStatus, DecodeErrors> {
+        if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
+            return Ok(RawImcuRowStatus::Complete);
+        }
+
+        let layout = self.pull_layout()?;
+        let n = self.decoder.components.len();
+        if self.decoder.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
+        if planes.len() != n || strides.len() != n {
+            return Err(DecodeErrors::Format(format!(
+                "raw iMCU-row output expected {n} plane(s) and stride(s), got {} plane(s) and {} stride(s)",
+                planes.len(),
+                strides.len()
+            )));
+        }
+
+        let total_stripes = self.decoder.raw_imcu_row_count(&layout, n);
+        if self.decoder.raw_pull_state.next_stripe >= total_stripes {
+            self.decoder.finish_raw_pull_source();
+            self.decoder.raw_pull_state.phase = RawPullPhase::Complete;
+            return Ok(RawImcuRowStatus::Complete);
+        }
+
+        let targets = self.pull_targets(planes, strides, &layout, n)?;
+        match self.decoder.raw_pull_state.owner {
+            RawPullOwner::None => self.decoder.raw_pull_state.owner = owner,
+            active if active == owner => {}
+            _ => {
+                return Err(DecodeErrors::FormatStatic(
+                    "cannot switch raw output API during an active decode sequence"
+                ))
+            }
+        }
+        let requested_stripe = self.decoder.raw_pull_state.next_stripe;
+        let raw_planes = RawPlanesSink {
+            planes,
+            lengths: targets.lengths,
+            target_strides: targets.strides,
+            target_widths: targets.widths,
+            target_heights: targets.heights,
+            n_components: n,
+            requested_stripe: Some(requested_stripe),
+            rows_written: [0; MAX_COMPONENTS],
+            stripe_ready: false,
+            source_complete: false
+        };
+        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
+
+        if let Err(error) = self.decode_pull_phase(&mut output, &layout, n) {
+            if error.is_recoverable_eof() {
+                return Ok(RawImcuRowStatus::NeedMoreInput);
+            }
+            return Err(error);
+        }
+
+        let sink = match output {
+            McuDecodeOutput::RawPlanes(sink) => sink,
+            McuDecodeOutput::Pixels(_) => unreachable!()
+        };
+        if sink.source_complete {
+            self.decoder.raw_pull_state.buffered_source_complete = true;
+            self.decoder.finish_raw_pull_source();
+        }
+        if !sink.stripe_ready {
+            self.decoder.raw_pull_state.phase = RawPullPhase::Complete;
+            return Ok(RawImcuRowStatus::Complete);
+        }
+
+        self.decoder.raw_pull_state.next_stripe += 1;
+        for (index, rows) in sink.rows_written.iter().copied().enumerate().take(n) {
+            if rows != 0 && self.decoder.raw_pull_state.rows_per_stripe[index] == 0 {
+                self.decoder.raw_pull_state.rows_per_stripe[index] = rows;
+            }
+        }
+        if self.decoder.raw_pull_state.phase == RawPullPhase::StreamingBaseline
+            && self.decoder.is_arithmetic
+        {
+            self.decoder.raw_pull_state.entropy_tables = Some(self.decoder.entropy_tables.clone());
+        }
+        Ok(RawImcuRowStatus::RowReady {
+            rows_written: sink.rows_written
+        })
+    }
+
+    fn pull_layout(&mut self) -> Result<[PlaneInfo; MAX_COMPONENTS], DecodeErrors> {
+        if let Some(layout) = self.decoder.raw_pull_state.layout {
+            return Ok(layout);
+        }
+        let layout = self.decoder.raw_planar_layout().ok_or(
+            DecodeErrors::FormatStatic("raw layout unavailable before headers are decoded")
+        )?;
+        self.decoder.raw_pull_state.layout = Some(layout);
+        Ok(layout)
+    }
+
+    fn pull_targets(
+        &self, planes: &[&mut [u8]], strides: &[usize],
+        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+    ) -> Result<RawPullTargets, DecodeErrors> {
+        let mut targets = RawPullTargets {
+            lengths: [0; MAX_COMPONENTS],
+            strides: [0; MAX_COMPONENTS],
+            widths: [0; MAX_COMPONENTS],
+            heights: [0; MAX_COMPONENTS]
+        };
+        for i in 0..n {
+            if strides[i] < layout[i].width {
+                return Err(DecodeErrors::Format(format!(
+                    "stride[{i}] = {} is smaller than logical width {}",
+                    strides[i], layout[i].width
+                )));
+            }
+            let configured_rows = self.decoder.raw_pull_state.rows_per_stripe[i];
+            let stripe_rows = if configured_rows == 0 {
+                layout[i].vertical_sampling_factor * DCT_BLOCK_SIZE
+            } else {
+                configured_rows
+            };
+            let row_start = self.decoder.raw_pull_state.next_stripe * stripe_rows;
+            let rows = layout[i].height.saturating_sub(row_start).min(stripe_rows);
+            let need = strides[i]
+                .checked_mul(rows)
+                .ok_or(DecodeErrors::FormatStatic(
+                    "raw iMCU-row plane size overflow"
+                ))?;
+            if planes[i].len() < need {
+                return Err(DecodeErrors::TooSmallOutput(need, planes[i].len()));
+            }
+            targets.lengths[i] = planes[i].len();
+            targets.strides[i] = strides[i];
+            targets.widths[i] = layout[i].width;
+            targets.heights[i] = rows;
+        }
+        Ok(targets)
+    }
+
+    fn decode_pull_phase(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>,
+        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+    ) -> Result<(), DecodeErrors> {
+        match self.decoder.raw_pull_state.phase {
+            RawPullPhase::Start => self.start_pull(output, layout, n),
+            RawPullPhase::StreamingBaseline => {
+                self.prepare_pull_scan()?;
+                #[cfg(feature = "arith")]
+                self.restore_arithmetic_pull_context()?;
+                self.decoder.decode_mcu_output(output)
+            }
+            RawPullPhase::BufferedRows => {
+                if self.decoder.raw_pull_state.buffered_source_complete {
+                    self.decoder.render_buffered_raw_stripe(output)
+                } else {
+                    self.prepare_pull_scan()?;
+                    self.decode_buffered_source_and_render(output, layout, n)
+                }
+            }
+            RawPullPhase::Complete => unreachable!()
+        }
+    }
+
+    fn start_pull(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>,
+        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+    ) -> Result<(), DecodeErrors> {
+        self.prepare_pull_scan()?;
+        let buffered = self.decoder.is_progressive
+            || usize::from(self.decoder.num_scans) != self.decoder.components.len();
+        self.decoder.raw_pull_state.phase = if buffered {
+            RawPullPhase::BufferedRows
+        } else {
+            RawPullPhase::StreamingBaseline
+        };
+        if buffered {
+            self.decode_buffered_source_and_render(output, layout, n)
+        } else {
+            self.decoder.decode_mcu_output(output)
+        }
+    }
+
+    fn prepare_pull_scan(&mut self) -> Result<(), DecodeErrors> {
+        self.decoder.prepare_for_scan_decode()?;
+        self.decoder.mcu_checkpoints_enabled = true;
+        Ok(())
+    }
+
+    fn decode_buffered_source_and_render(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>,
+        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+    ) -> Result<(), DecodeErrors> {
+        let stripe = self.decoder.raw_pull_state.next_stripe;
+        self.decoder.decode_buffered_raw_source(stripe, layout, n)?;
+        self.decoder.raw_pull_state.buffered_source_complete = true;
+        self.decoder.render_buffered_raw_stripe(output)
+    }
+
+    #[cfg(feature = "arith")]
+    fn restore_arithmetic_pull_context(&mut self) -> Result<(), DecodeErrors> {
+        if !self.decoder.is_arithmetic {
+            return Ok(());
+        }
+        let resumes_completed_row = match self.decoder.scan_checkpoint() {
+            Some(checkpoint) => matches!(
+                checkpoint.bitstream_state,
+                BitstreamStateSnapshot::Arithmetic(_)
+            ),
+            None => false
+        };
+        if resumes_completed_row {
+            let tables = self
+                .decoder
+                .raw_pull_state
+                .entropy_tables
+                .as_ref()
+                .ok_or(DecodeErrors::FormatStatic(
+                    "missing arithmetic contexts for raw iMCU-row resume"
+                ))?;
+            self.decoder.entropy_tables = tables.clone();
+        }
+        Ok(())
     }
 
     /// Decode the complete image into DCT-block-padded component planes.
@@ -597,7 +976,36 @@ where
     /// [`DecodeErrors::Format`] for the wrong plane count, or an error from
     /// the underlying decode pipeline.
     pub fn decode_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
-        self.decoder.decode_raw_into(planes)
+        if self.decoder.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
+        if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
+            self.decoder.raw_pull_state = RawPullState::default();
+        }
+        let layout = self.layout().ok_or(DecodeErrors::FormatStatic(
+            "raw layout unavailable before headers are decoded"
+        ))?;
+        let count = self.num_components().ok_or(DecodeErrors::FormatStatic(
+            "raw components unavailable before headers are decoded"
+        ))?;
+        if planes.len() != count {
+            return Err(DecodeErrors::Format(format!(
+                "RawDecodeSession::decode_into expected {count} plane buffer(s), got {}",
+                planes.len()
+            )));
+        }
+        for (index, plane) in planes.iter().enumerate() {
+            if plane.len() < layout[index].byte_size {
+                return Err(DecodeErrors::TooSmallOutput(
+                    layout[index].byte_size,
+                    plane.len()
+                ));
+            }
+        }
+        let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.stride).collect();
+        self.decode_whole_with_strides(planes, &strides, &layout)
     }
 
     /// Decode the complete image into component planes with caller row strides.
@@ -646,7 +1054,86 @@ where
     pub fn decode_into_strided(
         &mut self, planes: &mut [&mut [u8]], strides: &[usize]
     ) -> Result<(), DecodeErrors> {
-        self.decoder.decode_raw_into_strided(planes, strides)
+        if self.decoder.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
+        if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
+            self.decoder.raw_pull_state = RawPullState::default();
+        }
+        let layout = self.layout().ok_or(DecodeErrors::FormatStatic(
+            "raw layout unavailable before headers are decoded"
+        ))?;
+        let count = self.num_components().ok_or(DecodeErrors::FormatStatic(
+            "raw components unavailable before headers are decoded"
+        ))?;
+        if planes.len() != count || strides.len() != count {
+            return Err(DecodeErrors::Format(format!(
+                "RawDecodeSession::decode_into_strided expected {count} plane(s) and stride(s), got {} plane(s) and {} stride(s)",
+                planes.len(),
+                strides.len()
+            )));
+        }
+        for index in 0..count {
+            if strides[index] < layout[index].width {
+                return Err(DecodeErrors::Format(format!(
+                    "stride[{index}] = {} is smaller than logical width {}",
+                    strides[index], layout[index].width
+                )));
+            }
+            let need = strides[index]
+                .checked_mul(layout[index].height)
+                .ok_or(DecodeErrors::FormatStatic("plane size overflow"))?;
+            if planes[index].len() < need {
+                return Err(DecodeErrors::TooSmallOutput(need, planes[index].len()));
+            }
+        }
+        self.decode_whole_with_strides(planes, strides, &layout)
+    }
+
+    fn decode_whole_with_strides(
+        &mut self, planes: &mut [&mut [u8]], strides: &[usize],
+        layout: &[PlaneInfo; MAX_COMPONENTS]
+    ) -> Result<(), DecodeErrors> {
+        let count = planes.len();
+        loop {
+            let stripe = self.decoder.raw_pull_state.next_stripe;
+            if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
+                self.decoder.finish_raw_pull_source();
+                return Ok(());
+            }
+            let mut stripe_planes: Vec<&mut [u8]> = planes
+                .iter_mut()
+                .enumerate()
+                .map(|(index, plane)| {
+                    let configured_rows = self.decoder.raw_pull_state.rows_per_stripe[index];
+                    let stripe_rows = if configured_rows == 0 {
+                        layout[index].vertical_sampling_factor * DCT_BLOCK_SIZE
+                    } else {
+                        configured_rows
+                    };
+                    let row_start = stripe * stripe_rows;
+                    let rows = layout[index]
+                        .height
+                        .saturating_sub(row_start)
+                        .min(stripe_rows);
+                    let start = (row_start * strides[index]).min(plane.len());
+                    let end = start + rows * strides[index];
+                    &mut plane[start..end]
+                })
+                .collect();
+
+            match self.decode_next_imcu_row_for(
+                RawPullOwner::WholeImage,
+                &mut stripe_planes,
+                &strides[..count]
+            )? {
+                RawImcuRowStatus::RowReady { .. } => {}
+                RawImcuRowStatus::NeedMoreInput => return Err(DecodeErrors::ExhaustedData),
+                RawImcuRowStatus::Complete => return Ok(())
+            }
+        }
     }
 }
 
@@ -973,7 +1460,8 @@ where
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,
             marker_body_scratch:         Vec::new(),
-            expects_dnl:                 false
+            expects_dnl:                 false,
+            raw_pull_state:              RawPullState::default()
         }
     }
     /// Decode a buffer already in memory
@@ -984,6 +1472,7 @@ where
     /// # Errors
     /// See DecodeErrors for an explanation
     pub fn decode(&mut self) -> Result<Vec<u8>, DecodeErrors> {
+        self.abort_raw_pull_sequence();
         self.decode_headers()?;
         self.ensure_supported_encoding()?;
 
@@ -1197,13 +1686,32 @@ where
     /// output planes. The session borrows this decoder mutably, preventing
     /// pixel output or option changes until the session is dropped.
     pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
-        self.clear_scan_checkpoints();
+        if self.raw_pull_state.phase == RawPullPhase::Complete {
+            self.raw_pull_state = RawPullState::default();
+        }
+        if self.raw_pull_state.owner == RawPullOwner::None {
+            self.clear_scan_checkpoints();
+        }
         let previous_incremental_mode = self.incremental_mode;
         self.incremental_mode = true;
         RawDecodeSession {
             decoder: self,
             previous_incremental_mode,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw_buffer_capacities(
+        &self
+    ) -> ([usize; MAX_COMPONENTS], [usize; MAX_COMPONENTS]) {
+        (
+            core::array::from_fn(|index| {
+                self.components
+                    .get(index)
+                    .map_or(0, |component| component.raw_coeff.capacity())
+            }),
+            core::array::from_fn(|index| self.progressive_mcus_buffer[index].capacity())
+        )
     }
 
     /// Number of components present in the JPEG scan (1..=4).
@@ -1289,6 +1797,23 @@ where
         Some(out)
     }
 
+    fn raw_imcu_row_count(&self, layout: &[PlaneInfo; MAX_COMPONENTS], n: usize) -> usize {
+        layout[..n]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| {
+                let configured_rows = self.raw_pull_state.rows_per_stripe[index];
+                let rows = if configured_rows == 0 {
+                    plane.vertical_sampling_factor * DCT_BLOCK_SIZE
+                } else {
+                    configured_rows
+                };
+                plane.height.div_ceil(rows)
+            })
+            .max()
+            .unwrap_or(0)
+    }
+
     /// Get an immutable reference to the decoder options
     /// for the decoder instance
     ///
@@ -1328,8 +1853,10 @@ where
     }
     /// Set decoder options
     ///
-    /// This can be used after initialization or a partial decode. The next
-    /// output operation replays from scan start with the new options.
+    /// This can be used to set new options even after initialization
+    /// but before decoding.
+    ///
+    /// This does not bear any significance after decoding an image
     ///
     /// # Arguments
     /// - `options`: New decoder options
@@ -1411,6 +1938,7 @@ where
     }
 
     pub fn set_options(&mut self, options: DecoderOptions) {
+        self.abort_raw_pull_sequence();
         self.clear_scan_checkpoints();
         self.options = options;
         self.coeff = 1;
@@ -2298,6 +2826,7 @@ where
     }
 
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
+        self.abort_raw_pull_sequence();
         self.prepare_for_scan_decode()?;
 
         let expected_size = self.output_buffer_size().unwrap();
@@ -2336,116 +2865,66 @@ where
         }
     }
 
-    // Shared implementation for `RawDecodeSession::decode_into`.
-    fn decode_raw_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
-        if self.expects_dnl {
-            return Err(DecodeErrors::FormatStatic(
-                "raw output does not support DNL images"
-            ));
+    fn render_buffered_raw_stripe(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        if self.is_progressive {
+            self.render_buffered_progressive_raw_stripe(output)
+        } else {
+            self.render_buffered_baseline_raw_stripe(output)
         }
-        self.prepare_for_scan_decode()?;
-
-        let n = self.components.len();
-        if planes.len() != n {
-            return Err(DecodeErrors::Format(format!(
-                "RawDecodeSession::decode_into expected {n} plane buffer(s), got {}",
-                planes.len()
-            )));
-        }
-        let layout = self.raw_planar_layout().ok_or(DecodeErrors::FormatStatic(
-            "raw layout unavailable after decode_headers"
-        ))?;
-        for (i, plane) in planes.iter().enumerate() {
-            let need = layout[i].byte_size;
-            if plane.len() < need {
-                return Err(DecodeErrors::TooSmallOutput(need, plane.len()));
-            }
-        }
-
-        let mut lengths = [0usize; MAX_COMPONENTS];
-        let mut target_strides = [0usize; MAX_COMPONENTS];
-        let mut target_widths = [0usize; MAX_COMPONENTS];
-        let mut target_heights = [0usize; MAX_COMPONENTS];
-        for i in 0..n {
-            lengths[i] = planes[i].len();
-            target_strides[i] = layout[i].stride;
-            target_widths[i] = layout[i].stride;
-            target_heights[i] = layout[i].allocated_height;
-        }
-        let raw_planes = RawPlanesSink {
-            planes,
-            lengths,
-            target_strides,
-            target_widths,
-            target_heights,
-            n_components: n
-        };
-        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
-        self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
-    // Shared implementation for `RawDecodeSession::decode_into_strided`.
-    fn decode_raw_into_strided(
-        &mut self, planes: &mut [&mut [u8]], strides: &[usize]
+    fn decode_buffered_raw_source(
+        &mut self, requested_stripe: usize, layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
     ) -> Result<(), DecodeErrors> {
-        if self.expects_dnl {
-            return Err(DecodeErrors::FormatStatic(
-                "raw output does not support DNL images"
-            ));
-        }
-        self.prepare_for_scan_decode()?;
-
-        let n = self.components.len();
-        if planes.len() != n {
-            return Err(DecodeErrors::Format(format!(
-                "RawDecodeSession::decode_into_strided expected {n} plane buffer(s), got {}",
-                planes.len()
-            )));
-        }
-        if strides.len() != n {
-            return Err(DecodeErrors::Format(format!(
-                "RawDecodeSession::decode_into_strided expected {n} stride(s), got {}",
-                strides.len()
-            )));
-        }
-        let layout = self.raw_planar_layout().ok_or(DecodeErrors::FormatStatic(
-            "raw layout unavailable after decode_headers"
-        ))?;
-        for (i, plane) in planes.iter().enumerate() {
-            if strides[i] < layout[i].width {
-                return Err(DecodeErrors::Format(format!(
-                    "stride[{i}] = {} is smaller than logical width {}",
-                    strides[i], layout[i].width
-                )));
-            }
-            let need = strides[i]
-                .checked_mul(layout[i].height)
-                .ok_or(DecodeErrors::FormatStatic("plane size overflow"))?;
-            if plane.len() < need {
-                return Err(DecodeErrors::TooSmallOutput(need, plane.len()));
-            }
-        }
-
+        let mut buffers: Vec<Vec<u8>> = layout[..n]
+            .iter()
+            .map(|plane| {
+                let rows = plane.vertical_sampling_factor * DCT_BLOCK_SIZE;
+                vec![0; plane.width * rows]
+            })
+            .collect();
+        let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(Vec::as_mut_slice).collect();
         let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        for i in 0..n {
-            lengths[i] = planes[i].len();
-            target_strides[i] = strides[i];
-            target_widths[i] = layout[i].width;
-            target_heights[i] = layout[i].height;
+        for index in 0..n {
+            lengths[index] = planes[index].len();
+            target_strides[index] = layout[index].width;
+            target_widths[index] = layout[index].width;
+            target_heights[index] = layout[index].vertical_sampling_factor * DCT_BLOCK_SIZE;
         }
-        let raw_planes = RawPlanesSink {
-            planes,
+        let sink = RawPlanesSink {
+            planes: &mut planes,
             lengths,
             target_strides,
             target_widths,
             target_heights,
-            n_components: n
+            n_components: n,
+            requested_stripe: Some(requested_stripe),
+            rows_written: [0; MAX_COMPONENTS],
+            stripe_ready: false,
+            source_complete: false
         };
-        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
-        self.decode_mcu_output_with_success_cleanup(&mut output)
+        let mut output = McuDecodeOutput::RawPlanes(sink);
+        self.decode_mcu_output(&mut output)
+    }
+
+    fn finish_raw_pull_source(&mut self) {
+        self.clear_scan_checkpoints();
+        if self.is_progressive {
+            self.progressive_displayed_scans = self.progressive_completed_scans;
+        }
+    }
+
+    fn abort_raw_pull_sequence(&mut self) {
+        if self.raw_pull_state.owner == RawPullOwner::None {
+            return;
+        }
+        self.raw_pull_state = RawPullState::default();
+        self.clear_scan_checkpoints();
     }
 
     fn raw_component_ids(&self) -> Option<Vec<u8>> {
@@ -2466,6 +2945,14 @@ where
     pub(crate) fn copy_raw_planes_for_mcu_stripe(
         &self, mcu_stripe_index: usize, sink: &mut RawPlanesSink<'_, '_>
     ) -> Result<(), DecodeErrors> {
+        if let Some(requested_stripe) = sink.requested_stripe {
+            if requested_stripe != mcu_stripe_index {
+                return Err(DecodeErrors::FormatStatic(
+                    "raw iMCU-row output advanced out of sequence"
+                ));
+            }
+        }
+
         for (idx, comp) in self.components.iter().enumerate() {
             if idx >= sink.n_components {
                 break;
@@ -2475,14 +2962,38 @@ where
             let target_height = sink.target_heights[idx];
 
             let stripe_rows = comp.vertical_sample * DCT_BLOCK_SIZE;
-            let row_start = mcu_stripe_index * stripe_rows;
+            let source_row_start = mcu_stripe_index * stripe_rows;
+            let row_start = if sink.requested_stripe.is_some() { 0 } else { source_row_start };
             // Clip rows to the plane height.
             if row_start >= target_height {
                 continue;
             }
-            let rows_to_copy = core::cmp::min(stripe_rows, target_height - row_start);
-
             let src_stride = comp.width_stride;
+            let available_source_rows = comp.raw_coeff.len() / src_stride;
+            let logical_rows = if let Some(requested_stripe) = sink.requested_stripe {
+                if self.expects_dnl {
+                    target_height
+                } else {
+                    self.raw_planar_layout().map_or(target_height, |layout| {
+                        layout[idx]
+                            .height
+                            .saturating_sub(requested_stripe * available_source_rows)
+                            .min(target_height)
+                    })
+                }
+            } else {
+                target_height - row_start
+            };
+            let rows_to_copy = if sink.requested_stripe.is_some() {
+                core::cmp::min(logical_rows, available_source_rows)
+            } else {
+                core::cmp::min(
+                    core::cmp::min(stripe_rows, target_height - row_start),
+                    available_source_rows
+                )
+            };
+            sink.rows_written[idx] = rows_to_copy;
+
             let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
             let len = sink.lengths[idx];
 
@@ -2510,6 +3021,7 @@ where
                 }
             }
         }
+        sink.stripe_ready = true;
         Ok(())
     }
 
@@ -2739,8 +3251,7 @@ mod planar_layout_helpers {
 
     use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
     use crate::idct::{choose_idct_1x1_func, choose_idct_4x4_func, choose_idct_func};
-
-    use super::{round_up_pow2, JpegDecoder};
+    use super::{round_up_pow2, JpegDecoder, RawImcuRowStatus};
 
     #[test]
     fn div_ceil_basic() {
@@ -2800,6 +3311,38 @@ mod planar_layout_helpers {
                 decoder.color_convert_16 as usize,
                 choose_ycbcr_to_rgb_convert_func(colorspace, &replacement).unwrap() as usize
             );
+        }
+    }
+
+    #[test]
+    fn baseline_pull_memory_is_stripe_bounded() {
+        let data = include_bytes!("../../../test-images/jpeg/2029.jpg");
+        let mut decoder = JpegDecoder::new(ZCursor::new(data));
+        decoder.decode_headers().unwrap();
+        let mut raw = decoder.raw_output();
+        let layout = raw.layout().unwrap();
+        let count = raw.num_components().unwrap();
+        let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+        let mut buffers: Vec<Vec<u8>> = layout[..count]
+            .iter()
+            .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+            .collect();
+        let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(Vec::as_mut_slice).collect();
+        assert!(matches!(
+            raw.decode_next_imcu_row(&mut planes, &strides).unwrap(),
+            RawImcuRowStatus::RowReady { .. }
+        ));
+        drop(raw);
+
+        let (stripe_buffers, full_buffers) = decoder.raw_buffer_capacities();
+        assert!(full_buffers[..count].iter().all(|length| *length == 0));
+        for index in 0..count {
+            let rows = layout[index].vertical_sampling_factor * 8;
+            assert!(
+                stripe_buffers[index] <= (layout[index].stride + 8) * rows,
+                "component {index} exceeded one-iMCU-row scratch bound"
+            );
+            assert!(stripe_buffers[index] < layout[index].byte_size);
         }
     }
 }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -870,6 +870,13 @@ where
         }
     }
 
+    fn clear_scan_checkpoints(&mut self) {
+        if let Some(state) = self.scan_state.as_deref_mut() {
+            state.scan_checkpoint = None;
+            state.progressive_checkpoint = None;
+        }
+    }
+
     // Match output colorspace; we only care for ycbcr to rgb/rgba here, in
     // case one is using another colorspace may god help you.
     fn set_color_convert_from_options(&mut self) {
@@ -1182,6 +1189,7 @@ where
     /// output planes. The session borrows this decoder mutably, preventing
     /// pixel output or option changes until the session is dropped.
     pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
+        self.clear_scan_checkpoints();
         RawDecodeSession { decoder: self }
     }
 
@@ -1307,10 +1315,8 @@ where
     }
     /// Set decoder options
     ///
-    /// This can be used to set new options even after initialization
-    /// but before decoding.
-    ///
-    /// This does not bear any significance after decoding an image
+    /// This can be used after initialization or a partial decode. The next
+    /// output operation replays from scan start with the new options.
     ///
     /// # Arguments
     /// - `options`: New decoder options
@@ -1392,7 +1398,15 @@ where
     }
 
     pub fn set_options(&mut self, options: DecoderOptions) {
+        self.clear_scan_checkpoints();
         self.options = options;
+        self.coeff = 1;
+        self.pixels_decoded = 0;
+        self.progressive_displayed_scans = 0;
+        self.set_color_convert_from_options();
+        self.idct_func = choose_idct_func(&self.options);
+        self.idct_4x4_func = choose_idct_4x4_func(&self.options);
+        self.idct_1x1_func = choose_idct_1x1_func(&self.options);
     }
     #[allow(clippy::cast_possible_truncation)]
     fn reassemble_extended_xmp(&mut self) {
@@ -2311,6 +2325,11 @@ where
 
     // Shared implementation for `RawDecodeSession::decode_into`.
     fn decode_raw_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
+        if self.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
         self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
@@ -2356,6 +2375,11 @@ where
     fn decode_raw_into_strided(
         &mut self, planes: &mut [&mut [u8]], strides: &[usize]
     ) -> Result<(), DecodeErrors> {
+        if self.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
         self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
@@ -2696,7 +2720,14 @@ impl ImageInfo {
 
 #[cfg(test)]
 mod planar_layout_helpers {
-    use super::round_up_pow2;
+    use zune_core::bytestream::ZCursor;
+    use zune_core::colorspace::ColorSpace;
+    use zune_core::options::DecoderOptions;
+
+    use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
+    use crate::idct::{choose_idct_1x1_func, choose_idct_4x4_func, choose_idct_func};
+
+    use super::{round_up_pow2, JpegDecoder};
 
     #[test]
     fn div_ceil_basic() {
@@ -2722,5 +2753,40 @@ mod planar_layout_helpers {
     #[test]
     fn round_up_pow2_overflow() {
         assert_eq!(round_up_pow2(usize::MAX, 8), None);
+    }
+
+    #[test]
+    fn set_options_refreshes_cached_dispatch() {
+        for (initial, replacement) in [
+            (DecoderOptions::new_fast(), DecoderOptions::new_safe()),
+            (DecoderOptions::new_safe(), DecoderOptions::new_fast())
+        ] {
+            let mut decoder = JpegDecoder::new_with_options(ZCursor::new(&[]), initial);
+            decoder.set_options(replacement);
+            assert_eq!(decoder.idct_func as usize, choose_idct_func(&replacement) as usize);
+            assert_eq!(
+                decoder.idct_4x4_func as usize,
+                choose_idct_4x4_func(&replacement) as usize
+            );
+            assert_eq!(
+                decoder.idct_1x1_func as usize,
+                choose_idct_1x1_func(&replacement) as usize
+            );
+        }
+
+        for colorspace in [
+            ColorSpace::RGB,
+            ColorSpace::BGR,
+            ColorSpace::RGBA,
+            ColorSpace::BGRA
+        ] {
+            let replacement = DecoderOptions::default().jpeg_set_out_colorspace(colorspace);
+            let mut decoder = JpegDecoder::new(ZCursor::new(&[]));
+            decoder.set_options(replacement);
+            assert_eq!(
+                decoder.color_convert_16 as usize,
+                choose_ycbcr_to_rgb_convert_func(colorspace, &replacement).unwrap() as usize
+            );
+        }
     }
 }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -441,29 +441,32 @@ pub struct JpegDecoder<T> {
     /// scan's entropy data. The MCU decode loop will intercept that marker
     /// and store the real height; if it never arrives, decoding returns an
     /// error.
-    pub(crate) expects_dnl: bool,
-    /// When `Some`, the decoder is in raw planar output mode and
-    /// `post_process()` is bypassed in favour of copying each component's
-    /// post-IDCT samples directly into the caller-provided plane buffers.
-    ///
-    /// Always set/cleared inside [`JpegDecoder::decode_raw`]; `None`
-    /// during normal interleaved-pixel decoding.
-    pub(crate) raw_planes_sink: Option<RawPlanesSink>
+    pub(crate) expects_dnl: bool
 }
 
-/// Internal sink for one raw planar decode call.
-///
-/// Holds raw pointers into the caller-provided plane buffers so that MCU-stripe
-/// processing can write decoded samples directly without an intermediate copy.
-///
-/// # Safety
-/// The pointers are valid for the lifetime of the `decode_raw` / `decode_raw_strided`
-/// call that sets up this sink.  The sink is always cleared (set to `None`) before
-/// those functions return, so the pointers never outlive the caller's slices.
-#[allow(unsafe_code)]
-pub(crate) struct RawPlanesSink {
-    /// Raw pointers into the caller's plane buffers (one per component).
-    pub(crate) ptrs:           [*mut u8; MAX_COMPONENTS],
+/// Output target for one MCU decode call.
+pub(crate) enum McuDecodeOutput<'planes, 'buf> {
+    Pixels(&'planes mut [u8]),
+    RawPlanes(RawPlanesSink<'planes, 'buf>)
+}
+
+impl McuDecodeOutput<'_, '_> {
+    pub(crate) const fn is_raw(&self) -> bool {
+        matches!(self, Self::RawPlanes(_))
+    }
+
+    pub(crate) fn pixels_mut(&mut self) -> Option<&mut [u8]> {
+        match self {
+            Self::Pixels(pixels) => Some(pixels),
+            Self::RawPlanes(_) => None
+        }
+    }
+}
+
+/// Caller-provided raw planar buffers for one decode call.
+pub(crate) struct RawPlanesSink<'planes, 'buf> {
+    /// Caller plane buffers, one per component.
+    pub(crate) planes:         &'planes mut [&'buf mut [u8]],
     /// Total byte length of each caller buffer.
     pub(crate) lengths:        [usize; MAX_COMPONENTS],
     /// Bytes between successive destination rows (used for strided output).
@@ -475,15 +478,6 @@ pub(crate) struct RawPlanesSink {
     /// Number of valid components.
     pub(crate) n_components:   usize
 }
-
-/// SAFETY: The pointers in `RawPlanesSink` are derived from `&mut [u8]` references
-/// that live on the calling thread's stack.  The sink is only alive for the duration
-/// of a single `decode_raw*` call, never sent across threads.
-#[allow(unsafe_code)]
-unsafe impl Send for RawPlanesSink {}
-/// SAFETY: No shared-mutable state; see `Send` impl above.
-#[allow(unsafe_code)]
-unsafe impl Sync for RawPlanesSink {}
 
 impl<T> JpegDecoder<T>
 where
@@ -800,8 +794,7 @@ where
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,
             marker_body_scratch:         Vec::new(),
-                expects_dnl:                 false,
-                raw_planes_sink:             None
+            expects_dnl:                 false
         }
     }
     /// Decode a buffer already in memory
@@ -2078,23 +2071,8 @@ where
         }
         self.scan_decode_attempted = true;
 
-        let result: Result<(), DecodeErrors>;
-        if self.is_arithmetic {
-            #[cfg(feature = "arith")]
-            {
-                result = if self.is_progressive {
-                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(out)
-                } else {
-                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(out)
-                };
-            }
-            #[cfg(not(feature = "arith"))]
-            unreachable!();
-        } else if self.is_progressive {
-            result = self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(out);
-        } else {
-            result = self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(out);
-        }
+        let mut output = McuDecodeOutput::Pixels(out);
+        let result = self.decode_mcu_output(&mut output);
 
         match result {
             Ok(()) => {
@@ -2116,6 +2094,27 @@ where
                 Ok(())
             }
             Err(e) => Err(e)
+        }
+    }
+
+    fn decode_mcu_output(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        if self.is_arithmetic {
+            #[cfg(feature = "arith")]
+            {
+                if self.is_progressive {
+                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(output)
+                } else {
+                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(output)
+                }
+            }
+            #[cfg(not(feature = "arith"))]
+            unreachable!();
+        } else if self.is_progressive {
+            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(output)
+        } else {
+            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(output)
         }
     }
 
@@ -2210,55 +2209,26 @@ where
             }
         }
 
-        // Set up the raw-planes sink pointing directly into the caller's slices.
-        // SAFETY: The pointers are derived from the mutable slice references in
-        // `planes`, which are guaranteed to remain valid and exclusively borrowed
-        // for the duration of this call.  The sink is cleared before we return.
-        let mut ptrs = [core::ptr::null_mut(); MAX_COMPONENTS];
         let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
         for i in 0..n {
-            ptrs[i] = planes[i].as_mut_ptr();
             lengths[i] = planes[i].len();
             target_strides[i] = layout[i].stride;
             target_widths[i] = layout[i].stride;
             target_heights[i] = layout[i].allocated_height;
         }
-        self.raw_planes_sink = Some(RawPlanesSink {
-            ptrs,
+        let raw_planes = RawPlanesSink {
+            planes,
             lengths,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
-        });
-
-        // Raw mode writes directly into the caller's buffers; downstream pixel
-        // bookkeeping only needs a placeholder slice.
-        let mut sink: [u8; 0] = [];
-        let result = if self.is_arithmetic {
-            #[cfg(feature = "arith")]
-            {
-                if self.is_progressive {
-                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(&mut sink)
-                } else {
-                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(&mut sink)
-                }
-            }
-            #[cfg(not(feature = "arith"))]
-            unreachable!();
-        } else if self.is_progressive {
-            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
-        } else {
-            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
         };
-
-        // Clear the sink so pointers don't outlive the caller's slices.
-        self.raw_planes_sink = None;
-
-        result
+        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
+        self.decode_mcu_output(&mut output)
     }
 
     /// Decode raw planes using caller-supplied row strides.
@@ -2357,52 +2327,26 @@ where
             }
         }
 
-        // Set up the raw-planes sink pointing directly into the caller's slices.
-        // SAFETY: Same guarantees as `decode_raw` — pointers derived from exclusive
-        // mutable borrows, valid for the entire call, cleared before return.
-        let mut ptrs = [core::ptr::null_mut(); MAX_COMPONENTS];
         let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
         for i in 0..n {
-            ptrs[i] = planes[i].as_mut_ptr();
             lengths[i] = planes[i].len();
             target_strides[i] = strides[i];
             target_widths[i] = layout[i].width;
             target_heights[i] = layout[i].height;
         }
-        self.raw_planes_sink = Some(RawPlanesSink {
-            ptrs,
+        let raw_planes = RawPlanesSink {
+            planes,
             lengths,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
-        });
-
-        let mut sink: [u8; 0] = [];
-        let result = if self.is_arithmetic {
-            #[cfg(feature = "arith")]
-            {
-                if self.is_progressive {
-                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(&mut sink)
-                } else {
-                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(&mut sink)
-                }
-            }
-            #[cfg(not(feature = "arith"))]
-            unreachable!();
-        } else if self.is_progressive {
-            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
-        } else {
-            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
         };
-
-        // Clear the sink so pointers don't outlive the caller's slices.
-        self.raw_planes_sink = None;
-
-        result
+        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
+        self.decode_mcu_output(&mut output)
     }
 
     /// Per-component [`ComponentID`] in declaration order
@@ -2427,20 +2371,13 @@ where
     /// each component's `raw_coeff` into the caller-provided plane buffers.
     ///
     /// Called from the baseline / progressive paths in place of
-    /// `post_process()` when [`raw_planes_sink`](Self::raw_planes_sink)
-    /// is `Some` (i.e. inside [`decode_raw`](Self::decode_raw)).
+    /// `post_process()` when decoding raw planes.
     ///
     /// The IDCT outputs are already clamped to `[0, 255]` so the `i16 -> u8`
     /// truncation here is exact.
-    #[allow(unsafe_code)]
     pub(crate) fn copy_raw_planes_for_mcu_stripe(
-        &mut self, mcu_stripe_index: usize
+        &self, mcu_stripe_index: usize, sink: &mut RawPlanesSink<'_, '_>
     ) -> Result<(), DecodeErrors> {
-        let sink = self
-            .raw_planes_sink
-            .as_mut()
-            .expect("copy_raw_planes_for_mcu_stripe called without active sink");
-
         for (idx, comp) in self.components.iter().enumerate() {
             if idx >= sink.n_components {
                 break;
@@ -2459,8 +2396,6 @@ where
 
             let src_stride = comp.width_stride;
             let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
-
-            let ptr = sink.ptrs[idx];
             let len = sink.lengths[idx];
 
             for r in 0..rows_to_copy {
@@ -2474,18 +2409,15 @@ where
                 let src = &comp.raw_coeff[src_row_start..src_row_end];
 
                 let dst_offset = (row_start + r) * target_stride;
-                debug_assert!(dst_offset + copy_w <= len);
-                // SAFETY: `ptr` points into the caller's `&mut [u8]` which is
-                // guaranteed to be at least `len` bytes.  The bounds check above
-                // (via `target_height` / `target_stride` validation in decode_raw*)
-                // ensures `dst_offset + copy_w <= len`.
-                unsafe {
-                    let dst = core::slice::from_raw_parts_mut(ptr.add(dst_offset), copy_w);
-                    for (i, sample) in src.iter().enumerate() {
-                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                        {
-                            dst[i] = *sample as u8;
-                        }
+                let dst_end = dst_offset + copy_w;
+                if dst_end > len {
+                    return Err(DecodeErrors::TooSmallOutput(dst_end, len));
+                }
+                let dst = &mut sink.planes[idx][dst_offset..dst_end];
+                for (sample, dst) in src.iter().zip(dst.iter_mut()) {
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    {
+                        *dst = *sample as u8;
                     }
                 }
             }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -646,6 +646,11 @@ where
 
     /// Decode the next sequential raw iMCU row into caller-provided planes.
     ///
+    /// Interleaved baseline images decode and deliver one iMCU row at a time.
+    /// Progressive and multi-SOS images must first buffer all coefficient data
+    /// needed for final samples; their rows are still pulled sequentially, but
+    /// compressed input consumption is not row-streaming.
+    ///
     /// Each stride must be at least the corresponding logical plane width.
     /// Each plane must be large enough for
     /// `stride * vertical_sampling_factor * 8` bytes. The returned

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -15,6 +15,7 @@ use alloc::vec::Vec;
 use alloc::sync::Arc;
 use alloc::{format, vec};
 use core::num::NonZeroU32;
+use core::ptr::NonNull;
 
 use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::colorspace::ColorSpace;
@@ -29,7 +30,7 @@ use crate::bitstream::{BitstreamStateSnapshot, BitStreamHuffman};
 #[cfg(feature = "arith")]
 use crate::bitstream_arith::{ArithACTables, ArithDCTables, BitStreamArithmetic};
 use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
-use crate::components::{Components, SampleRatios};
+use crate::components::{ComponentID, Components, SampleRatios};
 use crate::errors::{DecodeErrors, UnsupportedSchemes};
 #[cfg(feature = "arith")]
 use crate::headers::parse_dac;
@@ -49,8 +50,58 @@ use crate::upsampler::{
 /// Maximum components
 pub(crate) const MAX_COMPONENTS: usize = 4;
 
+/// DCT block side, in samples. JPEG always uses 8x8 blocks.
+pub(crate) const DCT_BLOCK_SIZE: usize = 8;
+
 /// Maximum image dimensions supported.
 pub(crate) const MAX_DIMENSIONS: usize = 1 << 27;
+
+/// Geometry of a single component plane for raw post-IDCT output.
+///
+/// Mirrors the padded buffer layout libjpeg-turbo's `jpeg_read_raw_data` expects:
+/// each component owns a plane sized to `stride * allocated_height` bytes,
+/// with both dimensions rounded up to DCT-block boundaries
+/// (`DCTSIZE = 8`). The logical `width`/`height` describe the meaningful
+/// sample area inside that buffer; trailing padding columns and rows
+/// contain implementation-defined data and should be ignored by the
+/// caller.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct PlaneInfo {
+    /// Logical component width in samples.
+    /// `ceil(image_width * h_samp / h_max)`.
+    pub width:            usize,
+    /// Logical component height in samples.
+    /// `ceil(image_height * v_samp / v_max)`.
+    pub height:           usize,
+    /// Allocated plane width (row stride) in bytes.
+    /// `ceil(width / 8) * 8`.
+    pub stride:           usize,
+    /// Allocated plane height in rows.
+    /// `ceil(height / 8) * 8`.
+    pub allocated_height: usize,
+    /// Required slice length for this plane: `stride * allocated_height`.
+    pub byte_size:        usize
+}
+
+/// Ceiling division: `ceil(a / b)` without overflow on the addition.
+#[inline]
+fn ceil_div(a: usize, b: usize) -> usize {
+    debug_assert!(b != 0);
+    a / b + usize::from(a % b != 0)
+}
+
+/// Round `n` up to the next multiple of `align` (which must be non-zero).
+/// Returns `None` on overflow.
+#[inline]
+fn round_up_pow2(n: usize, align: usize) -> Option<usize> {
+    debug_assert!(align != 0);
+    let rem = n % align;
+    if rem == 0 {
+        Some(n)
+    } else {
+        n.checked_add(align - rem)
+    }
+}
 
 /// Color conversion function that can convert YCbCr colorspace to RGB(A/X) for
 /// 16 values
@@ -398,7 +449,28 @@ pub struct JpegDecoder<T> {
     /// scan's entropy data. The MCU decode loop will intercept that marker
     /// and store the real height; if it never arrives, decoding returns an
     /// error.
-    pub(crate) expects_dnl: bool
+    pub(crate) expects_dnl: bool,
+    /// When `Some`, the decoder is in raw planar output mode and
+    /// `post_process()` is bypassed in favour of copying each component's
+    /// post-IDCT samples directly into the caller-provided plane buffers.
+    ///
+    /// Always set/cleared inside [`JpegDecoder::decode_raw`]; `None`
+    /// during normal interleaved-pixel decoding.
+    pub(crate) raw_planes_sink: Option<RawPlanesSink>
+}
+
+/// Internal sink for one raw planar decode call.
+pub(crate) struct RawPlanesSink {
+    /// Per-component plane base pointer (only `0..n_components` are valid).
+    pub(crate) ptrs:           [*mut u8; MAX_COMPONENTS],
+    /// Bytes between successive destination rows.
+    pub(crate) target_strides: [usize; MAX_COMPONENTS],
+    /// Maximum bytes to write per destination row.
+    pub(crate) target_widths:  [usize; MAX_COMPONENTS],
+    /// Number of destination rows the caller's buffer can accept.
+    pub(crate) target_heights: [usize; MAX_COMPONENTS],
+    /// Number of valid components in `ptrs`.
+    pub(crate) n_components:   usize
 }
 
 impl<T> JpegDecoder<T>
@@ -716,7 +788,8 @@ where
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,
             marker_body_scratch:         Vec::new(),
-            expects_dnl:                 false
+                expects_dnl:                 false,
+                raw_planes_sink:             None
         }
     }
     /// Decode a buffer already in memory
@@ -931,6 +1004,84 @@ where
         }
 
         Some((decoded_output_bytes / row_stride).min(usize::from(self.height())))
+    }
+
+    /// Number of components present in the JPEG scan (1..=4).
+    ///
+    /// Valid only after [`decode_headers`](Self::decode_headers).
+    ///
+    /// # Returns
+    /// - `Some(n)`: number of components in the input scan
+    /// - `None`: headers have not been decoded yet
+    #[must_use]
+    pub fn num_components(&self) -> Option<usize> {
+        if self.headers_decoded {
+            Some(self.components.len())
+        } else {
+            None
+        }
+    }
+
+    /// Per-component plane geometry for raw planar output.
+    ///
+    /// Returns one [`PlaneInfo`] per component in declaration order
+    /// (Y, Cb, Cr for YCbCr; Y for grayscale; C, M, Y, K for CMYK; etc.).
+    /// Indices `0..num_components()` are populated; trailing entries are
+    /// the default zero-sized [`PlaneInfo`].
+    ///
+    /// Plane dimensions are computed using the same rules as libjpeg-turbo's
+    /// `jpeg_read_raw_data`:
+    ///
+    /// ```text
+    /// comp_width       = ceil(image_width  * h_samp / h_max)
+    /// comp_height      = ceil(image_height * v_samp / v_max)
+    /// stride           = ceil(comp_width  / 8) * 8
+    /// allocated_height = ceil(comp_height / 8) * 8
+    /// byte_size        = stride * allocated_height
+    /// ```
+    ///
+    /// Valid only after [`decode_headers`](Self::decode_headers).
+    ///
+    /// # Returns
+    /// - `Some([PlaneInfo; MAX_COMPONENTS])`: per-component layout
+    /// - `None`: headers have not been decoded yet, or layout overflows `usize`
+    #[must_use]
+    pub fn planar_layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
+        if !self.headers_decoded || self.components.is_empty() {
+            return None;
+        }
+        let img_w = usize::from(self.width());
+        let img_h = usize::from(self.height());
+        // `self.h_max` / `self.v_max` aren't populated until `decode()` runs
+        // `setup_component_params`, so derive the maxima directly from the
+        // parsed component list (which is available right after
+        // `decode_headers`).
+        let mut h_max = 1usize;
+        let mut v_max = 1usize;
+        for comp in &self.components {
+            if comp.horizontal_sample > h_max {
+                h_max = comp.horizontal_sample;
+            }
+            if comp.vertical_sample > v_max {
+                v_max = comp.vertical_sample;
+            }
+        }
+        let mut out = [PlaneInfo::default(); MAX_COMPONENTS];
+        for (slot, comp) in out.iter_mut().zip(self.components.iter()) {
+            let comp_w = ceil_div(img_w.checked_mul(comp.horizontal_sample)?, h_max);
+            let comp_h = ceil_div(img_h.checked_mul(comp.vertical_sample)?, v_max);
+            let stride = round_up_pow2(comp_w, DCT_BLOCK_SIZE)?;
+            let allocated_height = round_up_pow2(comp_h, DCT_BLOCK_SIZE)?;
+            let byte_size = stride.checked_mul(allocated_height)?;
+            *slot = PlaneInfo {
+                width: comp_w,
+                height: comp_h,
+                stride,
+                allocated_height,
+                byte_size
+            };
+        }
+        Some(out)
     }
 
     /// Get an immutable reference to the decoder options
@@ -1956,6 +2107,290 @@ where
         }
     }
 
+    /// Decode the image into per-component raw planes, skipping upsampling
+    /// and color conversion.
+    ///
+    /// Mirrors libjpeg-turbo's `jpeg_read_raw_data`: each component's
+    /// post-IDCT samples are written directly into its own plane buffer.
+    /// A 4:2:0 YCbCr image yields a full-resolution Y plane and
+    /// half-resolution Cb / Cr planes, each rounded up to DCT-block
+    /// boundaries.
+    ///
+    /// Plane order matches `self.components[i]` declaration order, i.e.
+    /// the order from the SOF marker (`[Y, Cb, Cr]` for YCbCr,
+    /// `[Y]` for grayscale, `[C, M, Y, K]` for CMYK, etc.). The configured
+    /// output colorspace is **ignored** in raw mode.
+    ///
+    /// Each `planes[i]` must be at least
+    /// [`PlaneInfo::byte_size`](`PlaneInfo::byte_size`) bytes
+    /// (`stride * allocated_height`), i.e. dimensions rounded up to
+    /// 8-sample DCT-block boundaries. For a 388×477 4:2:0 image:
+    /// `392 * 480 = 188_160` for Y and `200 * 240 = 48_000` for Cb / Cr.
+    /// See [`decode_raw_strided`](Self::decode_raw_strided) for accepting
+    /// logically-sized buffers.
+    ///
+    /// Samples within `[0, width) × [0, height)` of each plane are
+    /// meaningful; trailing padding columns / rows contain
+    /// implementation-defined data.
+    ///
+    /// # Errors
+    /// - [`DecodeErrors::TooSmallOutput`]: a plane buffer is shorter than
+    ///   its `byte_size`.
+    /// - [`DecodeErrors::Format`]: `planes.len()` does not match the number
+    ///   of components.
+    /// - Any error from the underlying decode pipeline.
+    pub fn decode_raw(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
+        self.decode_headers_internal()?;
+
+        let n = self.components.len();
+        if planes.len() != n {
+            return Err(DecodeErrors::Format(format!(
+                "decode_raw expected {n} plane buffer(s), got {}",
+                planes.len()
+            )));
+        }
+        let layout = self.planar_layout().ok_or(DecodeErrors::FormatStatic(
+            "planar_layout unavailable after decode_headers"
+        ))?;
+        for (i, plane) in planes.iter().enumerate() {
+            let need = layout[i].byte_size;
+            if plane.len() < need {
+                return Err(DecodeErrors::TooSmallOutput(need, plane.len()));
+            }
+        }
+
+        // Each plane is mutably borrowed for this call; the guard clears the
+        // raw pointers before returning.
+        let mut ptrs: [*mut u8; MAX_COMPONENTS] = [core::ptr::null_mut(); MAX_COMPONENTS];
+        let mut target_strides = [0usize; MAX_COMPONENTS];
+        let mut target_widths = [0usize; MAX_COMPONENTS];
+        let mut target_heights = [0usize; MAX_COMPONENTS];
+        for (i, plane) in planes.iter_mut().enumerate() {
+            ptrs[i] = plane.as_mut_ptr();
+            target_strides[i] = layout[i].stride;
+            target_widths[i] = layout[i].stride;
+            target_heights[i] = layout[i].allocated_height;
+        }
+        self.raw_planes_sink = Some(RawPlanesSink {
+            ptrs,
+            target_strides,
+            target_widths,
+            target_heights,
+            n_components: n
+        });
+        let _guard = RawPlanesGuard {
+            dec: NonNull::from(&mut *self)
+        };
+
+        // Raw mode writes into the plane sink; downstream pixel bookkeeping
+        // only needs a placeholder slice.
+        let mut sink: [u8; 0] = [];
+        let result = if self.is_arithmetic {
+            #[cfg(feature = "arith")]
+            {
+                if self.is_progressive {
+                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(&mut sink)
+                } else {
+                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(&mut sink)
+                }
+            }
+            #[cfg(not(feature = "arith"))]
+            unreachable!();
+        } else if self.is_progressive {
+            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
+        } else {
+            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
+        };
+
+        // Guard clears `raw_planes_sink` on drop.
+        result
+    }
+
+    /// Decode raw planes using caller-supplied row strides.
+    ///
+    /// For each component `i` the caller must supply:
+    /// - `planes[i]`: a mutable byte slice of length at least
+    ///   `strides[i] * planar_layout()[i].height` bytes.
+    /// - `strides[i]`: the destination row stride in bytes. Must satisfy
+    ///   `strides[i] >= planar_layout()[i].width`.
+    ///
+    /// Only the logical plane area is written. Padding columns in the caller's
+    /// stride and trailing DCT rows are left untouched.
+    ///
+    /// # Errors
+    /// - [`DecodeErrors::Format`] if `planes.len()` or `strides.len()`
+    ///   doesn't match the number of components, or if any
+    ///   `strides[i] < width[i]`.
+    /// - [`DecodeErrors::TooSmallOutput`] if any plane buffer is shorter
+    ///   than `strides[i] * height[i]`.
+    /// - Any error from the underlying decode pipeline.
+    pub fn decode_raw_strided(
+        &mut self, planes: &mut [&mut [u8]], strides: &[usize]
+    ) -> Result<(), DecodeErrors> {
+        self.decode_headers_internal()?;
+
+        let n = self.components.len();
+        if planes.len() != n {
+            return Err(DecodeErrors::Format(format!(
+                "decode_raw_strided expected {n} plane buffer(s), got {}",
+                planes.len()
+            )));
+        }
+        if strides.len() != n {
+            return Err(DecodeErrors::Format(format!(
+                "decode_raw_strided expected {n} stride(s), got {}",
+                strides.len()
+            )));
+        }
+        let layout = self.planar_layout().ok_or(DecodeErrors::FormatStatic(
+            "planar_layout unavailable after decode_headers"
+        ))?;
+        for (i, plane) in planes.iter().enumerate() {
+            if strides[i] < layout[i].width {
+                return Err(DecodeErrors::Format(format!(
+                    "stride[{i}] = {} is smaller than logical width {}",
+                    strides[i], layout[i].width
+                )));
+            }
+            let need = strides[i]
+                .checked_mul(layout[i].height)
+                .ok_or(DecodeErrors::FormatStatic("plane size overflow"))?;
+            if plane.len() < need {
+                return Err(DecodeErrors::TooSmallOutput(need, plane.len()));
+            }
+        }
+
+        // Each plane is mutably borrowed for this call; the guard clears the
+        // raw pointers before returning.
+        let mut ptrs: [*mut u8; MAX_COMPONENTS] = [core::ptr::null_mut(); MAX_COMPONENTS];
+        let mut target_strides = [0usize; MAX_COMPONENTS];
+        let mut target_widths = [0usize; MAX_COMPONENTS];
+        let mut target_heights = [0usize; MAX_COMPONENTS];
+        for (i, plane) in planes.iter_mut().enumerate() {
+            ptrs[i] = plane.as_mut_ptr();
+            target_strides[i] = strides[i];
+            target_widths[i] = layout[i].width;
+            target_heights[i] = layout[i].height;
+        }
+        self.raw_planes_sink = Some(RawPlanesSink {
+            ptrs,
+            target_strides,
+            target_widths,
+            target_heights,
+            n_components: n
+        });
+        let _guard = RawPlanesGuard {
+            dec: NonNull::from(&mut *self)
+        };
+
+        let mut sink: [u8; 0] = [];
+        let result = if self.is_arithmetic {
+            #[cfg(feature = "arith")]
+            {
+                if self.is_progressive {
+                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(&mut sink)
+                } else {
+                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(&mut sink)
+                }
+            }
+            #[cfg(not(feature = "arith"))]
+            unreachable!();
+        } else if self.is_progressive {
+            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
+        } else {
+            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
+        };
+
+        result
+    }
+
+    /// Per-component [`ComponentID`] in declaration order
+    /// (`Y, Cb, Cr` for YCbCr; `Y` for grayscale; `Y, Cb, Cr, Q` for
+    /// 4-component scans, etc.).
+    ///
+    /// Useful when consuming the planes returned by
+    /// [`decode_raw`](Self::decode_raw) /
+    /// [`decode_raw_strided`](Self::decode_raw_strided) on non-conforming
+    /// JPEGs whose component order differs from the canonical layout.
+    ///
+    /// Valid only after [`decode_headers`](Self::decode_headers).
+    #[must_use]
+    pub fn component_ids(&self) -> Option<Vec<ComponentID>> {
+        if !self.headers_decoded || self.components.is_empty() {
+            return None;
+        }
+        Some(self.components.iter().map(|c| c.component_id).collect())
+    }
+
+    /// Copy one MCU stripe (`mcu_stripe_index`) of post-IDCT samples from
+    /// each component's `raw_coeff` into the caller-provided plane buffers.
+    ///
+    /// Called from the baseline / progressive paths in place of
+    /// `post_process()` when [`raw_planes_sink`](Self::raw_planes_sink)
+    /// is `Some` (i.e. inside [`decode_raw`](Self::decode_raw)).
+    ///
+    /// The IDCT outputs are already clamped to `[0, 255]` so the `i16 -> u8`
+    /// truncation here is exact.
+    pub(crate) fn copy_raw_planes_for_mcu_stripe(
+        &mut self, mcu_stripe_index: usize
+    ) -> Result<(), DecodeErrors> {
+        let sink = self
+            .raw_planes_sink
+            .as_ref()
+            .expect("copy_raw_planes_for_mcu_stripe called without active sink");
+
+        for (idx, comp) in self.components.iter().enumerate() {
+            if idx >= sink.n_components {
+                break;
+            }
+            let plane_ptr = sink.ptrs[idx];
+            if plane_ptr.is_null() {
+                continue;
+            }
+            let target_stride = sink.target_strides[idx];
+            let target_width = sink.target_widths[idx];
+            let target_height = sink.target_heights[idx];
+
+            let stripe_rows = comp.vertical_sample * DCT_BLOCK_SIZE;
+            let row_start = mcu_stripe_index * stripe_rows;
+            // Clip rows to the caller-provided plane height.
+            if row_start >= target_height {
+                continue;
+            }
+            let rows_to_copy = core::cmp::min(stripe_rows, target_height - row_start);
+
+            let src_stride = comp.width_stride;
+            let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
+
+            for r in 0..rows_to_copy {
+                let src_row_start = r * src_stride;
+                let src_row_end = src_row_start + copy_w;
+                if src_row_end > comp.raw_coeff.len() {
+                    return Err(DecodeErrors::FormatStatic(
+                        "raw_coeff shorter than expected for MCU stripe"
+                    ));
+                }
+                let src = &comp.raw_coeff[src_row_start..src_row_end];
+
+                // SAFETY: `plane_ptr` came from a `&mut [u8]` of length at
+                // least `target_stride * target_height` (validated in
+                // `decode_raw` / `decode_raw_strided`). `(row_start + r) <
+                // target_height` and `copy_w <= target_stride`, so
+                // `dst_offset + copy_w <= target_stride * target_height`.
+                // No other code path borrows the plane buffer while
+                // `raw_planes_sink` is set.
+                unsafe {
+                    let dst_offset = (row_start + r) * target_stride;
+                    let dst = plane_ptr.add(dst_offset);
+                    for (i, sample) in src.iter().enumerate() {
+                        *dst.add(i) = *sample as u8;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Read only headers from a jpeg image buffer
     ///
     /// This allows you to extract important information like
@@ -2171,5 +2606,61 @@ impl ImageInfo {
     #[allow(dead_code)]
     pub(crate) fn set_y(&mut self, sample: u16) {
         self.y_density = sample;
+    }
+}
+
+// SAFETY: `RawPlanesSink` only ever holds raw pointers into caller-owned
+// buffers for the duration of a single `decode_raw` call (which takes
+// `&mut self`). No other code path can observe or alias the pointers, so
+// these auto-trait restorations are defensive — they let `JpegDecoder<T>`
+// retain whatever Send/Sync it would have had without this field, when
+// `T: Send + Sync`.
+unsafe impl Send for RawPlanesSink {}
+unsafe impl Sync for RawPlanesSink {}
+
+/// RAII guard that clears [`JpegDecoder::raw_planes_sink`] when dropped,
+/// including on panic / early `?` returns from inside `decode_raw`.
+pub(crate) struct RawPlanesGuard<T: ZByteReaderTrait> {
+    pub(crate) dec: NonNull<JpegDecoder<T>>
+}
+
+impl<T: ZByteReaderTrait> Drop for RawPlanesGuard<T> {
+    fn drop(&mut self) {
+        // SAFETY: `dec` was created from `&mut *self` inside `decode_raw`
+        // and the guard does not outlive that borrow.
+        unsafe {
+            self.dec.as_mut().raw_planes_sink = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod planar_layout_helpers {
+    use super::{ceil_div, round_up_pow2};
+
+    #[test]
+    fn ceil_div_basic() {
+        assert_eq!(ceil_div(0, 8), 0);
+        assert_eq!(ceil_div(1, 8), 1);
+        assert_eq!(ceil_div(8, 8), 1);
+        assert_eq!(ceil_div(9, 8), 2);
+        assert_eq!(ceil_div(64, 8), 8);
+        assert_eq!(ceil_div(65, 8), 9);
+        assert_eq!(ceil_div(101, 8), 13);
+    }
+
+    #[test]
+    fn round_up_pow2_basic() {
+        assert_eq!(round_up_pow2(0, 8), Some(0));
+        assert_eq!(round_up_pow2(1, 8), Some(8));
+        assert_eq!(round_up_pow2(8, 8), Some(8));
+        assert_eq!(round_up_pow2(9, 8), Some(16));
+        assert_eq!(round_up_pow2(64, 8), Some(64));
+        assert_eq!(round_up_pow2(101, 8), Some(104));
+    }
+
+    #[test]
+    fn round_up_pow2_overflow() {
+        assert_eq!(round_up_pow2(usize::MAX, 8), None);
     }
 }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -1845,7 +1845,7 @@ where
     ///
     ///
     #[allow(clippy::too_many_lines)]
-    pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
+    fn prepare_for_scan_decode(&mut self) -> Result<(), DecodeErrors> {
         // Pull the scan-resume state out into owned locals so the restore
         // below can freely mutate `self`. When headers haven't completed
         // yet, `scan_plan` is `None` and we just run header decoding below.
@@ -2046,17 +2046,6 @@ where
 
         self.ensure_supported_encoding()?;
 
-        let expected_size = self.output_buffer_size().unwrap();
-
-        if out.len() < expected_size {
-            // too small of a size
-            return Err(DecodeErrors::TooSmallOutput(expected_size, out.len()));
-        }
-
-        // ensure we don't touch anyone else's scratch space
-        let out_len = core::cmp::min(out.len(), expected_size);
-        let out = &mut out[0..out_len];
-
         // By default, enable per-row checkpointing only after a previous
         // scan decode attempt has run. Incremental mode opts into the same
         // checkpoints on the first scan attempt so a streaming caller avoids
@@ -2071,10 +2060,13 @@ where
         }
         self.scan_decode_attempted = true;
 
-        let mut output = McuDecodeOutput::Pixels(out);
-        let result = self.decode_mcu_output(&mut output);
+        Ok(())
+    }
 
-        match result {
+    fn decode_mcu_output_with_success_cleanup(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        match self.decode_mcu_output(output) {
             Ok(()) => {
                 // Drop the scan checkpoint so a post-success replay starts
                 // from scan-start with zeroed DC predictors instead of
@@ -2087,7 +2079,9 @@ where
                     state.scan_checkpoint = None;
                     state.progressive_checkpoint = None;
                 }
-                self.pixels_decoded = expected_size;
+                if let Some(pixels) = output.pixels_mut() {
+                    self.pixels_decoded = pixels.len();
+                }
                 if self.is_progressive {
                     self.progressive_displayed_scans = self.progressive_completed_scans;
                 }
@@ -2095,6 +2089,24 @@ where
             }
             Err(e) => Err(e)
         }
+    }
+
+    pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
+        self.prepare_for_scan_decode()?;
+
+        let expected_size = self.output_buffer_size().unwrap();
+
+        if out.len() < expected_size {
+            // too small of a size
+            return Err(DecodeErrors::TooSmallOutput(expected_size, out.len()));
+        }
+
+        // ensure we don't touch anyone else's scratch space
+        let out_len = core::cmp::min(out.len(), expected_size);
+        let out = &mut out[0..out_len];
+
+        let mut output = McuDecodeOutput::Pixels(out);
+        self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
     fn decode_mcu_output(
@@ -2144,6 +2156,17 @@ where
     /// meaningful; trailing padding columns / rows contain
     /// implementation-defined data.
     ///
+    /// # Resumability
+    ///
+    /// On a recoverable EOF (`DecodeErrors::is_recoverable_eof()`) the
+    /// decoder keeps enough state to resume; the caller can grow the input
+    /// stream and call `decode_raw` again with plane buffers sized from the
+    /// same [`planar_layout`](Self::planar_layout).
+    ///
+    /// On success the decoder keeps scan-start replay state, so a later
+    /// `decode_raw` call is well-defined and produces bit-identical planes.
+    /// Replay re-runs entropy decoding from the first SOS.
+    ///
     /// # Examples
     ///
     /// Decode a JPEG into raw YCbCr planes (libjpeg-turbo style) and access
@@ -2190,7 +2213,7 @@ where
     ///   of components.
     /// - Any error from the underlying decode pipeline.
     pub fn decode_raw(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
-        self.decode_headers_internal()?;
+        self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
         if planes.len() != n {
@@ -2228,7 +2251,7 @@ where
             n_components: n
         };
         let mut output = McuDecodeOutput::RawPlanes(raw_planes);
-        self.decode_mcu_output(&mut output)
+        self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
     /// Decode raw planes using caller-supplied row strides.
@@ -2241,6 +2264,17 @@ where
     ///
     /// Only the logical plane area is written. Padding columns in the caller's
     /// stride and trailing DCT rows are left untouched.
+    ///
+    /// # Resumability
+    ///
+    /// On a recoverable EOF (`DecodeErrors::is_recoverable_eof()`) the
+    /// decoder keeps enough state to resume; the caller can grow the input
+    /// stream and call `decode_raw_strided` again with the same plane layout.
+    ///
+    /// On success the decoder keeps scan-start replay state, so a later
+    /// `decode_raw_strided` call is well-defined and produces bit-identical
+    /// logical plane samples. Replay re-runs entropy decoding from the first
+    /// SOS.
     ///
     /// # Examples
     ///
@@ -2294,7 +2328,7 @@ where
     pub fn decode_raw_strided(
         &mut self, planes: &mut [&mut [u8]], strides: &[usize]
     ) -> Result<(), DecodeErrors> {
-        self.decode_headers_internal()?;
+        self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
         if planes.len() != n {
@@ -2346,7 +2380,7 @@ where
             n_components: n
         };
         let mut output = McuDecodeOutput::RawPlanes(raw_planes);
-        self.decode_mcu_output(&mut output)
+        self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
     /// Per-component [`ComponentID`] in declaration order

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -452,7 +452,10 @@ pub(crate) enum McuDecodeOutput<'planes, 'buf> {
 
 impl McuDecodeOutput<'_, '_> {
     pub(crate) const fn is_raw(&self) -> bool {
-        matches!(self, Self::RawPlanes(_))
+        match self {
+            Self::Pixels(_) => false,
+            Self::RawPlanes(_) => true
+        }
     }
 
     pub(crate) fn pixels_mut(&mut self) -> Option<&mut [u8]> {

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -82,13 +82,6 @@ pub struct PlaneInfo {
     pub byte_size:        usize
 }
 
-/// Ceiling division: `ceil(a / b)` without overflow on the addition.
-#[inline]
-fn ceil_div(a: usize, b: usize) -> usize {
-    debug_assert!(b != 0);
-    a / b + usize::from(a % b != 0)
-}
-
 /// Round `n` up to the next multiple of `align` (which must be non-zero).
 /// Returns `None` on overflow.
 #[inline]
@@ -460,11 +453,19 @@ pub struct JpegDecoder<T> {
 
 /// Internal sink for one raw planar decode call.
 ///
-/// Holds owned per-component plane buffers that MCU-stripe copies write into.
-/// After decoding completes, the caller copies from these into its output slices.
+/// Holds raw pointers into the caller-provided plane buffers so that MCU-stripe
+/// processing can write decoded samples directly without an intermediate copy.
+///
+/// # Safety
+/// The pointers are valid for the lifetime of the `decode_raw` / `decode_raw_strided`
+/// call that sets up this sink.  The sink is always cleared (set to `None`) before
+/// those functions return, so the pointers never outlive the caller's slices.
+#[allow(unsafe_code)]
 pub(crate) struct RawPlanesSink {
-    /// Internal plane buffers (one per component, sized to full plane).
-    pub(crate) planes:         Vec<Vec<u8>>,
+    /// Raw pointers into the caller's plane buffers (one per component).
+    pub(crate) ptrs:           [*mut u8; MAX_COMPONENTS],
+    /// Total byte length of each caller buffer.
+    pub(crate) lengths:        [usize; MAX_COMPONENTS],
     /// Bytes between successive destination rows (used for strided output).
     pub(crate) target_strides: [usize; MAX_COMPONENTS],
     /// Maximum bytes to write per destination row.
@@ -474,6 +475,15 @@ pub(crate) struct RawPlanesSink {
     /// Number of valid components.
     pub(crate) n_components:   usize
 }
+
+/// SAFETY: The pointers in `RawPlanesSink` are derived from `&mut [u8]` references
+/// that live on the calling thread's stack.  The sink is only alive for the duration
+/// of a single `decode_raw*` call, never sent across threads.
+#[allow(unsafe_code)]
+unsafe impl Send for RawPlanesSink {}
+/// SAFETY: No shared-mutable state; see `Send` impl above.
+#[allow(unsafe_code)]
+unsafe impl Sync for RawPlanesSink {}
 
 impl<T> JpegDecoder<T>
 where
@@ -1070,8 +1080,8 @@ where
         }
         let mut out = [PlaneInfo::default(); MAX_COMPONENTS];
         for (slot, comp) in out.iter_mut().zip(self.components.iter()) {
-            let comp_w = ceil_div(img_w.checked_mul(comp.horizontal_sample)?, h_max);
-            let comp_h = ceil_div(img_h.checked_mul(comp.vertical_sample)?, v_max);
+            let comp_w = img_w.checked_mul(comp.horizontal_sample)?.div_ceil(h_max);
+            let comp_h = img_h.checked_mul(comp.vertical_sample)?.div_ceil(v_max);
             let stride = round_up_pow2(comp_w, DCT_BLOCK_SIZE)?;
             let allocated_height = round_up_pow2(comp_h, DCT_BLOCK_SIZE)?;
             let byte_size = stride.checked_mul(allocated_height)?;
@@ -2200,27 +2210,32 @@ where
             }
         }
 
-        // Each plane is mutably borrowed for this call; internal buffers
-        // collect the MCU stripe outputs, then are copied to the caller at the end.
+        // Set up the raw-planes sink pointing directly into the caller's slices.
+        // SAFETY: The pointers are derived from the mutable slice references in
+        // `planes`, which are guaranteed to remain valid and exclusively borrowed
+        // for the duration of this call.  The sink is cleared before we return.
+        let mut ptrs = [core::ptr::null_mut(); MAX_COMPONENTS];
+        let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        let mut internal_planes: Vec<Vec<u8>> = Vec::with_capacity(n);
         for i in 0..n {
+            ptrs[i] = planes[i].as_mut_ptr();
+            lengths[i] = planes[i].len();
             target_strides[i] = layout[i].stride;
             target_widths[i] = layout[i].stride;
             target_heights[i] = layout[i].allocated_height;
-            internal_planes.push(vec![0u8; layout[i].byte_size]);
         }
         self.raw_planes_sink = Some(RawPlanesSink {
-            planes: internal_planes,
+            ptrs,
+            lengths,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
         });
 
-        // Raw mode writes into the internal plane buffers; downstream pixel
+        // Raw mode writes directly into the caller's buffers; downstream pixel
         // bookkeeping only needs a placeholder slice.
         let mut sink: [u8; 0] = [];
         let result = if self.is_arithmetic {
@@ -2240,13 +2255,8 @@ where
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
         };
 
-        // Copy from internal buffers to the caller's output slices.
-        if let Some(raw_sink) = self.raw_planes_sink.take() {
-            for (i, internal) in raw_sink.planes.into_iter().enumerate() {
-                let dst = &mut planes[i][..internal.len()];
-                dst.copy_from_slice(&internal);
-            }
-        }
+        // Clear the sink so pointers don't outlive the caller's slices.
+        self.raw_planes_sink = None;
 
         result
     }
@@ -2347,20 +2357,24 @@ where
             }
         }
 
-        // Each plane is mutably borrowed for this call; internal buffers
-        // collect the MCU stripe outputs, then are copied to the caller at the end.
+        // Set up the raw-planes sink pointing directly into the caller's slices.
+        // SAFETY: Same guarantees as `decode_raw` — pointers derived from exclusive
+        // mutable borrows, valid for the entire call, cleared before return.
+        let mut ptrs = [core::ptr::null_mut(); MAX_COMPONENTS];
+        let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        let mut internal_planes: Vec<Vec<u8>> = Vec::with_capacity(n);
         for i in 0..n {
+            ptrs[i] = planes[i].as_mut_ptr();
+            lengths[i] = planes[i].len();
             target_strides[i] = strides[i];
             target_widths[i] = layout[i].width;
             target_heights[i] = layout[i].height;
-            internal_planes.push(vec![0u8; strides[i] * layout[i].height]);
         }
         self.raw_planes_sink = Some(RawPlanesSink {
-            planes: internal_planes,
+            ptrs,
+            lengths,
             target_strides,
             target_widths,
             target_heights,
@@ -2385,20 +2399,8 @@ where
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
         };
 
-        // Copy from internal buffers to the caller's output slices.
-        // Only copy logical width per row to preserve caller's padding bytes.
-        if let Some(raw_sink) = self.raw_planes_sink.take() {
-            for (i, internal) in raw_sink.planes.into_iter().enumerate() {
-                let stride = raw_sink.target_strides[i];
-                let width = raw_sink.target_widths[i];
-                let height = raw_sink.target_heights[i];
-                for y in 0..height {
-                    let off = y * stride;
-                    planes[i][off..off + width]
-                        .copy_from_slice(&internal[off..off + width]);
-                }
-            }
-        }
+        // Clear the sink so pointers don't outlive the caller's slices.
+        self.raw_planes_sink = None;
 
         result
     }
@@ -2430,6 +2432,7 @@ where
     ///
     /// The IDCT outputs are already clamped to `[0, 255]` so the `i16 -> u8`
     /// truncation here is exact.
+    #[allow(unsafe_code)]
     pub(crate) fn copy_raw_planes_for_mcu_stripe(
         &mut self, mcu_stripe_index: usize
     ) -> Result<(), DecodeErrors> {
@@ -2457,7 +2460,8 @@ where
             let src_stride = comp.width_stride;
             let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
 
-            let plane = &mut sink.planes[idx];
+            let ptr = sink.ptrs[idx];
+            let len = sink.lengths[idx];
 
             for r in 0..rows_to_copy {
                 let src_row_start = r * src_stride;
@@ -2470,11 +2474,18 @@ where
                 let src = &comp.raw_coeff[src_row_start..src_row_end];
 
                 let dst_offset = (row_start + r) * target_stride;
-                let dst = &mut plane[dst_offset..dst_offset + copy_w];
-                for (i, sample) in src.iter().enumerate() {
-                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                    {
-                        dst[i] = *sample as u8;
+                debug_assert!(dst_offset + copy_w <= len);
+                // SAFETY: `ptr` points into the caller's `&mut [u8]` which is
+                // guaranteed to be at least `len` bytes.  The bounds check above
+                // (via `target_height` / `target_stride` validation in decode_raw*)
+                // ensures `dst_offset + copy_w <= len`.
+                unsafe {
+                    let dst = core::slice::from_raw_parts_mut(ptr.add(dst_offset), copy_w);
+                    for (i, sample) in src.iter().enumerate() {
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        {
+                            dst[i] = *sample as u8;
+                        }
                     }
                 }
             }
@@ -2702,17 +2713,17 @@ impl ImageInfo {
 
 #[cfg(test)]
 mod planar_layout_helpers {
-    use super::{ceil_div, round_up_pow2};
+    use super::round_up_pow2;
 
     #[test]
-    fn ceil_div_basic() {
-        assert_eq!(ceil_div(0, 8), 0);
-        assert_eq!(ceil_div(1, 8), 1);
-        assert_eq!(ceil_div(8, 8), 1);
-        assert_eq!(ceil_div(9, 8), 2);
-        assert_eq!(ceil_div(64, 8), 8);
-        assert_eq!(ceil_div(65, 8), 9);
-        assert_eq!(ceil_div(101, 8), 13);
+    fn div_ceil_basic() {
+        assert_eq!(0usize.div_ceil(8), 0);
+        assert_eq!(1usize.div_ceil(8), 1);
+        assert_eq!(8usize.div_ceil(8), 1);
+        assert_eq!(9usize.div_ceil(8), 2);
+        assert_eq!(64usize.div_ceil(8), 8);
+        assert_eq!(65usize.div_ceil(8), 9);
+        assert_eq!(101usize.div_ceil(8), 13);
     }
 
     #[test]

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -2144,7 +2144,7 @@ where
     /// decoder.decode_headers().unwrap();
     ///
     /// let layout = decoder.planar_layout().unwrap();
-    /// let n = decoder.num_components();
+    /// let n = decoder.num_components().unwrap();
     /// let mut buffers: Vec<Vec<u8>> = (0..n)
     ///     .map(|i| vec![0u8; layout[i].byte_size])
     ///     .collect();
@@ -2250,7 +2250,7 @@ where
     /// decoder.decode_headers().unwrap();
     ///
     /// let layout = decoder.planar_layout().unwrap();
-    /// let n = decoder.num_components();
+    /// let n = decoder.num_components().unwrap();
     ///
     /// // Use a 64-byte aligned stride (common for GPU upload).
     /// let strides: Vec<usize> = (0..n)

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -653,13 +653,14 @@ where
     /// needed for final samples; their rows are still pulled sequentially, but
     /// compressed input consumption is not row-streaming.
     ///
-    /// Each stride must be at least the corresponding logical plane width.
-    /// Each plane must be large enough for
-    /// `stride * vertical_sampling_factor * 8` bytes. The returned
-    /// `rows_written` count identifies the meaningful prefix; the final iMCU
-    /// row is clipped to the logical component height. Components that exhaust
-    /// their logical height before other components report zero rows on later
-    /// calls.
+    /// Each stride must be at least the corresponding logical plane width. For
+    /// a component that will return `rows` rows, its plane must contain at least
+    /// `(rows - 1) * stride + width` bytes, or zero bytes when `rows == 0`.
+    /// Padding is addressable only between logical rows; no padding is required
+    /// after the final row. The returned `rows_written` count identifies the
+    /// meaningful prefix; the final iMCU row is clipped to the logical component
+    /// height. Components that exhaust their logical height before other
+    /// components report zero rows on later calls.
     ///
     /// A recoverable input suspension returns [`RawImcuRowStatus::NeedMoreInput`]
     /// and leaves caller planes untouched. Expose more input through the same
@@ -841,11 +842,16 @@ where
             };
             let row_start = self.decoder.raw_pull_state.next_stripe * stripe_rows;
             let rows = layout[i].height.saturating_sub(row_start).min(stripe_rows);
-            let need = strides[i]
-                .checked_mul(rows)
-                .ok_or(DecodeErrors::FormatStatic(
-                    "raw iMCU-row plane size overflow"
-                ))?;
+            let need = if rows == 0 {
+                0
+            } else {
+                (rows - 1)
+                    .checked_mul(strides[i])
+                    .and_then(|offset| offset.checked_add(layout[i].width))
+                    .ok_or(DecodeErrors::FormatStatic(
+                        "raw iMCU-row plane size overflow",
+                    ))?
+            };
             if planes[i].len() < need {
                 return Err(DecodeErrors::TooSmallOutput(need, planes[i].len()));
             }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -15,7 +15,6 @@ use alloc::vec::Vec;
 use alloc::sync::Arc;
 use alloc::{format, vec};
 use core::num::NonZeroU32;
-use core::ptr::NonNull;
 
 use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::colorspace::ColorSpace;
@@ -460,16 +459,19 @@ pub struct JpegDecoder<T> {
 }
 
 /// Internal sink for one raw planar decode call.
+///
+/// Holds owned per-component plane buffers that MCU-stripe copies write into.
+/// After decoding completes, the caller copies from these into its output slices.
 pub(crate) struct RawPlanesSink {
-    /// Per-component plane base pointer (only `0..n_components` are valid).
-    pub(crate) ptrs:           [*mut u8; MAX_COMPONENTS],
-    /// Bytes between successive destination rows.
+    /// Internal plane buffers (one per component, sized to full plane).
+    pub(crate) planes:         Vec<Vec<u8>>,
+    /// Bytes between successive destination rows (used for strided output).
     pub(crate) target_strides: [usize; MAX_COMPONENTS],
     /// Maximum bytes to write per destination row.
     pub(crate) target_widths:  [usize; MAX_COMPONENTS],
-    /// Number of destination rows the caller's buffer can accept.
+    /// Number of destination rows per plane.
     pub(crate) target_heights: [usize; MAX_COMPONENTS],
-    /// Number of valid components in `ptrs`.
+    /// Number of valid components.
     pub(crate) n_components:   usize
 }
 
@@ -2180,33 +2182,30 @@ where
             }
         }
 
-        // Each plane is mutably borrowed for this call; the guard clears the
-        // raw pointers before returning.
-        let mut ptrs: [*mut u8; MAX_COMPONENTS] = [core::ptr::null_mut(); MAX_COMPONENTS];
+        // Each plane is mutably borrowed for this call; internal buffers
+        // collect the MCU stripe outputs, then are copied to the caller at the end.
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        for (i, plane) in planes.iter_mut().enumerate() {
-            ptrs[i] = plane.as_mut_ptr();
+        let mut internal_planes: Vec<Vec<u8>> = Vec::with_capacity(n);
+        for i in 0..n {
             target_strides[i] = layout[i].stride;
             target_widths[i] = layout[i].stride;
             target_heights[i] = layout[i].allocated_height;
+            internal_planes.push(vec![0u8; layout[i].byte_size]);
         }
         self.raw_planes_sink = Some(RawPlanesSink {
-            ptrs,
+            planes: internal_planes,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
         });
-        let _guard = RawPlanesGuard {
-            dec: NonNull::from(&mut *self)
-        };
 
-        // Raw mode writes into the plane sink; downstream pixel bookkeeping
-        // only needs a placeholder slice.
+        // Raw mode writes into the internal plane buffers; downstream pixel
+        // bookkeeping only needs a placeholder slice.
         let mut sink: [u8; 0] = [];
-        if self.is_arithmetic {
+        let result = if self.is_arithmetic {
             #[cfg(feature = "arith")]
             {
                 if self.is_progressive {
@@ -2221,8 +2220,17 @@ where
             self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
         } else {
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
+        };
+
+        // Copy from internal buffers to the caller's output slices.
+        if let Some(raw_sink) = self.raw_planes_sink.take() {
+            for (i, internal) in raw_sink.planes.into_iter().enumerate() {
+                let dst = &mut planes[i][..internal.len()];
+                dst.copy_from_slice(&internal);
+            }
         }
-        // Guard clears `raw_planes_sink` on drop.
+
+        result
     }
 
     /// Decode raw planes using caller-supplied row strides.
@@ -2309,31 +2317,28 @@ where
             }
         }
 
-        // Each plane is mutably borrowed for this call; the guard clears the
-        // raw pointers before returning.
-        let mut ptrs: [*mut u8; MAX_COMPONENTS] = [core::ptr::null_mut(); MAX_COMPONENTS];
+        // Each plane is mutably borrowed for this call; internal buffers
+        // collect the MCU stripe outputs, then are copied to the caller at the end.
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        for (i, plane) in planes.iter_mut().enumerate() {
-            ptrs[i] = plane.as_mut_ptr();
+        let mut internal_planes: Vec<Vec<u8>> = Vec::with_capacity(n);
+        for i in 0..n {
             target_strides[i] = strides[i];
             target_widths[i] = layout[i].width;
             target_heights[i] = layout[i].height;
+            internal_planes.push(vec![0u8; strides[i] * layout[i].height]);
         }
         self.raw_planes_sink = Some(RawPlanesSink {
-            ptrs,
+            planes: internal_planes,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
         });
-        let _guard = RawPlanesGuard {
-            dec: NonNull::from(&mut *self)
-        };
 
         let mut sink: [u8; 0] = [];
-        if self.is_arithmetic {
+        let result = if self.is_arithmetic {
             #[cfg(feature = "arith")]
             {
                 if self.is_progressive {
@@ -2348,7 +2353,24 @@ where
             self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
         } else {
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
+        };
+
+        // Copy from internal buffers to the caller's output slices.
+        // Only copy logical width per row to preserve caller's padding bytes.
+        if let Some(raw_sink) = self.raw_planes_sink.take() {
+            for (i, internal) in raw_sink.planes.into_iter().enumerate() {
+                let stride = raw_sink.target_strides[i];
+                let width = raw_sink.target_widths[i];
+                let height = raw_sink.target_heights[i];
+                for y in 0..height {
+                    let off = y * stride;
+                    planes[i][off..off + width]
+                        .copy_from_slice(&internal[off..off + width]);
+                }
+            }
         }
+
+        result
     }
 
     /// Per-component [`ComponentID`] in declaration order
@@ -2383,16 +2405,12 @@ where
     ) -> Result<(), DecodeErrors> {
         let sink = self
             .raw_planes_sink
-            .as_ref()
+            .as_mut()
             .expect("copy_raw_planes_for_mcu_stripe called without active sink");
 
         for (idx, comp) in self.components.iter().enumerate() {
             if idx >= sink.n_components {
                 break;
-            }
-            let plane_ptr = sink.ptrs[idx];
-            if plane_ptr.is_null() {
-                continue;
             }
             let target_stride = sink.target_strides[idx];
             let target_width = sink.target_widths[idx];
@@ -2400,7 +2418,7 @@ where
 
             let stripe_rows = comp.vertical_sample * DCT_BLOCK_SIZE;
             let row_start = mcu_stripe_index * stripe_rows;
-            // Clip rows to the caller-provided plane height.
+            // Clip rows to the plane height.
             if row_start >= target_height {
                 continue;
             }
@@ -2408,6 +2426,8 @@ where
 
             let src_stride = comp.width_stride;
             let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
+
+            let plane = &mut sink.planes[idx];
 
             for r in 0..rows_to_copy {
                 let src_row_start = r * src_stride;
@@ -2419,22 +2439,12 @@ where
                 }
                 let src = &comp.raw_coeff[src_row_start..src_row_end];
 
-                // SAFETY: `plane_ptr` came from a `&mut [u8]` of length at
-                // least `target_stride * target_height` (validated in
-                // `decode_raw` / `decode_raw_strided`). `(row_start + r) <
-                // target_height` and `copy_w <= target_stride`, so
-                // `dst_offset + copy_w <= target_stride * target_height`.
-                // No other code path borrows the plane buffer while
-                // `raw_planes_sink` is set.
-                unsafe {
-                    let dst_offset = (row_start + r) * target_stride;
-                    let dst = plane_ptr.add(dst_offset);
-                    for (i, sample) in src.iter().enumerate() {
-                        // Post-IDCT samples are already clamped to [0, 255].
-                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                        {
-                            *dst.add(i) = *sample as u8;
-                        }
+                let dst_offset = (row_start + r) * target_stride;
+                let dst = &mut plane[dst_offset..dst_offset + copy_w];
+                for (i, sample) in src.iter().enumerate() {
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    {
+                        dst[i] = *sample as u8;
                     }
                 }
             }
@@ -2657,31 +2667,6 @@ impl ImageInfo {
     #[allow(dead_code)]
     pub(crate) fn set_y(&mut self, sample: u16) {
         self.y_density = sample;
-    }
-}
-
-// SAFETY: `RawPlanesSink` only ever holds raw pointers into caller-owned
-// buffers for the duration of a single `decode_raw` call (which takes
-// `&mut self`). No other code path can observe or alias the pointers, so
-// these auto-trait restorations are defensive — they let `JpegDecoder<T>`
-// retain whatever Send/Sync it would have had without this field, when
-// `T: Send + Sync`.
-unsafe impl Send for RawPlanesSink {}
-unsafe impl Sync for RawPlanesSink {}
-
-/// RAII guard that clears [`JpegDecoder::raw_planes_sink`] when dropped,
-/// including on panic / early `?` returns from inside `decode_raw`.
-pub(crate) struct RawPlanesGuard<T: ZByteReaderTrait> {
-    pub(crate) dec: NonNull<JpegDecoder<T>>
-}
-
-impl<T: ZByteReaderTrait> Drop for RawPlanesGuard<T> {
-    fn drop(&mut self) {
-        // SAFETY: `dec` was created from `&mut *self` inside `decode_raw`
-        // and the guard does not outlive that borrow.
-        unsafe {
-            self.dec.as_mut().raw_planes_sink = None;
-        }
     }
 }
 

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -206,17 +206,16 @@ pub(crate) fn parse_dac<T: ZByteReaderTrait>(
 where
 {
     with_marker_body(decoder, |decoder, mut cursor| {
+        if cursor.body().len() % 2 != 0 {
+            return Err(DecodeErrors::FormatStatic(
+                "Bogus (odd) Arithmetic-coding conditioning segment length"
+            ));
+        }
         // Validate everything before committing: collect new entries into a
         // local Vec and apply them only when the whole body parses cleanly.
         enum DacEntry {
             Dc { index: usize, l: u8, u: u8 },
             Ac { index: usize, kx: u8 }
-        }
-
-        if cursor.body().len() % 2 != 0 {
-            return Err(DecodeErrors::FormatStatic(
-                "Bogus (odd) Arithmetic-coding conditioning segment length"
-            ));
         }
         let mut entries: Vec<DacEntry> = Vec::with_capacity(cursor.body().len() / 2);
         while cursor.remaining() >= 2 {

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -416,6 +416,12 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
 
         trace!("Image components : {num_components}");
 
+        if usize::from(num_components) > MAX_COMPONENTS {
+            return Err(DecodeErrors::SofError(format!(
+                "Invalid number of components in start of frame {num_components}, expected in range 1..={MAX_COMPONENTS}"
+            )));
+        }
+
         // Build components list locally; commit only when the whole body parses.
         let mut components = Vec::with_capacity(num_components as usize);
         let mut temp = [0; 3];

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -206,16 +206,17 @@ pub(crate) fn parse_dac<T: ZByteReaderTrait>(
 where
 {
     with_marker_body(decoder, |decoder, mut cursor| {
-        if cursor.body().len() % 2 != 0 {
-            return Err(DecodeErrors::FormatStatic(
-                "Bogus (odd) Arithmetic-coding conditioning segment length"
-            ));
-        }
         // Validate everything before committing: collect new entries into a
         // local Vec and apply them only when the whole body parses cleanly.
         enum DacEntry {
             Dc { index: usize, l: u8, u: u8 },
             Ac { index: usize, kx: u8 }
+        }
+
+        if cursor.body().len() % 2 != 0 {
+            return Err(DecodeErrors::FormatStatic(
+                "Bogus (odd) Arithmetic-coding conditioning segment length"
+            ));
         }
         let mut entries: Vec<DacEntry> = Vec::with_capacity(cursor.body().len() / 2);
         while cursor.remaining() >= 2 {

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -277,7 +277,7 @@
 )]
 // no_std compatibility
 #![deny(clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
-#![cfg_attr(not(any(feature = "x86", feature = "neon")), forbid(unsafe_code))]
+#![cfg_attr(not(any(feature = "x86", feature = "neon")), deny(unsafe_code))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "portable_simd", feature(portable_simd))]
 #![macro_use]

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -277,7 +277,7 @@
 )]
 // no_std compatibility
 #![deny(clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
-#![cfg_attr(not(any(feature = "x86", feature = "neon")), deny(unsafe_code))]
+#![cfg_attr(not(any(feature = "x86", feature = "neon")), forbid(unsafe_code))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "portable_simd", feature(portable_simd))]
 #![macro_use]
@@ -286,8 +286,8 @@ extern crate core;
 
 pub use zune_core;
 
-pub use crate::components::{ComponentID, SampleRatios};
-pub use crate::decoder::{ImageInfo, JpegDecoder, PlaneInfo};
+pub use crate::components::SampleRatios;
+pub use crate::decoder::{ImageInfo, JpegDecoder, PlaneInfo, RawDecodeSession};
 pub use crate::marker::Marker;
 pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -287,7 +287,9 @@ extern crate core;
 pub use zune_core;
 
 pub use crate::components::SampleRatios;
-pub use crate::decoder::{ImageInfo, JpegDecoder, PlaneInfo, RawDecodeSession};
+pub use crate::decoder::{
+    ImageInfo, JpegDecoder, PlaneInfo, RawDecodeSession, RawImcuRowStatus
+};
 pub use crate::marker::Marker;
 pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -286,8 +286,8 @@ extern crate core;
 
 pub use zune_core;
 
-pub use crate::components::SampleRatios;
-pub use crate::decoder::{ImageInfo, JpegDecoder};
+pub use crate::components::{ComponentID, SampleRatios};
+pub use crate::decoder::{ImageInfo, JpegDecoder, PlaneInfo};
 pub use crate::marker::Marker;
 pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -245,45 +245,47 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
 
         'sos: loop {
+            let scan_mcu_height = if all_components_in_first_scan {
+                mcu_height
+            } else {
+                let z_scans = &self.z_order[..usize::from(self.num_scans)];
+                z_scans
+                    .iter()
+                    .map(|&component_index| {
+                        let component = &self.components[component_index];
+                        (self.info.height as usize * component.vertical_sample)
+                            .div_ceil(self.v_max * 8)
+                    })
+                    .min()
+                    .unwrap_or(mcu_height)
+            };
+
             trace!(
                 "Baseline decoding of components: {:?}",
                 &self.z_order[..usize::from(self.num_scans)]
             );
 
-            trace!("Decoding MCU width: {mcu_width}, height: {mcu_height}");
+            trace!("Decoding MCU width: {mcu_width}, height: {scan_mcu_height}");
 
-            // Consume the resume position once into locals so later SOS scans
-            // start at row 0, and so we don't mutate the loop's range bound
-            // from inside the loop below.
-            let current_resume_row = resume_row;
-            let current_resume_col = resume_col;
+            let scan_start_row = resume_row;
+            let scan_start_col = resume_col;
             resume_row = 0;
             resume_col = 0;
 
-            let scan_du_height = if all_components_in_first_scan {
-                mcu_height
-            } else {
-                let k = self.z_order.first().copied().unwrap_or(0);
-                if let Some(comp) = self.components.get(k) {
-                    (self.info.height as usize * comp.vertical_sample).div_ceil(self.v_max * 8)
-                } else {
-                    mcu_height
-                }
-            };
-
             let mut cancel = self.cancel_debounced(mcu_width);
-            for i in current_resume_row..scan_du_height {
-                let start_col = if i == current_resume_row {
-                    current_resume_col
-                } else {
-                    0
-                };
+            for i in scan_start_row..scan_mcu_height {
+                let start_col = if i == scan_start_row { scan_start_col } else { 0 };
+                if cancel.is_cancelled() {
+                    return Err(DecodeErrors::Cancelled);
+                }
                 if stream.overread_by() > 0 {
                     if self.scan_eof_is_error() {
                         return Err(DecodeErrors::ExhaustedData);
                     }
                     if all_components_in_first_scan {
-                        if let Some(remaining) = pixels.get_mut(pixels_written..) {
+                        if let Some(remaining) =
+                            output.pixels_mut().and_then(|pixels| pixels.get_mut(pixels_written..))
+                        {
                             remaining.fill(128);
                         }
                         return Ok(());
@@ -365,20 +367,27 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     Err(e) if e.is_recoverable_eof() && !self.scan_eof_is_error() => {
                         error!("{e}");
                         if all_components_in_first_scan {
-                            self.post_process(
-                                pixels,
-                                i,
-                                mcu_height,
-                                width,
-                                padded_width,
-                                &mut pixels_written,
-                                &mut upsampler_scratch_space,
-                            )?;
-                            self.pixels_decoded = pixels_written;
-                            if let Some(remaining) = pixels.get_mut(pixels_written..) {
-                                remaining.fill(128);
+                            match output {
+                                McuDecodeOutput::Pixels(pixels) => {
+                                    self.post_process(
+                                        pixels,
+                                        i,
+                                        mcu_height,
+                                        width,
+                                        padded_width,
+                                        &mut pixels_written,
+                                        &mut upsampler_scratch_space,
+                                    )?;
+                                    self.pixels_decoded = pixels_written;
+                                    if let Some(remaining) = pixels.get_mut(pixels_written..) {
+                                        remaining.fill(128);
+                                    }
+                                }
+                                McuDecodeOutput::RawPlanes(raw_planes) => {
+                                    self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                                }
                             }
-                        } else {
+                        } else if let Some(pixels) = output.pixels_mut() {
                             pixels.fill(128);
                         }
                         return Ok(());

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -153,15 +153,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // must not be re-zeroed. On a fresh decode they are (re-)allocated.
         let resuming = self.scan_checkpoint().is_some();
 
+        let raw_mode = self.raw_planes_sink.is_some();
+
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
             //
             // For special colorspaces i.e YCCK and CMYK, just allocate all of the needed
             // components.
-            if min(
-                self.options.jpeg_get_out_colorspace().num_components() - 1,
-                pos,
-            ) == pos
+            //
+            // Raw output needs every component regardless of output colorspace.
+            if raw_mode
+                || min(
+                    self.options.jpeg_get_out_colorspace().num_components() - 1,
+                    pos,
+                ) == pos
                 || comp_len == 4
             // Special colorspace
             {
@@ -382,16 +387,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // process that width up until it's impossible. This is faster than allocation the
                 // full components, which we skipped earlier.
                 if all_components_in_first_scan {
-                    self.post_process(
-                        pixels,
-                        i,
-                        mcu_height,
-                        width,
-                        padded_width,
-                        &mut pixels_written,
-                        &mut upsampler_scratch_space,
-                    )?;
-                    self.pixels_decoded = pixels_written;
+                    if self.raw_planes_sink.is_some() {
+                        self.copy_raw_planes_for_mcu_stripe(i)?;
+                    } else {
+                        self.post_process(
+                            pixels,
+                            i,
+                            mcu_height,
+                            width,
+                            padded_width,
+                            &mut pixels_written,
+                            &mut upsampler_scratch_space,
+                        )?;
+                        self.pixels_decoded = pixels_written;
+                    }
                     // This row's coefficient buffers can be reused next, so
                     // any checkpoint inside the row is no longer valid.
                     self.invalidate_scan_checkpoint();
@@ -569,12 +578,17 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
 
+        let raw_mode = self.raw_planes_sink.is_some();
+
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Mark only needed components for computing output colors.
-            comp.needed = min(
-                self.options.jpeg_get_out_colorspace().num_components() - 1,
-                pos,
-            ) == pos
+            //
+            // Raw output needs every component regardless of output colorspace.
+            comp.needed = raw_mode
+                || min(
+                    self.options.jpeg_get_out_colorspace().num_components() - 1,
+                    pos,
+                ) == pos
                 || self.input_colorspace == ColorSpace::YCCK
                 || self.input_colorspace == ColorSpace::CMYK;
         }
@@ -611,15 +625,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             // process that whole stripe of MCUs
-            self.post_process(
-                pixels,
-                i,
-                mcu_height,
-                width,
-                padded_width,
-                &mut pixels_written,
-                &mut upsampler_scratch_space,
-            )?;
+            if self.raw_planes_sink.is_some() {
+                self.copy_raw_planes_for_mcu_stripe(i)?;
+            } else {
+                self.post_process(
+                    pixels,
+                    i,
+                    mcu_height,
+                    width,
+                    padded_width,
+                    &mut pixels_written,
+                    &mut upsampler_scratch_space,
+                )?;
+            }
         }
 
         return Ok(());

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -248,16 +248,13 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             let scan_mcu_height = if all_components_in_first_scan {
                 mcu_height
             } else {
-                let z_scans = &self.z_order[..usize::from(self.num_scans)];
-                z_scans
-                    .iter()
-                    .map(|&component_index| {
-                        let component = &self.components[component_index];
-                        (self.info.height as usize * component.vertical_sample)
-                            .div_ceil(self.v_max * 8)
-                    })
-                    .min()
-                    .unwrap_or(mcu_height)
+                let component_index = self.z_order.first().copied().unwrap_or(0);
+                if let Some(component) = self.components.get(component_index) {
+                    (self.info.height as usize * component.vertical_sample)
+                        .div_ceil(self.v_max * 8)
+                } else {
+                    mcu_height
+                }
             };
 
             trace!(

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -392,9 +392,37 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     Err(e) => return Err(e)
                 };
 
+                // A pull request must not publish a row assembled after the
+                // entropy reader exhausted visible input.
+                if output.requested_raw_stripe().is_some() && stream.overread_by() > 0 {
+                    return Err(DecodeErrors::ExhaustedData);
+                }
+                if output.requested_raw_stripe().is_some()
+                    && matches!(terminate, McuContinuation::Terminate)
+                    && !*stream.seen_eoi()
+                {
+                    return Err(DecodeErrors::ExhaustedData);
+                }
+
                 // process that width up until it's impossible. This is faster than allocation the
                 // full components, which we skipped earlier.
                 if all_components_in_first_scan {
+                    let pull_row_ready = output.requested_raw_stripe().is_some();
+                    if pull_row_ready {
+                        let dc_predictions = core::array::from_fn(|idx| {
+                            self.components
+                                .get(idx)
+                                .map_or((0, 0), |component| (component.dc_pred, component.dc_diff))
+                        });
+                        self.checkpoint_scan_with_bitstream(
+                            i + 1,
+                            0,
+                            pixels_written,
+                            dc_predictions,
+                            stream.snapshot_state()
+                        )?;
+                    }
+
                     match output {
                         McuDecodeOutput::Pixels(pixels) => {
                             self.post_process(
@@ -411,6 +439,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         McuDecodeOutput::RawPlanes(raw_planes) => {
                             self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
                         }
+                    }
+                    if pull_row_ready {
+                        return Ok(());
                     }
                     // This row's coefficient buffers can be reused next, so
                     // any checkpoint inside the row is no longer valid.
@@ -561,6 +592,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         trace!("Finished decoding image");
 
+        output.mark_raw_source_complete();
+
         Ok(())
     }
 
@@ -606,10 +639,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         let mut pixels_written = 0;
-        let mut cancel = self.cancel_debounced(self.mcu_x);
+        let stripe_start = output.requested_raw_stripe().unwrap_or(0);
+        let stripe_end = if output.requested_raw_stripe().is_some() {
+            core::cmp::min(stripe_start + 1, mcu_height)
+        } else {
+            mcu_height
+        };
 
         // dequantize and idct have been performed, only color convert.
-        for i in 0..mcu_height {
+        let mut cancel = self.cancel_debounced(self.mcu_x);
+        for i in stripe_start..stripe_end {
             if cancel.is_cancelled() {
                 return Err(DecodeErrors::Cancelled);
             }
@@ -653,7 +692,18 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
         }
 
+        output.mark_raw_source_complete();
+
         return Ok(());
+    }
+
+    pub(crate) fn render_buffered_baseline_raw_stripe(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        let block = core::mem::take(&mut self.progressive_mcus_buffer);
+        let result = self.finish_baseline_decoding(&block, 0, output);
+        self.progressive_mcus_buffer = block;
+        result
     }
 
     fn decode_mcu_width<const PROGRESSIVE: bool, B: BitStream>(

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -70,9 +70,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // `decode_into` retries, which is what lets scan checkpoints stay
         // allocation-free.
         let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
-        let result =
-            self.decode_mcu_ycbcr_baseline_inner::<B>(output, &mut progressive_mcus);
+        let mut upsampler_scratch = core::mem::take(&mut self.upsampler_scratch);
+        let result = self.decode_mcu_ycbcr_baseline_inner::<B>(
+            output,
+            &mut progressive_mcus,
+            &mut upsampler_scratch,
+        );
         self.progressive_mcus_buffer = progressive_mcus;
+        self.upsampler_scratch = upsampler_scratch;
         result
     }
 
@@ -93,7 +98,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[inline(never)]
     fn decode_mcu_ycbcr_baseline_inner<B: BitStream>(
         &mut self, output: &mut McuDecodeOutput<'_, '_>,
-        progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS]
+        progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS], upsampler_scratch_space: &mut Vec<i16>,
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
 
@@ -233,7 +238,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             stream.restore_snapshot(checkpoint.bitstream_state);
         }
 
-        let is_hv = usize::from(self.is_interleaved);
+        let is_hv = usize::from(self.is_interleaved && !raw_mode);
         let upsampler_scratch_size = is_hv
             * self
                 .components
@@ -242,7 +247,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 .max()
                 .unwrap_or(0)
             * 8;
-        let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
+        upsampler_scratch_space.clear();
+        upsampler_scratch_space.resize(upsampler_scratch_size, 0);
 
         'sos: loop {
             let scan_mcu_height = if all_components_in_first_scan {
@@ -373,7 +379,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                         width,
                                         padded_width,
                                         &mut pixels_written,
-                                        &mut upsampler_scratch_space,
+                                        upsampler_scratch_space,
                                     )?;
                                     self.pixels_decoded = pixels_written;
                                     if let Some(remaining) = pixels.get_mut(pixels_written..) {
@@ -432,7 +438,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 width,
                                 padded_width,
                                 &mut pixels_written,
-                                &mut upsampler_scratch_space,
+                                upsampler_scratch_space,
                             )?;
                             self.pixels_decoded = pixels_written;
                         }
@@ -609,7 +615,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mcu_height = self.mcu_y;
 
         // Size of our output image(width*height)
-        let is_hv = usize::from(self.is_interleaved);
+        let raw_mode = output.is_raw();
+        let is_hv = usize::from(self.is_interleaved && !raw_mode);
         let upsampler_scratch_size = is_hv
             * self
                 .components
@@ -622,8 +629,6 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let padded_width = calculate_padded_width(width, self.info.sample_ratio);
 
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
-
-        let raw_mode = output.is_raw();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Mark only needed components for computing output colors.

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -17,7 +17,7 @@ use zune_core::log::{error, trace, warn};
 
 use crate::bitstream::BitStream;
 use crate::components::SampleRatios;
-use crate::decoder::{HeaderAppendStateSnapshot, MAX_COMPONENTS};
+use crate::decoder::{HeaderAppendStateSnapshot, McuDecodeOutput, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
 use crate::marker::Marker;
 use crate::mcu_prog::get_marker;
@@ -62,7 +62,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     ///
     /// This is the main decoder loop for the library, the hot path.
     pub(crate) fn decode_mcu_ycbcr_baseline<B: BitStream>(
-        &mut self, pixels: &mut [u8],
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         // Move the persistent multi-SOS coefficient buffer out of `self` so
         // the inner decoder can borrow it mutably while still calling methods
@@ -70,7 +70,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // `decode_into` retries, which is what lets scan checkpoints stay
         // allocation-free.
         let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
-        let result = self.decode_mcu_ycbcr_baseline_inner::<B>(pixels, &mut progressive_mcus);
+        let result =
+            self.decode_mcu_ycbcr_baseline_inner::<B>(output, &mut progressive_mcus);
         self.progressive_mcus_buffer = progressive_mcus;
         result
     }
@@ -91,7 +92,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     )]
     #[inline(never)]
     fn decode_mcu_ycbcr_baseline_inner<B: BitStream>(
-        &mut self, pixels: &mut [u8], progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS],
+        &mut self, output: &mut McuDecodeOutput<'_, '_>,
+        progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
 
@@ -153,7 +155,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // must not be re-zeroed. On a fresh decode they are (re-)allocated.
         let resuming = self.scan_checkpoint().is_some();
 
-        let raw_mode = self.raw_planes_sink.is_some();
+        let raw_mode = output.is_raw();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
@@ -387,19 +389,22 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // process that width up until it's impossible. This is faster than allocation the
                 // full components, which we skipped earlier.
                 if all_components_in_first_scan {
-                    if self.raw_planes_sink.is_some() {
-                        self.copy_raw_planes_for_mcu_stripe(i)?;
-                    } else {
-                        self.post_process(
-                            pixels,
-                            i,
-                            mcu_height,
-                            width,
-                            padded_width,
-                            &mut pixels_written,
-                            &mut upsampler_scratch_space,
-                        )?;
-                        self.pixels_decoded = pixels_written;
+                    match output {
+                        McuDecodeOutput::Pixels(pixels) => {
+                            self.post_process(
+                                pixels,
+                                i,
+                                mcu_height,
+                                width,
+                                padded_width,
+                                &mut pixels_written,
+                                &mut upsampler_scratch_space,
+                            )?;
+                            self.pixels_decoded = pixels_written;
+                        }
+                        McuDecodeOutput::RawPlanes(raw_planes) => {
+                            self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                        }
                     }
                     // This row's coefficient buffers can be reused next, so
                     // any checkpoint inside the row is no longer valid.
@@ -424,7 +429,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     }
                     McuContinuation::Terminate => {
                         warn!("Got terminate signal, will not process further");
-                        if let Some(v) = pixels.get_mut(pixels_written..) {
+                        if let Some(v) = output.pixels_mut().and_then(|p| p.get_mut(pixels_written..)) {
                             v.fill(128);
                         }
                         return Ok(());
@@ -516,7 +521,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         if !all_components_in_first_scan {
-            self.finish_baseline_decoding(progressive_mcus, mcu_width, pixels)?;
+            self.finish_baseline_decoding(progressive_mcus, mcu_width, output)?;
         }
 
         // it may happen that some images don't have the whole buffer
@@ -559,7 +564,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::cast_sign_loss)]
     pub(crate) fn finish_baseline_decoding(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], _mcu_width: usize, pixels: &mut [u8],
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], _mcu_width: usize,
+        output: &mut McuDecodeOutput<'_, '_>,
     ) -> Result<(), DecodeErrors> {
         let mcu_height = self.mcu_y;
 
@@ -578,7 +584,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
 
-        let raw_mode = self.raw_planes_sink.is_some();
+        let raw_mode = output.is_raw();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Mark only needed components for computing output colors.
@@ -625,10 +631,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             // process that whole stripe of MCUs
-            if self.raw_planes_sink.is_some() {
-                self.copy_raw_planes_for_mcu_stripe(i)?;
-            } else {
-                self.post_process(
+            match output {
+                McuDecodeOutput::Pixels(pixels) => self.post_process(
                     pixels,
                     i,
                     mcu_height,
@@ -636,7 +640,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     padded_width,
                     &mut pixels_written,
                     &mut upsampler_scratch_space,
-                )?;
+                )?,
+                McuDecodeOutput::RawPlanes(raw_planes) => {
+                    self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                }
             }
         }
 

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -950,15 +950,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
         let mut tmp = [0_i32; DCT_BLOCK];
 
+        let raw_mode = self.raw_planes_sink.is_some();
+
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
             //
             // For special colorspaces i.e YCCK and CMYK, just allocate all of the needed
             // components.
-            if min(
-                self.options.jpeg_get_out_colorspace().num_components() - 1,
-                pos,
-            ) == pos
+            //
+            // Raw output needs every component regardless of output colorspace.
+            if raw_mode
+                || min(
+                    self.options.jpeg_get_out_colorspace().num_components() - 1,
+                    pos
+                ) == pos
                 || self.input_colorspace == ColorSpace::YCCK
                 || self.input_colorspace == ColorSpace::CMYK
             {
@@ -1048,15 +1053,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             // process that width up until it's impossible
-            self.post_process(
-                pixels,
-                i,
-                mcu_height,
-                width,
-                padded_width,
-                &mut pixels_written,
-                &mut upsampler_scratch_space,
-            )?;
+            if self.raw_planes_sink.is_some() {
+                self.copy_raw_planes_for_mcu_stripe(i)?;
+            } else {
+                self.post_process(
+                    pixels,
+                    i,
+                    mcu_height,
+                    width,
+                    padded_width,
+                    &mut pixels_written,
+                    &mut upsampler_scratch_space
+                )?;
+            }
         }
 
         trace!("Finished decoding image");

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -19,7 +19,7 @@ use zune_core::log::{error, trace, warn};
 
 use crate::bitstream::BitStream;
 use crate::components::SampleRatios;
-use crate::decoder::{JpegDecoder, ProgressiveFineCheckpoint, MAX_COMPONENTS};
+use crate::decoder::{JpegDecoder, McuDecodeOutput, ProgressiveFineCheckpoint, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
 use crate::headers::parse_sos;
 use crate::marker::Marker;
@@ -46,14 +46,17 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     )]
     #[inline(never)]
     pub(crate) fn decode_mcu_ycbcr_progressive<B: BitStream>(
-        &mut self, pixels: &mut [u8],
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         // Move the coefficient buffers out so scan helpers can borrow `self`
         // while receiving the buffers separately.
         let mut block = core::mem::take(&mut self.progressive_mcus_buffer);
         let mut scan_block = core::mem::take(&mut self.progressive_scan_buffer);
-        let result =
-            self.decode_mcu_ycbcr_progressive_inner::<B>(pixels, &mut block, &mut scan_block);
+        let result = self.decode_mcu_ycbcr_progressive_inner::<B>(
+            output,
+            &mut block,
+            &mut scan_block,
+        );
         if matches!(&result, Err(error) if error.is_recoverable_eof() || matches!(error, DecodeErrors::Cancelled)) {
             self.progressive_scan_buffer = scan_block;
         }
@@ -68,8 +71,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         clippy::too_many_lines
     )]
     fn decode_mcu_ycbcr_progressive_inner<B: BitStream>(
-        &mut self, pixels: &mut [u8], block: &mut [Vec<i16>; MAX_COMPONENTS],
-        scan_block: &mut [Vec<i16>; MAX_COMPONENTS]
+        &mut self, output: &mut McuDecodeOutput<'_, '_>, block: &mut [Vec<i16>; MAX_COMPONENTS]
+        , scan_block: &mut [Vec<i16>; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
         let mut mcu_height;
@@ -133,10 +136,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             &mut stream,
             block,
             scan_block,
-            pixels,
+            output,
             preserve_progressive_scans,
         )? {
-            return self.finish_progressive_decoding(block, pixels);
+            return self.finish_progressive_decoding(block, output);
         }
         if self.progressive_completed_scans > self.options.jpeg_get_max_scans() {
             return Err(DecodeErrors::Format(format!(
@@ -151,7 +154,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 return self.handle_progressive_inter_scan_error(
                     e,
                     block,
-                    pixels,
+                    output,
                     preserve_progressive_scans
                 )
             }
@@ -166,7 +169,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         return self.handle_progressive_inter_scan_error(
                             e,
                             block,
-                            pixels,
+                            output,
                             preserve_progressive_scans
                         );
                     }
@@ -181,7 +184,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         &mut stream,
                         block,
                         scan_block,
-                        pixels,
+                        output,
                         preserve_progressive_scans
                     )? {
                         break 'eoi;
@@ -205,7 +208,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             return self.handle_progressive_inter_scan_error(
                                 e,
                                 block,
-                                pixels,
+                                output,
                                 preserve_progressive_scans
                             )
                         }
@@ -219,7 +222,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         return self.handle_progressive_inter_scan_error(
                             e,
                             block,
-                            pixels,
+                            output,
                             preserve_progressive_scans
                         );
                     }
@@ -234,19 +237,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     return self.handle_progressive_inter_scan_error(
                         e,
                         block,
-                        pixels,
+                        output,
                         preserve_progressive_scans
                     )
                 }
             }
         }
 
-        self.finish_progressive_decoding(block, pixels)
+    self.finish_progressive_decoding(block, output)
     }
 
     fn decode_progressive_scan<B: BitStream>(
         &mut self, stream: &mut B, block: &mut [Vec<i16>; MAX_COMPONENTS],
-        scan_block: &mut [Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        scan_block: &mut [Vec<i16>; MAX_COMPONENTS], output: &mut McuDecodeOutput<'_, '_>,
         use_scratch_coefficients: bool
     ) -> Result<bool, DecodeErrors> {
         if !use_scratch_coefficients {
@@ -296,14 +299,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 if fine_resume.is_some() {
                     self.invalidate_progressive_fine_checkpoint();
                 }
-                self.finish_progressive_partial(block, pixels)?;
+                self.finish_progressive_partial(block, output)?;
                 return Err(e);
             }
             if self.stream.eof()? && self.scan_eof_is_error() {
                 if fine_resume.is_some() {
                     self.invalidate_progressive_fine_checkpoint();
                 }
-                self.finish_progressive_partial(block, pixels)?;
+                self.finish_progressive_partial(block, output)?;
                 return Err(DecodeErrors::ExhaustedData);
             }
             if self.options.strict_mode() {
@@ -328,7 +331,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 if fine_resume.is_some() {
                     self.invalidate_progressive_fine_checkpoint();
                 }
-                self.finish_progressive_partial(block, pixels)?;
+                self.finish_progressive_partial(block, output)?;
                 return Err(DecodeErrors::ExhaustedData);
             }
             error!("{}", DecodeErrors::ExhaustedData);
@@ -392,7 +395,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn handle_progressive_inter_scan_error(
-        &mut self, error: DecodeErrors, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        &mut self, error: DecodeErrors, block: &[Vec<i16>; MAX_COMPONENTS],
+        output: &mut McuDecodeOutput<'_, '_>,
         preserve_completed_scans: bool
     ) -> Result<(), DecodeErrors> {
         if matches!(error, DecodeErrors::Cancelled) {
@@ -400,7 +404,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
         if error.is_recoverable_eof() && self.scan_eof_is_error() {
             if preserve_completed_scans {
-                self.finish_progressive_partial(block, pixels)?;
+                self.finish_progressive_partial(block, output)?;
             } else {
                 self.discard_progressive_partial();
             }
@@ -410,7 +414,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             return Err(error);
         }
         error!("{error}");
-        self.finish_progressive_decoding(block, pixels)
+        self.finish_progressive_decoding(block, output)
     }
 
     fn discard_progressive_partial(&mut self) {
@@ -422,7 +426,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn finish_progressive_partial(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8]
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         if self.progressive_completed_scans == 0 {
             self.pixels_decoded = 0;
@@ -431,7 +435,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         if self.progressive_displayed_scans != self.progressive_completed_scans {
-            self.finish_progressive_decoding(block, pixels)?;
+            self.finish_progressive_decoding(block, output)?;
             self.progressive_displayed_scans = self.progressive_completed_scans;
         }
         self.pixels_decoded = 0;
@@ -900,7 +904,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::needless_range_loop, clippy::cast_sign_loss)]
     fn finish_progressive_decoding(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         // Rendering replaces the caller's output row by row. Until every row
         // succeeds, the buffer may contain a mix of preview generations and
@@ -950,7 +954,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
         let mut tmp = [0_i32; DCT_BLOCK];
 
-        let raw_mode = self.raw_planes_sink.is_some();
+        let raw_mode = output.is_raw();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
@@ -1053,10 +1057,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             // process that width up until it's impossible
-            if self.raw_planes_sink.is_some() {
-                self.copy_raw_planes_for_mcu_stripe(i)?;
-            } else {
-                self.post_process(
+            match output {
+                McuDecodeOutput::Pixels(pixels) => self.post_process(
                     pixels,
                     i,
                     mcu_height,
@@ -1064,7 +1066,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     padded_width,
                     &mut pixels_written,
                     &mut upsampler_scratch_space
-                )?;
+                )?,
+                McuDecodeOutput::RawPlanes(raw_planes) => {
+                    self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                }
             }
         }
 

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -984,10 +984,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         let mut pixels_written = 0;
+        let stripe_start = output.requested_raw_stripe().unwrap_or(0);
+        let stripe_end = if output.requested_raw_stripe().is_some() {
+            core::cmp::min(stripe_start + 1, mcu_height)
+        } else {
+            mcu_height
+        };
 
         // dequantize, idct and color convert.
         let mut cancel = self.cancel_debounced(self.mcu_x);
-        for i in 0..mcu_height {
+        for i in stripe_start..stripe_end {
             if cancel.is_cancelled() {
                 return Err(DecodeErrors::Cancelled);
             }
@@ -1073,12 +1079,24 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
         }
 
+        output.mark_raw_source_complete();
+
         trace!("Finished decoding image");
 
         self.progressive_render_incomplete = false;
 
         return Ok(());
     }
+
+    pub(crate) fn render_buffered_progressive_raw_stripe(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        let block = core::mem::take(&mut self.progressive_mcus_buffer);
+        let result = self.finish_progressive_decoding(&block, output);
+        self.progressive_mcus_buffer = block;
+        result
+    }
+
     pub(crate) fn reset_params(&mut self) {
         /*
         Apparently, grayscale images which can be down sampled exists, which is weird in the sense

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -64,6 +64,50 @@ fn decode_raw_into_owned(bytes: &[u8]) -> Vec<Vec<u8>> {
 }
 
 #[test]
+fn decode_raw_matches_libjpeg_turbo_with_idct_tolerance() {
+    // Logical samples produced by libjpeg-turbo 2.1.5 through
+    // jpeg_read_raw_data. Rows in this 16x16 fixture are constant, keeping
+    // the independent oracle compact while still checking every sample.
+    let expected_rows = [
+        [
+            76, 74, 70, 66, 64, 60, 56, 54, 51, 49, 45, 41, 39, 35, 31, 29,
+        ],
+        [
+            85, 95, 108, 120, 129, 141, 154, 164, 176, 186, 200, 211, 221, 232, 245, 255,
+        ],
+        [
+            255, 247, 235, 225, 218, 208, 196, 187, 176, 167, 155, 145, 138, 128, 116, 107,
+        ],
+    ];
+    let bytes = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..3)
+        .map(|index| vec![0; layout[index].byte_size])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    raw.decode_into(&mut refs).unwrap();
+
+    for (plane_index, expected) in expected_rows.iter().enumerate() {
+        assert_eq!(
+            (layout[plane_index].width, layout[plane_index].height),
+            (16, 16)
+        );
+        for (row, expected_sample) in expected.iter().enumerate() {
+            for column in 0..16 {
+                let actual = planes[plane_index][row * layout[plane_index].stride + column];
+                assert!(
+                    actual.abs_diff(*expected_sample) <= 2,
+                    "plane {plane_index} sample ({column},{row}) differs from libjpeg-turbo: {actual} vs {expected_sample}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn decode_raw_rejects_wrong_plane_count() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -656,3 +656,25 @@ fn component_ids_returns_none_before_headers() {
     let raw = decoder.raw_output();
     assert!(raw.component_ids().is_none());
 }
+
+#[test]
+fn dnl_whole_raw_apis_are_rejected_before_false_completion() {
+    let bytes = include_bytes!("images/dnl_image.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let mut planes = [];
+
+    assert!(matches!(
+        raw.decode_into(&mut planes),
+        Err(DecodeErrors::FormatStatic(
+            "raw output does not support DNL images"
+        ))
+    ));
+    assert!(matches!(
+        raw.decode_into_strided(&mut planes, &[]),
+        Err(DecodeErrors::FormatStatic(
+            "raw output does not support DNL images"
+        ))
+    ));
+}

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -11,14 +11,6 @@
 //! Mirrors libjpeg-turbo's `jpeg_read_raw_data` semantics: each component's
 //! post-IDCT samples are written directly into a caller-provided plane,
 //! skipping upsampling and color conversion.
-//!
-//! Note: the existing baseline decoder has a long-standing layout quirk for
-//! `non_interleaved_*` fixtures (each component in its own SOS) where the
-//! per-stripe data is not laid out contiguously in `progressive_mcus`. The
-//! existing `post_process` path papers over this; the raw bypass faithfully
-//! reflects what the decoder actually writes, so non-interleaved fixtures
-//! are exercised only for API surface (validation, plane sizing) and not
-//! for sample-content sanity.
 
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::errors::DecodeErrors;
@@ -310,36 +302,26 @@ fn ycbcr_to_rgb(y: u8, cb: u8, cr: u8) -> [u8; 3] {
     ]
 }
 
-#[test]
-fn decode_raw_content_matches_decode_within_upsample_tolerance() {
-    // Decode the same image two ways and assert the planes, after
-    // nearest-neighbour upsampling and JFIF YCbCr -> RGB, are statistically
-    // close to the regular RGB output. This guards against plane-ordering,
-    // stride, and clamp-cast regressions.
-    //
-    // Tolerance is loose because zune-jpeg uses a fancier upsampler than the
-    // nearest-neighbour we apply in test code; we only assert that the mean
-    // absolute difference per channel is small.
-    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
-
+fn assert_raw_content_matches_decode_within_upsample_tolerance(
+    name: &str, bytes: &[u8], max_mean_delta: u64
+) {
     let rgb = {
-        let mut d = JpegDecoder::new(ZCursor::new(bytes));
-        d.decode().unwrap()
+        let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+        decoder.decode().unwrap()
     };
 
-    let mut d2 = JpegDecoder::new(ZCursor::new(bytes));
-    d2.decode_headers().unwrap();
-    let (w, h) = d2.dimensions().unwrap();
-    let layout = d2.planar_layout().unwrap();
-    let n = d2.num_components().unwrap();
-    assert_eq!(n, 3);
+    let mut raw_decoder = JpegDecoder::new(ZCursor::new(bytes));
+    raw_decoder.decode_headers().unwrap();
+    let (w, h) = raw_decoder.dimensions().unwrap();
+    let layout = raw_decoder.planar_layout().unwrap();
+    let n = raw_decoder.num_components().unwrap();
+    assert_eq!(n, 3, "{name}: expected YCbCr fixture");
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        d2.decode_raw(&mut refs).unwrap();
+        raw_decoder.decode_raw(&mut refs).unwrap();
     }
 
-    // Upsample Cb / Cr to Y dimensions.
     let y_up = nearest_upsample(
         &planes[0],
         layout[0].width,
@@ -381,13 +363,54 @@ fn decode_raw_content_matches_decode_within_upsample_tolerance() {
     let avg_dr = sum_dr / total;
     let avg_dg = sum_dg / total;
     let avg_db = sum_db / total;
+    assert!(
+        avg_dr < max_mean_delta && avg_dg < max_mean_delta && avg_db < max_mean_delta,
+        "{name}: mean abs RGB delta too large: dr={avg_dr} dg={avg_dg} db={avg_db}"
+    );
+}
+
+#[test]
+fn decode_raw_content_matches_decode_within_upsample_tolerance() {
+    // Decode the same image two ways and assert the planes, after
+    // nearest-neighbour upsampling and JFIF YCbCr -> RGB, are statistically
+    // close to the regular RGB output. This guards against plane-ordering,
+    // stride, and clamp-cast regressions.
+    //
+    // Tolerance is loose because zune-jpeg uses a fancier upsampler than the
+    // nearest-neighbour we apply in test code; we only assert that the mean
+    // absolute difference per channel is small.
     // A plane swap, stride bug, or wrong YCbCr->RGB matrix would produce
     // mean absolute deltas in the dozens; nearest-vs-fancy-upsample alone
     // typically produces single-digit deltas on photographic content.
-    assert!(
-        avg_dr < 12 && avg_dg < 12 && avg_db < 12,
-        "mean abs RGB delta too large: dr={avg_dr} dg={avg_dg} db={avg_db}"
+    assert_raw_content_matches_decode_within_upsample_tolerance(
+        "interleaved_420",
+        include_bytes!("../../../test-images/jpeg/2029.jpg"),
+        12
     );
+}
+
+#[test]
+fn decode_raw_non_interleaved_content_matches_decode() {
+    for (name, bytes) in [
+        (
+            "non_interleaved_444",
+            &include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg")[..]
+        ),
+        (
+            "non_interleaved_420",
+            &include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg")[..]
+        ),
+        (
+            "non_interleaved_422",
+            &include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg")[..]
+        ),
+        (
+            "non_interleaved_440",
+            &include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg")[..]
+        )
+    ] {
+        assert_raw_content_matches_decode_within_upsample_tolerance(name, bytes, 24);
+    }
 }
 
 // decode_raw_strided: Skia-style logically-sized planes.

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -1,0 +1,590 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+//! Tests for `JpegDecoder::decode_raw()`.
+//!
+//! Mirrors libjpeg-turbo's `jpeg_read_raw_data` semantics: each component's
+//! post-IDCT samples are written directly into a caller-provided plane,
+//! skipping upsampling and color conversion.
+//!
+//! Note: the existing baseline decoder has a long-standing layout quirk for
+//! `non_interleaved_*` fixtures (each component in its own SOS) where the
+//! per-stripe data is not laid out contiguously in `progressive_mcus`. The
+//! existing `post_process` path papers over this; the raw bypass faithfully
+//! reflects what the decoder actually writes, so non-interleaved fixtures
+//! are exercised only for API surface (validation, plane sizing) and not
+//! for sample-content sanity.
+
+use zune_core::bytestream::ZCursor;
+use zune_jpeg::errors::DecodeErrors;
+use zune_jpeg::JpegDecoder;
+
+/// Allocate per-plane buffers sized to the layout reported by
+/// `planar_layout()`, then run `decode_raw` and return the populated planes.
+fn decode_raw_into_owned(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().expect("decode_headers");
+    let n = decoder.num_components().expect("num_components");
+    let layout = decoder.planar_layout().expect("planar_layout");
+
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw(&mut refs).expect("decode_raw");
+    }
+    planes
+}
+
+#[test]
+fn decode_raw_rejects_wrong_plane_count() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    // 3-component image, pass 2 planes.
+    let mut p0 = vec![0u8; layout[0].byte_size];
+    let mut p1 = vec![0u8; layout[1].byte_size];
+    let mut refs: [&mut [u8]; 2] = [&mut p0, &mut p1];
+    let err = decoder.decode_raw(&mut refs).unwrap_err();
+    match err {
+        DecodeErrors::Format(_) => {}
+        other => panic!("expected Format error, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_rejects_too_small_plane() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let mut p0 = vec![0u8; layout[0].byte_size - 1]; // one byte short
+    let mut p1 = vec![0u8; layout[1].byte_size];
+    let mut p2 = vec![0u8; layout[2].byte_size];
+    let mut refs: [&mut [u8]; 3] = [&mut p0, &mut p1, &mut p2];
+    let err = decoder.decode_raw(&mut refs).unwrap_err();
+    match err {
+        DecodeErrors::TooSmallOutput(need, got) => {
+            assert_eq!(need, layout[0].byte_size);
+            assert_eq!(got, layout[0].byte_size - 1);
+        }
+        other => panic!("expected TooSmallOutput, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_rejects_more_than_four_sof_components() {
+    const FIVE_COMPONENTS: &[u8] = &[
+        0xff, 0xd8, // SOI
+        0xff, 0xc0, // SOF0
+        0x00, 0x17, // length = 8 + 3 * 5
+        0x08, // precision
+        0x00, 0x01, // height
+        0x00, 0x01, // width
+        0x05, // components
+        1, 0x11, 0,
+        2, 0x11, 0,
+        3, 0x11, 0,
+        4, 0x11, 0,
+        5, 0x11, 0
+    ];
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(FIVE_COMPONENTS));
+    let err = decoder.decode_headers().unwrap_err();
+    match err {
+        DecodeErrors::SofError(_) => {}
+        other => panic!("expected SofError, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_interleaved_420_full_range() {
+    // 388x477 4:2:0 photographic JPEG, all 3 components in a single SOS.
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let planes = decode_raw_into_owned(bytes);
+    assert_eq!(planes.len(), 3);
+
+    // Photographic content: each plane should span a wide range and the
+    // chroma planes should be centred near 128 (neutral).
+    let y_min = *planes[0].iter().min().unwrap();
+    let y_max = *planes[0].iter().max().unwrap();
+    assert!(
+        y_max - y_min > 100,
+        "Y plane range too narrow: {y_min}..{y_max}"
+    );
+    for (idx, plane) in planes[1..].iter().enumerate() {
+        let pmin = *plane.iter().min().unwrap();
+        let pmax = *plane.iter().max().unwrap();
+        assert!(pmax > pmin, "chroma plane {} appears constant", idx + 1);
+        let avg: u64 = plane.iter().map(|&v| v as u64).sum::<u64>() / plane.len() as u64;
+        assert!(
+            (96..=160).contains(&avg),
+            "chroma plane {} avg {} not in expected near-neutral band",
+            idx + 1,
+            avg
+        );
+    }
+}
+
+#[test]
+fn decode_raw_interleaved_420_deterministic() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let a = decode_raw_into_owned(bytes);
+    let b = decode_raw_into_owned(bytes);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn decode_raw_interleaved_no_subsampling() {
+    // 4:4:4 image where every plane has the same dimensions.
+    let bytes = include_bytes!("../../../test-images/jpeg/medium_no_samp_2500x1786.jpg");
+    let planes = decode_raw_into_owned(bytes);
+    assert_eq!(planes.len(), 3);
+    assert_eq!(planes[0].len(), planes[1].len());
+    assert_eq!(planes[1].len(), planes[2].len());
+    for (i, plane) in planes.iter().enumerate() {
+        let pmin = *plane.iter().min().unwrap();
+        let pmax = *plane.iter().max().unwrap();
+        assert!(pmax > pmin, "plane {i} appears constant");
+    }
+}
+
+#[test]
+fn decode_raw_grayscale_progressive_single_plane() {
+    let bytes = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let n = decoder.num_components().unwrap();
+    assert_eq!(n, 1, "expected grayscale (1 component)");
+    let layout = decoder.planar_layout().unwrap();
+    let mut p = vec![0u8; layout[0].byte_size];
+    {
+        let mut refs: [&mut [u8]; 1] = [&mut p];
+        decoder
+            .decode_raw(&mut refs)
+            .expect("decode_raw progressive");
+    }
+    let min = *p.iter().min().unwrap();
+    let max = *p.iter().max().unwrap();
+    assert!(max > min, "decoded grayscale plane is a single constant");
+}
+
+#[test]
+fn decode_raw_progressive_four_component() {
+    let bytes =
+        include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let n = decoder.num_components().unwrap();
+    assert_eq!(n, 4, "expected 4-component CMYK/YCCK image");
+    let layout = decoder.planar_layout().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw(&mut refs).expect("decode_raw");
+    }
+    for (i, plane) in planes.iter().enumerate() {
+        assert_eq!(plane.len(), layout[i].byte_size);
+        let pmin = *plane.iter().min().unwrap();
+        let pmax = *plane.iter().max().unwrap();
+        assert!(pmax > pmin, "plane {i} appears constant");
+    }
+}
+
+#[test]
+fn decode_raw_works_after_explicit_decode_headers() {
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    decoder.decode_raw(&mut refs).unwrap();
+}
+
+#[test]
+fn decode_raw_ignores_out_colorspace_setting() {
+    // Regression test: previously, configuring `out_colorspace = Luma` on a
+    // 3-component YCbCr image caused the baseline decoder to skip allocating
+    // raw_coeff for Cb / Cr (their `comp.needed` was set to false), so
+    // `decode_raw` would either panic or return garbage planes.
+    //
+    // In raw mode we want every component regardless of the configured
+    // output colorspace.
+    use zune_core::colorspace::ColorSpace;
+    use zune_core::options::DecoderOptions;
+
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let opts = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::Luma);
+    let mut decoder = JpegDecoder::new_with_options(ZCursor::new(bytes), opts);
+    decoder.decode_headers().unwrap();
+    let n = decoder.num_components().unwrap();
+    assert_eq!(n, 3, "fixture is 3-component");
+    let layout = decoder.planar_layout().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder
+            .decode_raw(&mut refs)
+            .expect("decode_raw should succeed regardless of out_colorspace");
+    }
+    // All three planes must contain real decoded data, not zeros.
+    for (i, plane) in planes.iter().enumerate() {
+        let pmin = *plane.iter().min().unwrap();
+        let pmax = *plane.iter().max().unwrap();
+        assert!(
+            pmax > pmin,
+            "plane {i} appears constant ({pmin}); raw mode must decode all components"
+        );
+    }
+}
+
+#[test]
+fn decode_raw_unaligned_dimensions_decode_succeeds() {
+    // 605x806 image with unaligned dimensions: width padded 605 -> 608,
+    // height padded 806 -> 808. Exercises the per-row padding-truncation
+    // path in `copy_raw_planes_for_mcu_stripe` and the trailing-padding-row
+    // bookkeeping.
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    assert_eq!(layout[0].width, 605);
+    assert_eq!(layout[0].height, 806);
+    assert_eq!(layout[0].stride, 608);
+    assert_eq!(layout[0].allocated_height, 808);
+
+    let n = decoder.num_components().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw(&mut refs).unwrap();
+    }
+    // Spot-check: meaningful Y region (rows 0..806, cols 0..605) has data.
+    let y = &planes[0];
+    let mut has_non_zero = false;
+    for row in 0..layout[0].height {
+        let v = y[row * layout[0].stride];
+        if v != 0 {
+            has_non_zero = true;
+            break;
+        }
+    }
+    assert!(has_non_zero, "first column of Y plane is all zero");
+}
+
+/// Manual nearest-neighbour upsampling of `src` (size `sw x sh`, row stride
+/// `s_stride`) into a `tw x th` plane.
+fn nearest_upsample(
+    src: &[u8], sw: usize, sh: usize, s_stride: usize, tw: usize, th: usize
+) -> Vec<u8> {
+    let mut out = vec![0u8; tw * th];
+    for y in 0..th {
+        let sy = (y * sh) / th;
+        for x in 0..tw {
+            let sx = (x * sw) / tw;
+            out[y * tw + x] = src[sy * s_stride + sx];
+        }
+    }
+    out
+}
+
+/// JFIF YCbCr -> RGB conversion (8-bit).
+fn ycbcr_to_rgb(y: u8, cb: u8, cr: u8) -> [u8; 3] {
+    let yf = y as f32;
+    let cbf = cb as f32 - 128.0;
+    let crf = cr as f32 - 128.0;
+    let r = yf + 1.402 * crf;
+    let g = yf - 0.344136 * cbf - 0.714136 * crf;
+    let b = yf + 1.772 * cbf;
+    [
+        r.round().clamp(0.0, 255.0) as u8,
+        g.round().clamp(0.0, 255.0) as u8,
+        b.round().clamp(0.0, 255.0) as u8
+    ]
+}
+
+#[test]
+fn decode_raw_content_matches_decode_within_upsample_tolerance() {
+    // Decode the same image two ways and assert the planes, after
+    // nearest-neighbour upsampling and JFIF YCbCr -> RGB, are statistically
+    // close to the regular RGB output. This guards against plane-ordering,
+    // stride, and clamp-cast regressions.
+    //
+    // Tolerance is loose because zune-jpeg uses a fancier upsampler than the
+    // nearest-neighbour we apply in test code; we only assert that the mean
+    // absolute difference per channel is small.
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+
+    let rgb = {
+        let mut d = JpegDecoder::new(ZCursor::new(bytes));
+        d.decode().unwrap()
+    };
+
+    let mut d2 = JpegDecoder::new(ZCursor::new(bytes));
+    d2.decode_headers().unwrap();
+    let (w, h) = d2.dimensions().unwrap();
+    let layout = d2.planar_layout().unwrap();
+    let n = d2.num_components().unwrap();
+    assert_eq!(n, 3);
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        d2.decode_raw(&mut refs).unwrap();
+    }
+
+    // Upsample Cb / Cr to Y dimensions.
+    let y_up = nearest_upsample(
+        &planes[0],
+        layout[0].width,
+        layout[0].height,
+        layout[0].stride,
+        w,
+        h
+    );
+    let cb_up = nearest_upsample(
+        &planes[1],
+        layout[1].width,
+        layout[1].height,
+        layout[1].stride,
+        w,
+        h
+    );
+    let cr_up = nearest_upsample(
+        &planes[2],
+        layout[2].width,
+        layout[2].height,
+        layout[2].stride,
+        w,
+        h
+    );
+
+    let mut sum_dr = 0u64;
+    let mut sum_dg = 0u64;
+    let mut sum_db = 0u64;
+    let total = (w * h) as u64;
+    for i in 0..(w * h) {
+        let [r, g, b] = ycbcr_to_rgb(y_up[i], cb_up[i], cr_up[i]);
+        let rr = rgb[i * 3];
+        let gg = rgb[i * 3 + 1];
+        let bb = rgb[i * 3 + 2];
+        sum_dr += (r as i32 - rr as i32).unsigned_abs() as u64;
+        sum_dg += (g as i32 - gg as i32).unsigned_abs() as u64;
+        sum_db += (b as i32 - bb as i32).unsigned_abs() as u64;
+    }
+    let avg_dr = sum_dr / total;
+    let avg_dg = sum_dg / total;
+    let avg_db = sum_db / total;
+    // A plane swap, stride bug, or wrong YCbCr->RGB matrix would produce
+    // mean absolute deltas in the dozens; nearest-vs-fancy-upsample alone
+    // typically produces single-digit deltas on photographic content.
+    assert!(
+        avg_dr < 12 && avg_dg < 12 && avg_db < 12,
+        "mean abs RGB delta too large: dr={avg_dr} dg={avg_dg} db={avg_db}"
+    );
+}
+
+// decode_raw_strided: Skia-style logically-sized planes.
+
+#[test]
+fn decode_raw_strided_logical_size_matches_padded_decode() {
+    // 605x806 4:2:0 image: padded layout is 608x808 / 304x404; logical layout
+    // is 605x806 / 303x403. Verify that decode_raw_strided into a logical
+    // (width-stride) buffer returns identical samples within
+    // [0,width) x [0,height) versus decode_raw into the padded buffer.
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+
+    // Padded reference.
+    let padded = decode_raw_into_owned(bytes);
+
+    // Logical-sized via decode_raw_strided.
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
+    let mut logical: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0u8; strides[i] * layout[i].height])
+        .collect();
+    {
+        let mut refs: Vec<&mut [u8]> = logical.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+    }
+
+    for i in 0..n {
+        let pi = layout[i];
+        for y in 0..pi.height {
+            for x in 0..pi.width {
+                let logical_byte = logical[i][y * strides[i] + x];
+                let padded_byte = padded[i][y * pi.stride + x];
+                assert_eq!(
+                    logical_byte, padded_byte,
+                    "mismatch at component {i} ({},{})",
+                    x, y
+                );
+            }
+        }
+        assert_eq!(logical[i].len(), strides[i] * pi.height);
+    }
+}
+
+#[test]
+fn decode_raw_strided_accepts_oversized_stride() {
+    // Caller supplies a larger-than-width stride (e.g. row alignment of 64).
+    // Verify the per-row padding bytes stay zero and the meaningful samples
+    // match the logical decode.
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let padded = decode_raw_into_owned(bytes);
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    // Round each width up to the next multiple of 64.
+    let strides: Vec<usize> = (0..n).map(|i| (layout[i].width + 63) & !63).collect();
+    let mut planes: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0xAAu8; strides[i] * layout[i].height])
+        .collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+    }
+
+    for i in 0..n {
+        let pi = layout[i];
+        for y in 0..pi.height {
+            for x in 0..pi.width {
+                assert_eq!(
+                    planes[i][y * strides[i] + x],
+                    padded[i][y * pi.stride + x],
+                    "mismatch at component {i} ({},{})",
+                    x,
+                    y
+                );
+            }
+            // Trailing pad bytes from logical width up to caller stride
+            // must remain at the sentinel value (we did not write them).
+            for x in pi.width..strides[i] {
+                assert_eq!(
+                    planes[i][y * strides[i] + x],
+                    0xAA,
+                    "stride padding modified at component {i} ({},{})",
+                    x,
+                    y
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn decode_raw_strided_rejects_too_small_stride() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    // Stride for component 0 is one less than the logical width.
+    let strides: Vec<usize> = (0..n)
+        .map(|i| if i == 0 { layout[i].width - 1 } else { layout[i].width })
+        .collect();
+    let mut planes: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0u8; strides[i].max(1) * layout[i].height])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    let err = decoder.decode_raw_strided(&mut refs, &strides).unwrap_err();
+    match err {
+        DecodeErrors::Format(_) => {}
+        other => panic!("expected Format error, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_strided_rejects_too_small_buffer() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
+    let mut planes: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0u8; strides[i] * layout[i].height])
+        .collect();
+    // Truncate component 0 by one byte.
+    planes[0].pop();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    let err = decoder.decode_raw_strided(&mut refs, &strides).unwrap_err();
+    match err {
+        DecodeErrors::TooSmallOutput(_, _) => {}
+        other => panic!("expected TooSmallOutput, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_strided_unaligned_dimensions_no_pad_writes() {
+    // Logical-sized buffer on a non-DCT-aligned image. Verify the trailing
+    // row past `height` is never touched by the decoder (no scratch leak).
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    // Allocate exactly one extra sentinel row past `height` in the same
+    // backing Vec, but tell the decoder the buffer is `stride * height`.
+    let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
+    let buf_lens: Vec<usize> = (0..n).map(|i| strides[i] * layout[i].height).collect();
+    let mut backing: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0xCDu8; buf_lens[i] + strides[i]]) // one extra row of sentinel
+        .collect();
+
+    {
+        // Slice each plane to exactly buf_lens[i] so the decoder cannot
+        // address past it.
+        let mut refs: Vec<&mut [u8]> = backing
+            .iter_mut()
+            .enumerate()
+            .map(|(i, v)| &mut v[..buf_lens[i]])
+            .collect();
+        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+    }
+
+    for i in 0..n {
+        let extra = &backing[i][buf_lens[i]..];
+        assert!(
+            extra.iter().all(|&b| b == 0xCD),
+            "trailing sentinel row clobbered for component {i}"
+        );
+    }
+}
+
+// component_ids() accessor.
+
+#[test]
+fn component_ids_returns_ycbcr_for_3_component_jpeg() {
+    use zune_jpeg::ComponentID;
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let ids = decoder
+        .component_ids()
+        .expect("component_ids after headers");
+    assert_eq!(ids, vec![ComponentID::Y, ComponentID::Cb, ComponentID::Cr]);
+}
+
+#[test]
+fn component_ids_returns_none_before_headers() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let decoder = JpegDecoder::new(ZCursor::new(bytes));
+    assert!(decoder.component_ids().is_none());
+}

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-//! Tests for `JpegDecoder::decode_raw()`.
+//! Tests for `JpegDecoder::raw_output()`.
 //!
 //! Mirrors libjpeg-turbo's `jpeg_read_raw_data` semantics: each component's
 //! post-IDCT samples are written directly into a caller-provided plane,
@@ -16,18 +16,49 @@ use zune_core::bytestream::ZCursor;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::JpegDecoder;
 
+fn with_component_ids(data: &[u8], ids: &[u8]) -> Vec<u8> {
+    let mut result = data.to_vec();
+    let sof = result
+        .windows(2)
+        .position(|bytes| bytes[0] == 0xff && (0xc0..=0xc2).contains(&bytes[1]))
+        .expect("fixture must contain a supported SOF marker");
+    assert_eq!(usize::from(result[sof + 9]), ids.len());
+    let old_ids: Vec<_> = (0..ids.len())
+        .map(|index| result[sof + 10 + 3 * index])
+        .collect();
+
+    for (index, id) in ids.iter().enumerate() {
+        result[sof + 10 + 3 * index] = *id;
+    }
+    for sos in result
+        .windows(2)
+        .enumerate()
+        .filter_map(|(offset, bytes)| (bytes == [0xff, 0xda]).then_some(offset))
+        .collect::<Vec<_>>()
+    {
+        for index in 0..usize::from(result[sos + 4]) {
+            let selector = &mut result[sos + 5 + 2 * index];
+            if let Some(id_index) = old_ids.iter().position(|id| id == selector) {
+                *selector = ids[id_index];
+            }
+        }
+    }
+    result
+}
+
 /// Allocate per-plane buffers sized to the layout reported by
-/// `planar_layout()`, then run `decode_raw` and return the populated planes.
+/// `RawDecodeSession::layout()`, then decode and return the populated planes.
 fn decode_raw_into_owned(bytes: &[u8]) -> Vec<Vec<u8>> {
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().expect("decode_headers");
-    let n = decoder.num_components().expect("num_components");
-    let layout = decoder.planar_layout().expect("planar_layout");
+    let mut raw = decoder.raw_output();
+    let n = raw.num_components().expect("num_components");
+    let layout = raw.layout().expect("raw layout");
 
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw(&mut refs).expect("decode_raw");
+        raw.decode_into(&mut refs).expect("raw decode");
     }
     planes
 }
@@ -37,12 +68,13 @@ fn decode_raw_rejects_wrong_plane_count() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
     // 3-component image, pass 2 planes.
     let mut p0 = vec![0u8; layout[0].byte_size];
     let mut p1 = vec![0u8; layout[1].byte_size];
     let mut refs: [&mut [u8]; 2] = [&mut p0, &mut p1];
-    let err = decoder.decode_raw(&mut refs).unwrap_err();
+    let err = raw.decode_into(&mut refs).unwrap_err();
     match err {
         DecodeErrors::Format(_) => {}
         other => panic!("expected Format error, got {other:?}")
@@ -54,12 +86,13 @@ fn decode_raw_rejects_too_small_plane() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
     let mut p0 = vec![0u8; layout[0].byte_size - 1]; // one byte short
     let mut p1 = vec![0u8; layout[1].byte_size];
     let mut p2 = vec![0u8; layout[2].byte_size];
     let mut refs: [&mut [u8]; 3] = [&mut p0, &mut p1, &mut p2];
-    let err = decoder.decode_raw(&mut refs).unwrap_err();
+    let err = raw.decode_into(&mut refs).unwrap_err();
     match err {
         DecodeErrors::TooSmallOutput(need, got) => {
             assert_eq!(need, layout[0].byte_size);
@@ -79,11 +112,7 @@ fn decode_raw_rejects_more_than_four_sof_components() {
         0x00, 0x01, // height
         0x00, 0x01, // width
         0x05, // components
-        1, 0x11, 0,
-        2, 0x11, 0,
-        3, 0x11, 0,
-        4, 0x11, 0,
-        5, 0x11, 0
+        1, 0x11, 0, 2, 0x11, 0, 3, 0x11, 0, 4, 0x11, 0, 5, 0x11, 0
     ];
 
     let mut decoder = JpegDecoder::new(ZCursor::new(FIVE_COMPONENTS));
@@ -151,15 +180,14 @@ fn decode_raw_grayscale_progressive_single_plane() {
     let bytes = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let n = raw.num_components().unwrap();
     assert_eq!(n, 1, "expected grayscale (1 component)");
-    let layout = decoder.planar_layout().unwrap();
+    let layout = raw.layout().unwrap();
     let mut p = vec![0u8; layout[0].byte_size];
     {
         let mut refs: [&mut [u8]; 1] = [&mut p];
-        decoder
-            .decode_raw(&mut refs)
-            .expect("decode_raw progressive");
+        raw.decode_into(&mut refs).expect("raw progressive decode");
     }
     let min = *p.iter().min().unwrap();
     let max = *p.iter().max().unwrap();
@@ -172,13 +200,14 @@ fn decode_raw_progressive_four_component() {
         include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let n = raw.num_components().unwrap();
     assert_eq!(n, 4, "expected 4-component CMYK/YCCK image");
-    let layout = decoder.planar_layout().unwrap();
+    let layout = raw.layout().unwrap();
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw(&mut refs).expect("decode_raw");
+        raw.decode_into(&mut refs).expect("raw decode");
     }
     for (i, plane) in planes.iter().enumerate() {
         assert_eq!(plane.len(), layout[i].byte_size);
@@ -193,11 +222,12 @@ fn decode_raw_works_after_explicit_decode_headers() {
     let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    decoder.decode_raw(&mut refs).unwrap();
+    raw.decode_into(&mut refs).unwrap();
 }
 
 #[test]
@@ -216,14 +246,14 @@ fn decode_raw_ignores_out_colorspace_setting() {
     let opts = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::Luma);
     let mut decoder = JpegDecoder::new_with_options(ZCursor::new(bytes), opts);
     decoder.decode_headers().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let n = raw.num_components().unwrap();
     assert_eq!(n, 3, "fixture is 3-component");
-    let layout = decoder.planar_layout().unwrap();
+    let layout = raw.layout().unwrap();
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder
-            .decode_raw(&mut refs)
+        raw.decode_into(&mut refs)
             .expect("decode_raw should succeed regardless of out_colorspace");
     }
     // All three planes must contain real decoded data, not zeros.
@@ -246,17 +276,18 @@ fn decode_raw_unaligned_dimensions_decode_succeeds() {
     let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
     assert_eq!(layout[0].width, 605);
     assert_eq!(layout[0].height, 806);
     assert_eq!(layout[0].stride, 608);
     assert_eq!(layout[0].allocated_height, 808);
 
-    let n = decoder.num_components().unwrap();
+    let n = raw.num_components().unwrap();
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw(&mut refs).unwrap();
+        raw.decode_into(&mut refs).unwrap();
     }
     // Spot-check: meaningful Y region (rows 0..806, cols 0..605) has data.
     let y = &planes[0];
@@ -313,13 +344,14 @@ fn assert_raw_content_matches_decode_within_upsample_tolerance(
     let mut raw_decoder = JpegDecoder::new(ZCursor::new(bytes));
     raw_decoder.decode_headers().unwrap();
     let (w, h) = raw_decoder.dimensions().unwrap();
-    let layout = raw_decoder.planar_layout().unwrap();
-    let n = raw_decoder.num_components().unwrap();
+    let mut raw = raw_decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
     assert_eq!(n, 3, "{name}: expected YCbCr fixture");
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        raw_decoder.decode_raw(&mut refs).unwrap();
+        raw.decode_into(&mut refs).unwrap();
     }
 
     let y_up = nearest_upsample(
@@ -429,8 +461,9 @@ fn decode_raw_strided_logical_size_matches_padded_decode() {
     // Logical-sized via decode_raw_strided.
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
     let mut logical: Vec<Vec<u8>> = (0..n)
@@ -438,7 +471,7 @@ fn decode_raw_strided_logical_size_matches_padded_decode() {
         .collect();
     {
         let mut refs: Vec<&mut [u8]> = logical.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+        raw.decode_into_strided(&mut refs, &strides).unwrap();
     }
 
     for i in 0..n {
@@ -468,8 +501,9 @@ fn decode_raw_strided_accepts_oversized_stride() {
 
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     // Round each width up to the next multiple of 64.
     let strides: Vec<usize> = (0..n).map(|i| (layout[i].width + 63) & !63).collect();
@@ -478,7 +512,7 @@ fn decode_raw_strided_accepts_oversized_stride() {
         .collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+        raw.decode_into_strided(&mut refs, &strides).unwrap();
     }
 
     for i in 0..n {
@@ -513,8 +547,9 @@ fn decode_raw_strided_rejects_too_small_stride() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     // Stride for component 0 is one less than the logical width.
     let strides: Vec<usize> = (0..n)
@@ -524,7 +559,7 @@ fn decode_raw_strided_rejects_too_small_stride() {
         .map(|i| vec![0u8; strides[i].max(1) * layout[i].height])
         .collect();
     let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    let err = decoder.decode_raw_strided(&mut refs, &strides).unwrap_err();
+    let err = raw.decode_into_strided(&mut refs, &strides).unwrap_err();
     match err {
         DecodeErrors::Format(_) => {}
         other => panic!("expected Format error, got {other:?}")
@@ -536,8 +571,9 @@ fn decode_raw_strided_rejects_too_small_buffer() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
     let mut planes: Vec<Vec<u8>> = (0..n)
@@ -546,7 +582,7 @@ fn decode_raw_strided_rejects_too_small_buffer() {
     // Truncate component 0 by one byte.
     planes[0].pop();
     let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    let err = decoder.decode_raw_strided(&mut refs, &strides).unwrap_err();
+    let err = raw.decode_into_strided(&mut refs, &strides).unwrap_err();
     match err {
         DecodeErrors::TooSmallOutput(_, _) => {}
         other => panic!("expected TooSmallOutput, got {other:?}")
@@ -560,8 +596,9 @@ fn decode_raw_strided_unaligned_dimensions_no_pad_writes() {
     let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     // Allocate exactly one extra sentinel row past `height` in the same
     // backing Vec, but tell the decoder the buffer is `stride * height`.
@@ -579,7 +616,7 @@ fn decode_raw_strided_unaligned_dimensions_no_pad_writes() {
             .enumerate()
             .map(|(i, v)| &mut v[..buf_lens[i]])
             .collect();
-        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+        raw.decode_into_strided(&mut refs, &strides).unwrap();
     }
 
     for i in 0..n {
@@ -591,23 +628,31 @@ fn decode_raw_strided_unaligned_dimensions_no_pad_writes() {
     }
 }
 
-// component_ids() accessor.
+// component_ids() metadata.
 
 #[test]
-fn component_ids_returns_ycbcr_for_3_component_jpeg() {
-    use zune_jpeg::ComponentID;
+fn component_ids_return_canonical_sof_selectors() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let ids = decoder
-        .component_ids()
-        .expect("component_ids after headers");
-    assert_eq!(ids, vec![ComponentID::Y, ComponentID::Cb, ComponentID::Cr]);
+    let raw = decoder.raw_output();
+    let ids = raw.component_ids().expect("component_ids after headers");
+    assert_eq!(ids, vec![1, 2, 3]);
+}
+
+#[test]
+fn component_ids_preserve_noncanonical_sof_selectors() {
+    let bytes = with_component_ids(include_bytes!("../../../test-images/jpeg/2029.jpg"), b"RGB");
+    let mut decoder = JpegDecoder::new(ZCursor::new(&bytes));
+    decoder.decode_headers().unwrap();
+    let raw = decoder.raw_output();
+    assert_eq!(raw.component_ids().as_deref(), Some(b"RGB".as_slice()));
 }
 
 #[test]
 fn component_ids_returns_none_before_headers() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
-    let decoder = JpegDecoder::new(ZCursor::new(bytes));
-    assert!(decoder.component_ids().is_none());
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let raw = decoder.raw_output();
+    assert!(raw.component_ids().is_none());
 }

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -12,6 +12,7 @@
 //! and that retrying with more data produces correct output.
 
 use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
+use zune_core::colorspace::ColorSpace;
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::{JpegDecoder, RawDecodeSession};
@@ -2727,6 +2728,86 @@ fn per_row_checkpoint_avoids_full_scan_replay() {
         "per-row checkpoint should resume past entropy_start ({entropy_start}), \
          but sought to {resume_pos} — indicates full scan replay instead of row resume"
     );
+}
+
+fn checkpointed_pixel_decoder<'a>(
+    data: &'a [u8], cutoff: usize, options: DecoderOptions
+) -> (JpegDecoder<GrowableCursor<'a>>, Rc<Cell<usize>>) {
+    let limit = Rc::new(Cell::new(cutoff));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new_with_options(cursor, options);
+    decoder.decode_headers().unwrap();
+    let mut output = vec![0; decoder.output_buffer_size().unwrap()];
+    for _ in 0..2 {
+        let error = decoder.decode_into(&mut output).unwrap_err();
+        assert!(error.is_recoverable_eof());
+    }
+    assert!(decoder.decoded_scanlines().unwrap_or(0) > 0);
+    (decoder, limit)
+}
+
+#[test]
+fn switching_checkpointed_pixel_decode_to_whole_raw_replays_from_start() {
+    let data = include_bytes!("../../../test-images/jpeg/sampling_factors.jpg");
+    let entropy_start = entropy_start(data);
+    let cutoff = entropy_start + (data.len() - entropy_start) * 60 / 100;
+    let expected = decode_raw_oneshot(data);
+    let (mut decoder, limit) =
+        checkpointed_pixel_decoder(data, cutoff, DecoderOptions::default());
+    limit.set(data.len());
+
+    let mut raw = decoder.raw_output();
+    let mut actual = allocate_raw_planes(&raw);
+    decode_raw_into_existing(&mut raw, &mut actual).unwrap();
+    assert_raw_planes_match(&actual, &expected, "pixel_to_whole_raw", data.len());
+}
+
+#[test]
+fn changing_options_replays_pixel_output_and_invalidates_progress() {
+    let baseline = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let luma = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::Luma);
+    let expected = decode_oneshot(baseline);
+    let entropy_start = entropy_start(baseline);
+    let cutoff = entropy_start + (baseline.len() - entropy_start) * 60 / 100;
+    let (mut decoder, limit) = checkpointed_pixel_decoder(baseline, cutoff, luma);
+    limit.set(baseline.len());
+    decoder.set_options(DecoderOptions::default());
+    assert_eq!(decoder.decoded_output_bytes(), Some(0));
+    assert_eq!(decoder.decoded_scanlines(), Some(0));
+    let mut output = vec![0; expected.len()];
+    decoder.decode_into(&mut output).unwrap();
+    assert_eq!(output, expected);
+
+    let progressive =
+        include_bytes!("../../../test-images/jpeg/rebuilt_relax_fill_bytes_before_marker.jpg");
+    let scans = progressive_sos_scans(progressive);
+    let cutoff = scans[1].data_start + 1;
+    let limit = Rc::new(Cell::new(cutoff));
+    let cursor = GrowableCursor::new(progressive, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new_with_options(cursor, luma);
+    decoder.set_incremental_mode(true);
+    decoder.decode_headers().unwrap();
+    let mut preview = vec![0; decoder.output_buffer_size().unwrap()];
+    let error = decoder.decode_into(&mut preview).unwrap_err();
+    assert!(error.is_recoverable_eof());
+    let committed_scans = decoder.decoded_scans().unwrap();
+    assert!(committed_scans > 0);
+    assert!(decoder.decoded_preview_output_bytes().unwrap_or(0) > 0);
+
+    let rgba = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::RGBA);
+    decoder.set_options(rgba);
+    assert_eq!(decoder.decoded_output_bytes(), Some(0));
+    assert_eq!(decoder.decoded_scanlines(), Some(0));
+    assert_eq!(decoder.decoded_scans(), Some(committed_scans));
+    assert_eq!(decoder.decoded_preview_output_bytes(), Some(0));
+    assert_eq!(decoder.decoded_preview_scanlines(), Some(0));
+    limit.set(progressive.len());
+    let expected = JpegDecoder::new_with_options(ZCursor::new(progressive), rgba)
+        .decode()
+        .unwrap();
+    let mut output = vec![0; expected.len()];
+    decoder.decode_into(&mut output).unwrap();
+    assert_eq!(output, expected);
 }
 
 #[test]

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -14,7 +14,7 @@
 use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
-use zune_jpeg::JpegDecoder;
+use zune_jpeg::{JpegDecoder, RawDecodeSession};
 
 use std::cell::{Cell, RefCell};
 use std::io::{BufRead, Read, Seek, SeekFrom};
@@ -220,33 +220,33 @@ fn assert_decode_into_replay_matches_oneshot(name: &str, data: &[u8]) {
     assert_pixels_match(&replay, &expected, name, data.len());
 }
 
-fn allocate_raw_planes<T>(decoder: &JpegDecoder<T>) -> Vec<Vec<u8>>
+fn allocate_raw_planes<T>(raw: &RawDecodeSession<'_, T>) -> Vec<Vec<u8>>
 where
     T: ZByteReaderTrait
 {
-    let layout = decoder.planar_layout().unwrap();
-    let n_components = decoder.num_components().unwrap();
+    let layout = raw.layout().unwrap();
+    let n_components = raw.num_components().unwrap();
     (0..n_components)
         .map(|index| vec![0u8; layout[index].byte_size])
         .collect()
 }
 
 fn decode_raw_into_existing<T>(
-    decoder: &mut JpegDecoder<T>, planes: &mut [Vec<u8>]
+    raw: &mut RawDecodeSession<'_, T>, planes: &mut [Vec<u8>]
 ) -> Result<(), zune_jpeg::errors::DecodeErrors>
 where
     T: ZByteReaderTrait
 {
     let mut plane_refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    decoder.decode_raw(&mut plane_refs)
+    raw.decode_into(&mut plane_refs)
 }
 
-fn allocate_raw_strided_planes<T>(decoder: &JpegDecoder<T>) -> (Vec<Vec<u8>>, Vec<usize>)
+fn allocate_raw_strided_planes<T>(raw: &RawDecodeSession<'_, T>) -> (Vec<Vec<u8>>, Vec<usize>)
 where
     T: ZByteReaderTrait
 {
-    let layout = decoder.planar_layout().unwrap();
-    let n_components = decoder.num_components().unwrap();
+    let layout = raw.layout().unwrap();
+    let n_components = raw.num_components().unwrap();
     let strides: Vec<usize> = (0..n_components)
         .map(|index| layout[index].width + 5)
         .collect();
@@ -257,35 +257,34 @@ where
 }
 
 fn decode_raw_strided_into_existing<T>(
-    decoder: &mut JpegDecoder<T>, planes: &mut [Vec<u8>], strides: &[usize]
+    raw: &mut RawDecodeSession<'_, T>, planes: &mut [Vec<u8>], strides: &[usize]
 ) -> Result<(), zune_jpeg::errors::DecodeErrors>
 where
     T: ZByteReaderTrait
 {
     let mut plane_refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    decoder.decode_raw_strided(&mut plane_refs, strides)
+    raw.decode_into_strided(&mut plane_refs, strides)
 }
 
 fn decode_raw_oneshot(data: &[u8]) -> Vec<Vec<u8>> {
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
-    decoder.decode_headers().expect("one-shot raw headers failed");
-    let mut planes = allocate_raw_planes(&decoder);
-    decode_raw_into_existing(&mut decoder, &mut planes).expect("one-shot raw decode failed");
+    decoder
+        .decode_headers()
+        .expect("one-shot raw headers failed");
+    let mut raw = decoder.raw_output();
+    let mut planes = allocate_raw_planes(&raw);
+    decode_raw_into_existing(&mut raw, &mut planes).expect("one-shot raw decode failed");
     planes
 }
 
-fn assert_raw_planes_match(
-    actual: &[Vec<u8>], expected: &[Vec<u8>], name: &str, available: usize
-) {
+fn assert_raw_planes_match(actual: &[Vec<u8>], expected: &[Vec<u8>], name: &str, available: usize) {
     assert_eq!(
         actual.len(),
         expected.len(),
         "{name}: incremental and one-shot raw plane counts differ"
     );
 
-    for (plane_index, (actual_plane, expected_plane)) in
-        actual.iter().zip(expected).enumerate()
-    {
+    for (plane_index, (actual_plane, expected_plane)) in actual.iter().zip(expected).enumerate() {
         assert_eq!(
             actual_plane.len(),
             expected_plane.len(),
@@ -310,17 +309,26 @@ fn assert_raw_planes_match(
 }
 
 fn assert_raw_strided_planes_match_padded(
-    actual: &[Vec<u8>], strides: &[usize], expected: &[Vec<u8>], name: &str,
-    data: &[u8], available: usize
+    actual: &[Vec<u8>], strides: &[usize], expected: &[Vec<u8>], name: &str, data: &[u8],
+    available: usize
 ) {
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n_components = decoder.num_components().unwrap();
+    let raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n_components = raw.num_components().unwrap();
 
-    assert_eq!(actual.len(), n_components, "{name}: strided plane count differs");
+    assert_eq!(
+        actual.len(),
+        n_components,
+        "{name}: strided plane count differs"
+    );
     assert_eq!(strides.len(), n_components, "{name}: stride count differs");
-    assert_eq!(expected.len(), n_components, "{name}: padded plane count differs");
+    assert_eq!(
+        expected.len(),
+        n_components,
+        "{name}: padded plane count differs"
+    );
 
     for index in 0..n_components {
         let plane = layout[index];
@@ -357,32 +365,29 @@ fn assert_incremental_raw_decode_matches_oneshot(name: &str, data: &[u8], step: 
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
 
-    let mut header_done = false;
-    let mut planes: Vec<Vec<u8>> = Vec::new();
     let mut available = 0_usize;
 
     loop {
         available = (available + step).min(data.len());
         limit.set(available);
 
-        if !header_done {
-            match decoder.decode_headers() {
-                Ok(()) => {
-                    header_done = true;
-                    planes = allocate_raw_planes(&decoder);
-                }
-                Err(ref err) if err.is_recoverable_eof() => {
-                    assert!(
-                        available < data.len(),
-                        "raw headers still need more data with the full input visible"
-                    );
-                    continue;
-                }
-                Err(err) => panic!("unexpected raw header error at byte {available}: {err:?}")
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(ref err) if err.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "raw headers still need more data with the full input visible"
+                );
             }
+            Err(err) => panic!("unexpected raw header error at byte {available}: {err:?}")
         }
+    }
 
-        match decode_raw_into_existing(&mut decoder, &mut planes) {
+    let mut raw = decoder.raw_output();
+    let mut planes = allocate_raw_planes(&raw);
+
+    loop {
+        match decode_raw_into_existing(&mut raw, &mut planes) {
             Ok(()) => {
                 assert_raw_planes_match(&planes, &expected, name, available);
                 return;
@@ -392,15 +397,15 @@ fn assert_incremental_raw_decode_matches_oneshot(name: &str, data: &[u8], step: 
                     available < data.len(),
                     "raw scan still needs more data with the full input visible"
                 );
+                available = (available + step).min(data.len());
+                limit.set(available);
             }
             Err(err) => panic!("unexpected raw scan error at byte {available}: {err:?}")
         }
     }
 }
 
-fn assert_incremental_raw_strided_decode_matches_oneshot(
-    name: &str, data: &[u8], step: usize
-) {
+fn assert_incremental_raw_strided_decode_matches_oneshot(name: &str, data: &[u8], step: usize) {
     assert!(step > 0, "incremental step must be non-zero");
 
     let expected = decode_raw_oneshot(data);
@@ -408,35 +413,31 @@ fn assert_incremental_raw_strided_decode_matches_oneshot(
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
 
-    let mut header_done = false;
-    let mut planes: Vec<Vec<u8>> = Vec::new();
-    let mut strides: Vec<usize> = Vec::new();
     let mut available = 0_usize;
 
     loop {
         available = (available + step).min(data.len());
         limit.set(available);
 
-        if !header_done {
-            match decoder.decode_headers() {
-                Ok(()) => {
-                    header_done = true;
-                    (planes, strides) = allocate_raw_strided_planes(&decoder);
-                }
-                Err(ref err) if err.is_recoverable_eof() => {
-                    assert!(
-                        available < data.len(),
-                        "raw strided headers still need more data with the full input visible"
-                    );
-                    continue;
-                }
-                Err(err) => {
-                    panic!("unexpected raw strided header error at byte {available}: {err:?}")
-                }
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(ref err) if err.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "raw strided headers still need more data with the full input visible"
+                );
+            }
+            Err(err) => {
+                panic!("unexpected raw strided header error at byte {available}: {err:?}")
             }
         }
+    }
 
-        match decode_raw_strided_into_existing(&mut decoder, &mut planes, &strides) {
+    let mut raw = decoder.raw_output();
+    let (mut planes, strides) = allocate_raw_strided_planes(&raw);
+
+    loop {
+        match decode_raw_strided_into_existing(&mut raw, &mut planes, &strides) {
             Ok(()) => {
                 assert_raw_strided_planes_match_padded(
                     &planes, &strides, &expected, name, data, available
@@ -448,6 +449,8 @@ fn assert_incremental_raw_strided_decode_matches_oneshot(
                     available < data.len(),
                     "raw strided scan still needs more data with the full input visible"
                 );
+                available = (available + step).min(data.len());
+                limit.set(available);
             }
             Err(err) => panic!("unexpected raw strided scan error at byte {available}: {err:?}")
         }
@@ -459,12 +462,13 @@ fn assert_decode_raw_replay_matches_oneshot(name: &str, data: &[u8]) {
 
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode_headers().unwrap();
-    let mut first = allocate_raw_planes(&decoder);
-    decode_raw_into_existing(&mut decoder, &mut first).unwrap();
+    let mut raw = decoder.raw_output();
+    let mut first = allocate_raw_planes(&raw);
+    decode_raw_into_existing(&mut raw, &mut first).unwrap();
     assert_raw_planes_match(&first, &expected, name, data.len());
 
-    let mut replay = allocate_raw_planes(&decoder);
-    decode_raw_into_existing(&mut decoder, &mut replay).unwrap();
+    let mut replay = allocate_raw_planes(&raw);
+    decode_raw_into_existing(&mut raw, &mut replay).unwrap();
     assert_raw_planes_match(&replay, &expected, name, data.len());
 }
 
@@ -473,13 +477,14 @@ fn assert_decode_raw_strided_replay_matches_oneshot(name: &str, data: &[u8]) {
 
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode_headers().unwrap();
-    let (mut first, strides) = allocate_raw_strided_planes(&decoder);
-    decode_raw_strided_into_existing(&mut decoder, &mut first, &strides).unwrap();
+    let mut raw = decoder.raw_output();
+    let (mut first, strides) = allocate_raw_strided_planes(&raw);
+    decode_raw_strided_into_existing(&mut raw, &mut first, &strides).unwrap();
     assert_raw_strided_planes_match_padded(&first, &strides, &expected, name, data, data.len());
 
-    let (mut replay, replay_strides) = allocate_raw_strided_planes(&decoder);
+    let (mut replay, replay_strides) = allocate_raw_strided_planes(&raw);
     assert_eq!(replay_strides, strides);
-    decode_raw_strided_into_existing(&mut decoder, &mut replay, &replay_strides).unwrap();
+    decode_raw_strided_into_existing(&mut raw, &mut replay, &replay_strides).unwrap();
     assert_raw_strided_planes_match_padded(
         &replay,
         &replay_strides,
@@ -1973,8 +1978,9 @@ fn arithmetic_restart_raw_resume_uses_rst_checkpoint() {
     decoder
         .decode_headers()
         .expect("headers should be visible before first raw RST retry");
-    let mut planes = allocate_raw_planes(&decoder);
-    let err = decode_raw_into_existing(&mut decoder, &mut planes)
+    let mut raw = decoder.raw_output();
+    let mut planes = allocate_raw_planes(&raw);
+    let err = decode_raw_into_existing(&mut raw, &mut planes)
         .expect_err("truncated raw scan after first RST should be recoverable");
     assert!(
         err.is_recoverable_eof(),
@@ -1983,7 +1989,7 @@ fn arithmetic_restart_raw_resume_uses_rst_checkpoint() {
 
     seek_log.borrow_mut().clear();
     limit.set(data.len());
-    decode_raw_into_existing(&mut decoder, &mut planes)
+    decode_raw_into_existing(&mut raw, &mut planes)
         .expect("full input should resume raw decode from RST checkpoint");
 
     let seeks = seek_log.borrow();

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -2736,6 +2736,7 @@ fn checkpointed_pixel_decoder<'a>(
     let limit = Rc::new(Cell::new(cutoff));
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new_with_options(cursor, options);
+    decoder.set_incremental_mode(true);
     decoder.decode_headers().unwrap();
     let mut output = vec![0; decoder.output_buffer_size().unwrap()];
     for _ in 0..2 {

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -15,10 +15,10 @@ use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
 use zune_core::colorspace::ColorSpace;
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
-use zune_jpeg::{JpegDecoder, RawDecodeSession};
+use zune_jpeg::{JpegDecoder, RawDecodeSession, RawImcuRowStatus};
 
 use std::cell::{Cell, RefCell};
-use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::io::{BufRead, Cursor, Read, Seek, SeekFrom};
 use std::rc::Rc;
 
 /// A cursor over a byte slice with an adjustable visibility limit.
@@ -105,6 +105,44 @@ impl Seek for GrowableCursor<'_> {
             seek_log.borrow_mut().push(self.position);
         }
         Ok(self.position as u64)
+    }
+}
+
+struct PositionFailCursor<'a> {
+    inner:       Cursor<&'a [u8]>,
+    calls:       Rc<Cell<usize>>,
+    fail_on_call: Rc<Cell<usize>>
+}
+
+impl Read for PositionFailCursor<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl BufRead for PositionFailCursor<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+impl Seek for PositionFailCursor<'_> {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        if position == SeekFrom::Current(0) {
+            let call = self.calls.get() + 1;
+            self.calls.set(call);
+            if self.fail_on_call.get() == call {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "injected position failure"
+                ));
+            }
+        }
+        self.inner.seek(position)
     }
 }
 
@@ -454,6 +492,78 @@ fn assert_incremental_raw_strided_decode_matches_oneshot(name: &str, data: &[u8]
                 limit.set(available);
             }
             Err(err) => panic!("unexpected raw strided scan error at byte {available}: {err:?}")
+        }
+    }
+}
+
+fn assert_incremental_raw_pull_matches_oneshot(name: &str, data: &[u8], step: usize) {
+    let expected = decode_raw_oneshot(data);
+    let limit = Rc::new(Cell::new(0usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+    let mut available = 0usize;
+
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(error) if error.is_recoverable_eof() => continue,
+            Err(error) => panic!("{name}: unexpected header error: {error:?}")
+        }
+    }
+
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut actual: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.height])
+        .collect();
+    let mut rows_emitted = [0usize; 4];
+    let mut suspended_before_first_row = false;
+
+    loop {
+        let mut stripe_storage: Vec<Vec<u8>> = layout[..count]
+            .iter()
+            .map(|plane| vec![0xCD; plane.width * plane.vertical_sampling_factor * 8])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = stripe_storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    let bytes = rows_written[index] * strides[index];
+                    let dst = rows_emitted[index] * strides[index];
+                    actual[index][dst..dst + bytes]
+                        .copy_from_slice(&stripe_storage[index][..bytes]);
+                    rows_emitted[index] += rows_written[index];
+                }
+            }
+            RawImcuRowStatus::NeedMoreInput => {
+                assert!(
+                    stripe_storage.iter().flatten().all(|byte| *byte == 0xCD),
+                    "{name}: suspended pull modified caller storage"
+                );
+                if rows_emitted[..count].iter().all(|rows| *rows == 0) {
+                    suspended_before_first_row = true;
+                }
+                assert!(available < data.len(), "{name}: suspended with full input");
+                available = (available + step).min(data.len());
+                limit.set(available);
+            }
+            RawImcuRowStatus::Complete => {
+                assert!(
+                    suspended_before_first_row,
+                    "{name}: test did not suspend before publishing its first row"
+                );
+                assert_raw_strided_planes_match_padded(
+                    &actual, &strides, &expected, name, data, available
+                );
+                return;
+            }
+            _ => unreachable!("unknown raw iMCU-row status")
         }
     }
 }
@@ -1896,6 +2006,88 @@ fn raw_strided_incremental_parity() {
 }
 
 #[test]
+fn raw_pull_incremental_parity() {
+    assert_incremental_raw_pull_matches_oneshot(
+        "baseline_pull",
+        include_bytes!("../../../test-images/jpeg/synthetic_image.jpg"),
+        37
+    );
+    assert_incremental_raw_pull_matches_oneshot(
+        "progressive_pull",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+        31
+    );
+    assert_incremental_raw_pull_matches_oneshot(
+        "restart_pull",
+        include_bytes!("../../../test-images/jpeg/four_components.jpg"),
+        97
+    );
+    assert_incremental_raw_pull_matches_oneshot(
+        "multi_sos_pull",
+        include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg"),
+        31
+    );
+}
+
+#[test]
+fn raw_pull_checkpoint_failure_is_atomic() {
+    let data = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let calls = Rc::new(Cell::new(0usize));
+    let fail_on_call = Rc::new(Cell::new(0usize));
+    let cursor = PositionFailCursor {
+        inner: Cursor::new(data.as_slice()),
+        calls: Rc::clone(&calls),
+        fail_on_call: Rc::clone(&fail_on_call)
+    };
+    let mut decoder = JpegDecoder::new(cursor);
+    decoder.decode_headers().unwrap();
+    calls.set(0);
+    fail_on_call.set(2);
+
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0xCD; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    assert_eq!(
+        raw.decode_next_imcu_row(&mut refs, &strides).unwrap(),
+        RawImcuRowStatus::NeedMoreInput
+    );
+    assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+
+    fail_on_call.set(0);
+    let mut retry_storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut retry_refs: Vec<&mut [u8]> =
+        retry_storage.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut retry_refs, &strides).unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_raw_pull_incremental_parity() {
+    assert_incremental_raw_pull_matches_oneshot(
+        "arithmetic_restart_pull",
+        include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg"),
+        23
+    );
+    assert_incremental_raw_pull_matches_oneshot(
+        "arithmetic_progressive_pull",
+        include_bytes!("../../../test-images/jpeg/arith/prog.jpg"),
+        23
+    );
+}
+
+#[test]
 #[cfg(feature = "arith")]
 fn arithmetic_incremental_parity() {
     assert_incremental_decode_matrix(&[
@@ -2761,6 +2953,43 @@ fn switching_checkpointed_pixel_decode_to_whole_raw_replays_from_start() {
     let mut actual = allocate_raw_planes(&raw);
     decode_raw_into_existing(&mut raw, &mut actual).unwrap();
     assert_raw_planes_match(&actual, &expected, "pixel_to_whole_raw", data.len());
+}
+
+#[test]
+fn switching_checkpointed_pixel_decode_to_raw_pull_replays_from_start() {
+    let data = include_bytes!("../../../test-images/jpeg/sampling_factors.jpg");
+    let entropy_start = entropy_start(data);
+    let cutoff = entropy_start + (data.len() - entropy_start) * 60 / 100;
+    let expected = decode_raw_oneshot(data);
+    let (mut decoder, limit) =
+        checkpointed_pixel_decoder(data, cutoff, DecoderOptions::default());
+    limit.set(data.len());
+
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<_> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut planes: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    let rows_written = match raw
+        .decode_next_imcu_row(&mut planes, &strides)
+        .unwrap()
+    {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("raw pull did not replay its first stripe")
+    };
+    for index in 0..count {
+        for row in 0..rows_written[index] {
+            assert_eq!(
+                &storage[index][row * strides[index]..(row + 1) * strides[index]],
+                &expected[index]
+                    [row * layout[index].stride..row * layout[index].stride + strides[index]]
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -11,7 +11,7 @@
 //! Verifies that `is_recoverable_eof()` is reported on truncated input
 //! and that retrying with more data produces correct output.
 
-use zune_core::bytestream::ZCursor;
+use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::JpegDecoder;
@@ -220,6 +220,276 @@ fn assert_decode_into_replay_matches_oneshot(name: &str, data: &[u8]) {
     assert_pixels_match(&replay, &expected, name, data.len());
 }
 
+fn allocate_raw_planes<T>(decoder: &JpegDecoder<T>) -> Vec<Vec<u8>>
+where
+    T: ZByteReaderTrait
+{
+    let layout = decoder.planar_layout().unwrap();
+    let n_components = decoder.num_components().unwrap();
+    (0..n_components)
+        .map(|index| vec![0u8; layout[index].byte_size])
+        .collect()
+}
+
+fn decode_raw_into_existing<T>(
+    decoder: &mut JpegDecoder<T>, planes: &mut [Vec<u8>]
+) -> Result<(), zune_jpeg::errors::DecodeErrors>
+where
+    T: ZByteReaderTrait
+{
+    let mut plane_refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    decoder.decode_raw(&mut plane_refs)
+}
+
+fn allocate_raw_strided_planes<T>(decoder: &JpegDecoder<T>) -> (Vec<Vec<u8>>, Vec<usize>)
+where
+    T: ZByteReaderTrait
+{
+    let layout = decoder.planar_layout().unwrap();
+    let n_components = decoder.num_components().unwrap();
+    let strides: Vec<usize> = (0..n_components)
+        .map(|index| layout[index].width + 5)
+        .collect();
+    let planes = (0..n_components)
+        .map(|index| vec![0xAAu8; strides[index] * layout[index].height])
+        .collect();
+    (planes, strides)
+}
+
+fn decode_raw_strided_into_existing<T>(
+    decoder: &mut JpegDecoder<T>, planes: &mut [Vec<u8>], strides: &[usize]
+) -> Result<(), zune_jpeg::errors::DecodeErrors>
+where
+    T: ZByteReaderTrait
+{
+    let mut plane_refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    decoder.decode_raw_strided(&mut plane_refs, strides)
+}
+
+fn decode_raw_oneshot(data: &[u8]) -> Vec<Vec<u8>> {
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().expect("one-shot raw headers failed");
+    let mut planes = allocate_raw_planes(&decoder);
+    decode_raw_into_existing(&mut decoder, &mut planes).expect("one-shot raw decode failed");
+    planes
+}
+
+fn assert_raw_planes_match(
+    actual: &[Vec<u8>], expected: &[Vec<u8>], name: &str, available: usize
+) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{name}: incremental and one-shot raw plane counts differ"
+    );
+
+    for (plane_index, (actual_plane, expected_plane)) in
+        actual.iter().zip(expected).enumerate()
+    {
+        assert_eq!(
+            actual_plane.len(),
+            expected_plane.len(),
+            "{name}: raw plane {plane_index} lengths differ"
+        );
+        if let Some(index) = actual_plane
+            .iter()
+            .zip(expected_plane)
+            .position(|(left, right)| left != right)
+        {
+            let start = index.saturating_sub(8);
+            let end = (index + 9).min(actual_plane.len());
+            panic!(
+                "{name}: first raw plane {plane_index} mismatch at {index} with {available} bytes visible: incremental={}, one-shot={}, incremental window={:?}, one-shot window={:?}",
+                actual_plane[index],
+                expected_plane[index],
+                &actual_plane[start..end],
+                &expected_plane[start..end]
+            );
+        }
+    }
+}
+
+fn assert_raw_strided_planes_match_padded(
+    actual: &[Vec<u8>], strides: &[usize], expected: &[Vec<u8>], name: &str,
+    data: &[u8], available: usize
+) {
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n_components = decoder.num_components().unwrap();
+
+    assert_eq!(actual.len(), n_components, "{name}: strided plane count differs");
+    assert_eq!(strides.len(), n_components, "{name}: stride count differs");
+    assert_eq!(expected.len(), n_components, "{name}: padded plane count differs");
+
+    for index in 0..n_components {
+        let plane = layout[index];
+        assert_eq!(
+            actual[index].len(),
+            strides[index] * plane.height,
+            "{name}: strided plane {index} length differs"
+        );
+        for y in 0..plane.height {
+            for x in 0..plane.width {
+                let actual_value = actual[index][y * strides[index] + x];
+                let expected_value = expected[index][y * plane.stride + x];
+                assert_eq!(
+                    actual_value, expected_value,
+                    "{name}: strided raw plane {index} mismatch at ({x},{y}) with {available} bytes visible"
+                );
+            }
+            for x in plane.width..strides[index] {
+                assert_eq!(
+                    actual[index][y * strides[index] + x],
+                    0xAA,
+                    "{name}: strided padding modified in plane {index} at ({x},{y})"
+                );
+            }
+        }
+    }
+}
+
+fn assert_incremental_raw_decode_matches_oneshot(name: &str, data: &[u8], step: usize) {
+    assert!(step > 0, "incremental step must be non-zero");
+
+    let expected = decode_raw_oneshot(data);
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    let mut header_done = false;
+    let mut planes: Vec<Vec<u8>> = Vec::new();
+    let mut available = 0_usize;
+
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+
+        if !header_done {
+            match decoder.decode_headers() {
+                Ok(()) => {
+                    header_done = true;
+                    planes = allocate_raw_planes(&decoder);
+                }
+                Err(ref err) if err.is_recoverable_eof() => {
+                    assert!(
+                        available < data.len(),
+                        "raw headers still need more data with the full input visible"
+                    );
+                    continue;
+                }
+                Err(err) => panic!("unexpected raw header error at byte {available}: {err:?}")
+            }
+        }
+
+        match decode_raw_into_existing(&mut decoder, &mut planes) {
+            Ok(()) => {
+                assert_raw_planes_match(&planes, &expected, name, available);
+                return;
+            }
+            Err(ref err) if err.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "raw scan still needs more data with the full input visible"
+                );
+            }
+            Err(err) => panic!("unexpected raw scan error at byte {available}: {err:?}")
+        }
+    }
+}
+
+fn assert_incremental_raw_strided_decode_matches_oneshot(
+    name: &str, data: &[u8], step: usize
+) {
+    assert!(step > 0, "incremental step must be non-zero");
+
+    let expected = decode_raw_oneshot(data);
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    let mut header_done = false;
+    let mut planes: Vec<Vec<u8>> = Vec::new();
+    let mut strides: Vec<usize> = Vec::new();
+    let mut available = 0_usize;
+
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+
+        if !header_done {
+            match decoder.decode_headers() {
+                Ok(()) => {
+                    header_done = true;
+                    (planes, strides) = allocate_raw_strided_planes(&decoder);
+                }
+                Err(ref err) if err.is_recoverable_eof() => {
+                    assert!(
+                        available < data.len(),
+                        "raw strided headers still need more data with the full input visible"
+                    );
+                    continue;
+                }
+                Err(err) => {
+                    panic!("unexpected raw strided header error at byte {available}: {err:?}")
+                }
+            }
+        }
+
+        match decode_raw_strided_into_existing(&mut decoder, &mut planes, &strides) {
+            Ok(()) => {
+                assert_raw_strided_planes_match_padded(
+                    &planes, &strides, &expected, name, data, available
+                );
+                return;
+            }
+            Err(ref err) if err.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "raw strided scan still needs more data with the full input visible"
+                );
+            }
+            Err(err) => panic!("unexpected raw strided scan error at byte {available}: {err:?}")
+        }
+    }
+}
+
+fn assert_decode_raw_replay_matches_oneshot(name: &str, data: &[u8]) {
+    let expected = decode_raw_oneshot(data);
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    let mut first = allocate_raw_planes(&decoder);
+    decode_raw_into_existing(&mut decoder, &mut first).unwrap();
+    assert_raw_planes_match(&first, &expected, name, data.len());
+
+    let mut replay = allocate_raw_planes(&decoder);
+    decode_raw_into_existing(&mut decoder, &mut replay).unwrap();
+    assert_raw_planes_match(&replay, &expected, name, data.len());
+}
+
+fn assert_decode_raw_strided_replay_matches_oneshot(name: &str, data: &[u8]) {
+    let expected = decode_raw_oneshot(data);
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    let (mut first, strides) = allocate_raw_strided_planes(&decoder);
+    decode_raw_strided_into_existing(&mut decoder, &mut first, &strides).unwrap();
+    assert_raw_strided_planes_match_padded(&first, &strides, &expected, name, data, data.len());
+
+    let (mut replay, replay_strides) = allocate_raw_strided_planes(&decoder);
+    assert_eq!(replay_strides, strides);
+    decode_raw_strided_into_existing(&mut decoder, &mut replay, &replay_strides).unwrap();
+    assert_raw_strided_planes_match_padded(
+        &replay,
+        &replay_strides,
+        &expected,
+        name,
+        data,
+        data.len()
+    );
+}
+
 /// Feeding the entire file at once via decode_headers + decode_into must
 /// produce byte-identical output to decode() — no regressions.
 #[test]
@@ -242,6 +512,30 @@ fn decode_into_replay_after_success_matches_oneshot() {
     );
     assert_decode_into_replay_matches_oneshot(
         "progressive_replay",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg")
+    );
+}
+
+#[test]
+fn decode_raw_replay_after_success_matches_oneshot() {
+    assert_decode_raw_replay_matches_oneshot(
+        "baseline_raw_replay",
+        include_bytes!("../../../test-images/jpeg/synthetic_image.jpg")
+    );
+    assert_decode_raw_replay_matches_oneshot(
+        "progressive_raw_replay",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg")
+    );
+}
+
+#[test]
+fn decode_raw_strided_replay_after_success_matches_oneshot() {
+    assert_decode_raw_strided_replay_matches_oneshot(
+        "baseline_raw_strided_replay",
+        include_bytes!("../../../test-images/jpeg/fox410.jpg")
+    );
+    assert_decode_raw_strided_replay_matches_oneshot(
+        "progressive_raw_strided_replay",
         include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg")
     );
 }
@@ -1451,6 +1745,20 @@ fn progressive_repeated_dc_eof_falls_back_to_scan_boundary() {
 }
 
 #[test]
+fn raw_incremental_parity() {
+    assert_incremental_raw_decode_matches_oneshot(
+        "synthetic_image_raw",
+        include_bytes!("../../../test-images/jpeg/synthetic_image.jpg"),
+        37
+    );
+    assert_incremental_raw_decode_matches_oneshot(
+        "down_sampled_grayscale_prog_raw",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+        31
+    );
+}
+
+#[test]
 fn progressive_unsafe_scans_replay_from_scan_boundary() {
     let data = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
     let expected = decode_oneshot(data);
@@ -1568,6 +1876,20 @@ fn progressive_arithmetic_restart_replays_dc_scan_boundary() {
 }
 
 #[test]
+fn raw_strided_incremental_parity() {
+    assert_incremental_raw_strided_decode_matches_oneshot(
+        "fox410_raw_strided",
+        include_bytes!("../../../test-images/jpeg/fox410.jpg"),
+        4096
+    );
+    assert_incremental_raw_strided_decode_matches_oneshot(
+        "down_sampled_grayscale_prog_raw_strided",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+        31
+    );
+}
+
+#[test]
 #[cfg(feature = "arith")]
 fn arithmetic_incremental_parity() {
     assert_incremental_decode_matrix(&[
@@ -1636,6 +1958,40 @@ fn arithmetic_restart_resume_uses_rst_checkpoint() {
         "retry should seek to first RST checkpoint at 857, got {seeks:?}"
     );
     assert_pixels_match(&out, &expected, "arith_seq_restart_checkpoint", data.len());
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_restart_raw_resume_uses_rst_checkpoint() {
+    let data = include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg");
+    let expected = decode_raw_oneshot(data);
+    let limit = Rc::new(Cell::new(874_usize));
+    let seek_log = Rc::new(RefCell::new(Vec::new()));
+    let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    decoder
+        .decode_headers()
+        .expect("headers should be visible before first raw RST retry");
+    let mut planes = allocate_raw_planes(&decoder);
+    let err = decode_raw_into_existing(&mut decoder, &mut planes)
+        .expect_err("truncated raw scan after first RST should be recoverable");
+    assert!(
+        err.is_recoverable_eof(),
+        "expected recoverable EOF, got {err:?}"
+    );
+
+    seek_log.borrow_mut().clear();
+    limit.set(data.len());
+    decode_raw_into_existing(&mut decoder, &mut planes)
+        .expect("full input should resume raw decode from RST checkpoint");
+
+    let seeks = seek_log.borrow();
+    assert!(
+        seeks.contains(&857),
+        "raw retry should seek to first RST checkpoint at 857, got {seeks:?}"
+    );
+    assert_raw_planes_match(&planes, &expected, "arith_seq_restart_raw_checkpoint", data.len());
 }
 
 /// Sanity check: byte-by-byte incremental decode of a normal image (no

--- a/crates/zune-jpeg/tests/non_interleaved.rs
+++ b/crates/zune-jpeg/tests/non_interleaved.rs
@@ -17,6 +17,12 @@
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::JpegDecoder;
 
+fn pixel_digest(pixels: &[u8]) -> u64 {
+    pixels.iter().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
+}
+
 /// Test decoding a non-interleaved 4:4:4 baseline JPEG (64x64).
 ///
 /// This test image has 3 separate SOS markers (one per Y, Cb, Cr component).
@@ -85,6 +91,7 @@ fn decode_non_interleaved_420_64x64() {
     assert_eq!(info.width, 64);
     assert_eq!(info.height, 64);
     assert_eq!(pixels.len(), 64 * 64 * 3);
+    assert_eq!(pixel_digest(&pixels), 0xcb8faa9b4c94a0e5);
 
     // All pixels should have color (no large black regions from failed upsampling)
     let non_black = pixels.chunks(3).filter(|c| c[0] > 5 || c[1] > 5 || c[2] > 5).count();
@@ -123,6 +130,7 @@ fn decode_non_interleaved_440_64x64() {
     assert_eq!(info.width, 64);
     assert_eq!(info.height, 64);
     assert_eq!(pixels.len(), 64 * 64 * 3);
+    assert_eq!(pixel_digest(&pixels), 0xcb8faa9b4c94a0e5);
 }
 
 /// Test that the existing sos_news.jpeg (non-interleaved) still works.

--- a/crates/zune-jpeg/tests/planar_layout.rs
+++ b/crates/zune-jpeg/tests/planar_layout.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-//! Tests for `JpegDecoder::planar_layout()` and `num_components()`.
+//! Tests for raw output session layout and component metadata.
 //!
 //! These verify the per-component plane geometry exposed for raw planar
 //! output, against fixture images with known dimensions and sampling
@@ -20,16 +20,31 @@ use zune_jpeg::JpegDecoder;
 fn layout_for(bytes: &[u8]) -> ([zune_jpeg::PlaneInfo; 4], usize) {
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().expect("decode_headers failed");
-    let n = decoder.num_components().expect("num_components");
-    let layout = decoder.planar_layout().expect("planar_layout");
+    let raw = decoder.raw_output();
+    let n = raw.num_components().expect("num_components");
+    let layout = raw.layout().expect("raw layout");
     (layout, n)
+}
+
+fn assert_sampling_factors(layout: &[zune_jpeg::PlaneInfo], expected: &[(usize, usize)]) {
+    let actual: Vec<(usize, usize)> = layout
+        .iter()
+        .map(|plane| {
+            (
+                plane.horizontal_sampling_factor,
+                plane.vertical_sampling_factor
+            )
+        })
+        .collect();
+    assert_eq!(actual, expected);
 }
 
 #[test]
 fn planar_layout_unavailable_before_headers() {
-    let decoder = JpegDecoder::new(ZCursor::new(&[][..]));
-    assert!(decoder.num_components().is_none());
-    assert!(decoder.planar_layout().is_none());
+    let mut decoder = JpegDecoder::new(ZCursor::new(&[][..]));
+    let raw = decoder.raw_output();
+    assert!(raw.num_components().is_none());
+    assert!(raw.layout().is_none());
 }
 
 #[test]
@@ -37,6 +52,7 @@ fn planar_layout_444_64x64_aligned() {
     let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
     let (layout, n) = layout_for(bytes);
     assert_eq!(n, 3, "expected 3 components for YCbCr 4:4:4");
+    assert_sampling_factors(&layout[..n], &[(1, 1), (1, 1), (1, 1)]);
     for plane in &layout[..3] {
         assert_eq!(plane.width, 64);
         assert_eq!(plane.height, 64);
@@ -53,6 +69,7 @@ fn planar_layout_422_64x64_aligned() {
     let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg");
     let (layout, n) = layout_for(bytes);
     assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(2, 1), (1, 1), (1, 1)]);
     // Y: full resolution.
     assert_eq!(layout[0].width, 64);
     assert_eq!(layout[0].height, 64);
@@ -73,6 +90,7 @@ fn planar_layout_420_64x64_aligned() {
     let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
     let (layout, n) = layout_for(bytes);
     assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(2, 2), (1, 1), (1, 1)]);
     assert_eq!(layout[0].width, 64);
     assert_eq!(layout[0].height, 64);
     assert_eq!(layout[0].stride, 64);
@@ -91,6 +109,7 @@ fn planar_layout_440_64x64_aligned() {
     let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg");
     let (layout, n) = layout_for(bytes);
     assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(1, 2), (1, 1), (1, 1)]);
     // Y: full resolution.
     assert_eq!(layout[0].width, 64);
     assert_eq!(layout[0].height, 64);
@@ -122,4 +141,27 @@ fn planar_layout_422_65x65_unaligned_pads_to_dct_block() {
         assert_eq!(plane.allocated_height, 72);
         assert_eq!(plane.byte_size, 40 * 72);
     }
+}
+
+#[test]
+fn planar_layout_exposes_411_sampling_factors() {
+    let mut bytes =
+        include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg").to_vec();
+    let sof = bytes
+        .windows(2)
+        .position(|marker| marker == [0xff, 0xc0])
+        .expect("SOF0 marker");
+    bytes[sof + 11] = 0x41;
+
+    let (layout, n) = layout_for(&bytes);
+    assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(4, 1), (1, 1), (1, 1)]);
+}
+
+#[test]
+fn planar_layout_exposes_410_sampling_factors() {
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(4, 2), (1, 1), (1, 1)]);
 }

--- a/crates/zune-jpeg/tests/planar_layout.rs
+++ b/crates/zune-jpeg/tests/planar_layout.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+//! Tests for `JpegDecoder::planar_layout()` and `num_components()`.
+//!
+//! These verify the per-component plane geometry exposed for raw planar
+//! output, against fixture images with known dimensions and sampling
+//! factors. The math mirrors libjpeg-turbo's `jpeg_read_raw_data`:
+//! component dimensions are derived from sampling factors, then both
+//! axes are rounded up to DCT-block (8 sample) boundaries.
+
+use zune_core::bytestream::ZCursor;
+use zune_jpeg::JpegDecoder;
+
+fn layout_for(bytes: &[u8]) -> ([zune_jpeg::PlaneInfo; 4], usize) {
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().expect("decode_headers failed");
+    let n = decoder.num_components().expect("num_components");
+    let layout = decoder.planar_layout().expect("planar_layout");
+    (layout, n)
+}
+
+#[test]
+fn planar_layout_unavailable_before_headers() {
+    let decoder = JpegDecoder::new(ZCursor::new(&[][..]));
+    assert!(decoder.num_components().is_none());
+    assert!(decoder.planar_layout().is_none());
+}
+
+#[test]
+fn planar_layout_444_64x64_aligned() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3, "expected 3 components for YCbCr 4:4:4");
+    for plane in &layout[..3] {
+        assert_eq!(plane.width, 64);
+        assert_eq!(plane.height, 64);
+        assert_eq!(plane.stride, 64);
+        assert_eq!(plane.allocated_height, 64);
+        assert_eq!(plane.byte_size, 64 * 64);
+    }
+    // Trailing slot is unused/zero.
+    assert_eq!(layout[3], zune_jpeg::PlaneInfo::default());
+}
+
+#[test]
+fn planar_layout_422_64x64_aligned() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    // Y: full resolution.
+    assert_eq!(layout[0].width, 64);
+    assert_eq!(layout[0].height, 64);
+    assert_eq!(layout[0].stride, 64);
+    assert_eq!(layout[0].allocated_height, 64);
+    // Cb, Cr: half horizontal, full vertical.
+    for plane in &layout[1..3] {
+        assert_eq!(plane.width, 32);
+        assert_eq!(plane.height, 64);
+        assert_eq!(plane.stride, 32);
+        assert_eq!(plane.allocated_height, 64);
+        assert_eq!(plane.byte_size, 32 * 64);
+    }
+}
+
+#[test]
+fn planar_layout_420_64x64_aligned() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    assert_eq!(layout[0].width, 64);
+    assert_eq!(layout[0].height, 64);
+    assert_eq!(layout[0].stride, 64);
+    assert_eq!(layout[0].allocated_height, 64);
+    for plane in &layout[1..3] {
+        assert_eq!(plane.width, 32);
+        assert_eq!(plane.height, 32);
+        assert_eq!(plane.stride, 32);
+        assert_eq!(plane.allocated_height, 32);
+        assert_eq!(plane.byte_size, 32 * 32);
+    }
+}
+
+#[test]
+fn planar_layout_440_64x64_aligned() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    // Y: full resolution.
+    assert_eq!(layout[0].width, 64);
+    assert_eq!(layout[0].height, 64);
+    // Cb, Cr: full horizontal, half vertical.
+    for plane in &layout[1..3] {
+        assert_eq!(plane.width, 64);
+        assert_eq!(plane.height, 32);
+        assert_eq!(plane.stride, 64);
+        assert_eq!(plane.allocated_height, 32);
+    }
+}
+
+#[test]
+fn planar_layout_422_65x65_unaligned_pads_to_dct_block() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    // Y: 65x65 → padded to 72x72.
+    assert_eq!(layout[0].width, 65);
+    assert_eq!(layout[0].height, 65);
+    assert_eq!(layout[0].stride, 72);
+    assert_eq!(layout[0].allocated_height, 72);
+    assert_eq!(layout[0].byte_size, 72 * 72);
+    // Cb, Cr: ceil(65/2) = 33 wide, 65 tall → padded to 40x72.
+    for plane in &layout[1..3] {
+        assert_eq!(plane.width, 33);
+        assert_eq!(plane.height, 65);
+        assert_eq!(plane.stride, 40);
+        assert_eq!(plane.allocated_height, 72);
+        assert_eq!(plane.byte_size, 40 * 72);
+    }
+}

--- a/crates/zune-jpeg/tests/raw_imcu_rows.rs
+++ b/crates/zune-jpeg/tests/raw_imcu_rows.rs
@@ -172,6 +172,55 @@ fn pull_rows_support_custom_strides_and_report_component_rows() {
 }
 
 #[test]
+fn recreated_session_continues_from_the_next_imcu_row() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+
+    let mut expected_decoder = JpegDecoder::new(ZCursor::new(bytes));
+    expected_decoder.decode_headers().unwrap();
+    let mut expected_session = expected_decoder.raw_output();
+    let layout = expected_session.layout().unwrap();
+    let count = expected_session.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let make_storage = || {
+        layout[..count]
+            .iter()
+            .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+            .collect::<Vec<Vec<u8>>>()
+    };
+    let mut expected_first = make_storage();
+    let mut expected_first_refs: Vec<&mut [u8]> =
+        expected_first.iter_mut().map(Vec::as_mut_slice).collect();
+    expected_session
+        .decode_next_imcu_row(&mut expected_first_refs, &strides)
+        .unwrap();
+    let mut expected_second = make_storage();
+    let mut expected_second_refs: Vec<&mut [u8]> =
+        expected_second.iter_mut().map(Vec::as_mut_slice).collect();
+    let expected_status = expected_session
+        .decode_next_imcu_row(&mut expected_second_refs, &strides)
+        .unwrap();
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut first = make_storage();
+    {
+        let mut session = decoder.raw_output();
+        let mut refs: Vec<&mut [u8]> = first.iter_mut().map(Vec::as_mut_slice).collect();
+        session.decode_next_imcu_row(&mut refs, &strides).unwrap();
+    }
+    let mut second = make_storage();
+    let actual_status = {
+        let mut session = decoder.raw_output();
+        let mut refs: Vec<&mut [u8]> = second.iter_mut().map(Vec::as_mut_slice).collect();
+        session.decode_next_imcu_row(&mut refs, &strides).unwrap()
+    };
+
+    assert_eq!(first, expected_first);
+    assert_eq!(actual_status, expected_status);
+    assert_eq!(second, expected_second);
+}
+
+#[test]
 fn completion_is_sticky_and_new_session_replays() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));

--- a/crates/zune-jpeg/tests/raw_imcu_rows.rs
+++ b/crates/zune-jpeg/tests/raw_imcu_rows.rs
@@ -1,0 +1,482 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use zune_core::bytestream::ZCursor;
+use zune_core::options::DecoderOptions;
+use zune_jpeg::errors::DecodeErrors;
+use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
+
+fn decode_whole(bytes: &[u8]) -> (Vec<Vec<u8>>, [zune_jpeg::PlaneInfo; 4], usize) {
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..count)
+        .map(|index| vec![0; layout[index].byte_size])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    raw.decode_into(&mut refs).unwrap();
+    (planes, layout, count)
+}
+
+fn assert_pull_matches_whole(bytes: &[u8]) {
+    let (whole, layout, count) = decode_whole(bytes);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let mut actual: Vec<Vec<u8>> = (0..count)
+        .map(|index| vec![0; layout[index].width * layout[index].height])
+        .collect();
+    let mut component_rows = [0usize; 4];
+
+    loop {
+        let strides: Vec<usize> = (0..count).map(|index| layout[index].width).collect();
+        let mut stripe_storage: Vec<Vec<u8>> = (0..count)
+            .map(|index| {
+                let max_rows = layout[index].vertical_sampling_factor * 8;
+                vec![0xCD; strides[index] * max_rows]
+            })
+            .collect();
+        let mut refs: Vec<&mut [u8]> = stripe_storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    let row_start = component_rows[index];
+                    let row_end = row_start + rows_written[index];
+                    let dst_start = row_start * strides[index];
+                    let dst_end = row_end * strides[index];
+                    actual[index][dst_start..dst_end].copy_from_slice(
+                        &stripe_storage[index][..rows_written[index] * strides[index]]
+                    );
+                    assert!(
+                        stripe_storage[index][rows_written[index] * strides[index]..]
+                            .iter()
+                            .all(|byte| *byte == 0xCD)
+                    );
+                    component_rows[index] = row_end;
+                }
+            }
+            RawImcuRowStatus::NeedMoreInput => panic!("one-shot input unexpectedly suspended"),
+            RawImcuRowStatus::Complete => break,
+            _ => unreachable!("unknown raw iMCU-row status")
+        }
+    }
+
+    for index in 0..count {
+        assert_eq!(component_rows[index], layout[index].height);
+        for row in 0..layout[index].height {
+            let actual_row =
+                &actual[index][row * layout[index].width..(row + 1) * layout[index].width];
+            let whole_row = &whole[index]
+                [row * layout[index].stride..row * layout[index].stride + layout[index].width];
+            assert_eq!(actual_row, whole_row, "component {index}, row {row}");
+        }
+    }
+}
+
+#[test]
+fn pull_rows_match_whole_image_420() {
+    assert_pull_matches_whole(include_bytes!("../../../test-images/jpeg/2029.jpg"));
+}
+
+#[test]
+fn pull_rows_match_whole_image_444() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_444_64x64.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_422() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_422_64x64.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_odd_dimensions() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_422_65x65.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_progressive() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_non_interleaved_420() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_420_64x64.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_440() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_440_64x64.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_410() {
+    assert_pull_matches_whole(include_bytes!("../../../test-images/jpeg/fox410.jpg"));
+}
+
+#[test]
+fn pull_rows_support_custom_strides_and_report_component_rows() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| vec![0xCD; strides[index] * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+    let rows_written = match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("first iMCU row was not ready")
+    };
+    assert_eq!(rows_written[0], 16);
+    assert_eq!(rows_written[1], 8);
+    assert_eq!(rows_written[2], 8);
+    for index in 0..count {
+        for row in 0..rows_written[index] {
+            let padding = &storage[index]
+                [row * strides[index] + layout[index].width..(row + 1) * strides[index]];
+            assert!(padding.iter().all(|byte| *byte == 0xCD));
+        }
+    }
+}
+
+#[test]
+fn completion_is_sticky_and_new_session_replays() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+
+    let mut first_rows = None;
+    loop {
+        let mut storage: Vec<Vec<u8>> = layout[..count]
+            .iter()
+            .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                first_rows.get_or_insert((rows_written, storage));
+            }
+            RawImcuRowStatus::Complete => break,
+            RawImcuRowStatus::NeedMoreInput => panic!("one-shot input suspended"),
+            _ => unreachable!("unknown raw iMCU-row status")
+        }
+    }
+
+    let mut empty: Vec<&mut [u8]> = Vec::new();
+    assert_eq!(
+        raw.decode_next_imcu_row(&mut empty, &[]).unwrap(),
+        RawImcuRowStatus::Complete
+    );
+    drop(raw);
+
+    let mut replay = decoder.raw_output();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    let rows_written = match replay.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("replay did not yield its first row")
+    };
+    let (expected_rows, expected_storage) = first_rows.unwrap();
+    assert_eq!(rows_written, expected_rows);
+    assert_eq!(storage, expected_storage);
+}
+
+#[test]
+fn cancellation_does_not_publish_a_row() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    decoder.set_cancel(|| true);
+    decoder.set_cancel_interval(1);
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0xCD; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+    let error = raw.decode_next_imcu_row(&mut refs, &strides).unwrap_err();
+    assert!(matches!(error, DecodeErrors::Cancelled));
+    assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+}
+
+#[test]
+fn buffered_baseline_cancellation_between_rows_is_atomic() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
+    let (whole, _, _) = decode_whole(bytes);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let check = Arc::clone(&cancelled);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.set_cancel(move || check.load(Ordering::SeqCst));
+    decoder.set_cancel_interval(1);
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+
+    let mut first: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut first_refs: Vec<&mut [u8]> = first.iter_mut().map(Vec::as_mut_slice).collect();
+    let first_rows = match raw.decode_next_imcu_row(&mut first_refs, &strides).unwrap() {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("first pull did not yield a row")
+    };
+
+    cancelled.store(true, Ordering::SeqCst);
+    let mut cancelled_storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0xCD; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut cancelled_refs: Vec<&mut [u8]> = cancelled_storage
+        .iter_mut()
+        .map(Vec::as_mut_slice)
+        .collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut cancelled_refs, &strides),
+        Err(DecodeErrors::Cancelled)
+    ));
+    assert!(cancelled_storage.iter().flatten().all(|byte| *byte == 0xCD));
+
+    cancelled.store(false, Ordering::SeqCst);
+    let mut retry: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut retry_refs: Vec<&mut [u8]> = retry.iter_mut().map(Vec::as_mut_slice).collect();
+    let retry_rows = match raw.decode_next_imcu_row(&mut retry_refs, &strides).unwrap() {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("retry did not yield the next row")
+    };
+    for index in 0..count {
+        for row in 0..retry_rows[index] {
+            let retry_start = row * strides[index];
+            let whole_start = (first_rows[index] + row) * layout[index].stride;
+            assert_eq!(
+                &retry[index][retry_start..retry_start + layout[index].width],
+                &whole[index][whole_start..whole_start + layout[index].width],
+                "component {index}, retried row {row}"
+            );
+        }
+    }
+}
+
+#[test]
+fn switching_to_pixel_decode_replays_from_scan_start() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut refs, &strides).unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+    drop(raw);
+
+    let mut actual = vec![0; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut actual).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn switching_pull_to_whole_raw_is_rejected() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut stripe: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut stripe_refs: Vec<&mut [u8]> = stripe.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut stripe_refs, &strides)
+            .unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+
+    let mut whole: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.byte_size])
+        .collect();
+    let mut whole_refs: Vec<&mut [u8]> = whole.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_into(&mut whole_refs),
+        Err(DecodeErrors::FormatStatic(_))
+    ));
+}
+
+#[test]
+fn invalid_pull_does_not_claim_raw_output_ownership() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut [], &[]),
+        Err(DecodeErrors::Format(_))
+    ));
+
+    let mut whole: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.byte_size])
+        .collect();
+    let mut whole_refs: Vec<&mut [u8]> = whole.iter_mut().map(Vec::as_mut_slice).collect();
+    raw.decode_into(&mut whole_refs).unwrap();
+    assert!(whole
+        .iter()
+        .all(|plane| plane.iter().any(|byte| *byte != 0)));
+}
+
+#[test]
+fn invalid_pull_stride_does_not_claim_raw_output_ownership() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let mut strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    strides[0] -= 1;
+    let mut stripe: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut stripe_refs: Vec<&mut [u8]> = stripe.iter_mut().map(Vec::as_mut_slice).collect();
+
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut stripe_refs, &strides),
+        Err(DecodeErrors::Format(_))
+    ));
+
+    let mut whole: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.byte_size])
+        .collect();
+    let mut whole_refs: Vec<&mut [u8]> = whole.iter_mut().map(Vec::as_mut_slice).collect();
+    raw.decode_into(&mut whole_refs).unwrap();
+    assert!(whole
+        .iter()
+        .all(|plane| plane.iter().any(|byte| *byte != 0)));
+}
+
+#[test]
+fn changing_options_aborts_pull_and_replays_from_scan_start() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut first: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut first_refs: Vec<&mut [u8]> = first.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut first_refs, &strides).unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+    drop(raw);
+
+    decoder.set_options(DecoderOptions::default());
+    let mut replay = decoder.raw_output();
+    let mut replay_first: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut replay_refs: Vec<&mut [u8]> = replay_first.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        replay
+            .decode_next_imcu_row(&mut replay_refs, &strides)
+            .unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+    assert_eq!(replay_first, first);
+}
+
+#[test]
+fn dnl_pull_is_rejected_before_false_completion() {
+    let bytes = include_bytes!("images/dnl_image.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let initial_layout = raw.layout().unwrap();
+    assert_eq!(initial_layout[0].height, 0);
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = initial_layout[..count]
+        .iter()
+        .map(|plane| plane.width)
+        .collect();
+    let mut storage: Vec<Vec<u8>> = initial_layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut refs, &strides),
+        Err(DecodeErrors::FormatStatic(
+            "raw output does not support DNL images"
+        ))
+    ));
+}

--- a/crates/zune-jpeg/tests/raw_imcu_rows.rs
+++ b/crates/zune-jpeg/tests/raw_imcu_rows.rs
@@ -6,13 +6,78 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::cell::Cell;
+use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use zune_core::bytestream::ZCursor;
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
+
+struct GrowableCursor<'a> {
+    data: &'a [u8],
+    position: usize,
+    limit: Rc<Cell<usize>>,
+}
+
+impl<'a> GrowableCursor<'a> {
+    fn new(data: &'a [u8], limit: Rc<Cell<usize>>) -> Self {
+        Self {
+            data,
+            position: 0,
+            limit,
+        }
+    }
+
+    fn visible(&self) -> usize {
+        self.limit.get().min(self.data.len())
+    }
+}
+
+impl Read for GrowableCursor<'_> {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        let visible = self.visible();
+        if self.position >= visible {
+            return Ok(0);
+        }
+        let count = output.len().min(visible - self.position);
+        output[..count].copy_from_slice(&self.data[self.position..self.position + count]);
+        self.position += count;
+        Ok(count)
+    }
+}
+
+impl BufRead for GrowableCursor<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        let visible = self.visible();
+        Ok(&self.data[self.position.min(visible)..visible])
+    }
+
+    fn consume(&mut self, amount: usize) {
+        self.position += amount;
+    }
+}
+
+impl Seek for GrowableCursor<'_> {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        let next = match position {
+            SeekFrom::Start(value) => value as i64,
+            SeekFrom::Current(value) => self.position as i64 + value,
+            SeekFrom::End(value) => self.visible() as i64 + value,
+        };
+        if next < 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "seek before start",
+            ));
+        }
+        self.position = next as usize;
+        Ok(self.position as u64)
+    }
+}
 
 fn decode_whole(bytes: &[u8]) -> (Vec<Vec<u8>>, [zune_jpeg::PlaneInfo; 4], usize) {
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
@@ -171,6 +236,398 @@ fn pull_rows_support_custom_strides_and_report_component_rows() {
     }
 }
 
+fn pull_required_len(rows: usize, stride: usize, width: usize) -> usize {
+    if rows == 0 {
+        0
+    } else {
+        (rows - 1) * stride + width
+    }
+}
+
+fn with_luma_sampling(data: &[u8], sampling: u8) -> Vec<u8> {
+    let mut bytes = data.to_vec();
+    let sof = bytes
+        .windows(2)
+        .position(|marker| marker == [0xff, 0xc0])
+        .expect("baseline SOF marker");
+    bytes[sof + 11] = sampling;
+    bytes
+}
+
+fn assert_exact_sized_pull_matches_whole(bytes: &[u8]) {
+    const GUARD: usize = 17;
+    const SENTINEL: u8 = 0xCD;
+
+    let (whole, layout, count) = decode_whole(bytes);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let mut component_rows = [0usize; 4];
+
+    loop {
+        let rows: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| {
+                (plane.height - component_rows[index]).min(plane.vertical_sampling_factor * 8)
+            })
+            .collect();
+        let required: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+            .collect();
+        let mut storage: Vec<Vec<u8>> = required
+            .iter()
+            .map(|length| vec![SENTINEL; length + GUARD])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    assert_eq!(rows_written[index], rows[index]);
+                    for row in 0..rows[index] {
+                        let actual_start = row * strides[index];
+                        let expected_start = (component_rows[index] + row) * layout[index].stride;
+                        assert_eq!(
+                            &storage[index][actual_start..actual_start + layout[index].width],
+                            &whole[index][expected_start..expected_start + layout[index].width]
+                        );
+                        if row + 1 < rows[index] {
+                            assert!(storage[index]
+                                [actual_start + layout[index].width..(row + 1) * strides[index]]
+                                .iter()
+                                .all(|byte| *byte == SENTINEL));
+                        }
+                    }
+                    assert!(storage[index][required[index]..]
+                        .iter()
+                        .all(|byte| *byte == SENTINEL));
+                    component_rows[index] += rows_written[index];
+                }
+            }
+            RawImcuRowStatus::Complete => break,
+            RawImcuRowStatus::NeedMoreInput => panic!("one-shot input suspended"),
+            _ => unreachable!("unknown raw iMCU-row status"),
+        }
+    }
+
+    for index in 0..count {
+        assert_eq!(component_rows[index], layout[index].height);
+    }
+}
+
+fn assert_incremental_pull_is_atomic(
+    name: &str, data: &[u8], step: usize, minimum_suspensions: usize,
+) {
+    const GUARD: usize = 17;
+    const SENTINEL: u8 = 0xCD;
+
+    let (whole, _, _) = decode_whole(data);
+    let limit = Rc::new(Cell::new(0));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+    let mut available = 0;
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(ref error) if error.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "{name}: headers suspended with full input"
+                );
+            }
+            Err(error) => panic!("{name}: header error at {available}: {error:?}"),
+        }
+    }
+
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 7)
+        .collect();
+    let mut component_rows = [0usize; 4];
+    let mut suspensions = 0;
+
+    loop {
+        let rows: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| {
+                (plane.height - component_rows[index]).min(plane.vertical_sampling_factor * 8)
+            })
+            .collect();
+        let required: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+            .collect();
+        let mut storage: Vec<Vec<u8>> = required
+            .iter()
+            .map(|length| vec![SENTINEL; length + GUARD])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::NeedMoreInput => {
+                suspensions += 1;
+                assert!(storage.iter().flatten().all(|byte| *byte == SENTINEL));
+                assert!(available < data.len(), "{name}: suspended with full input");
+                available = (available + step).min(data.len());
+                limit.set(available);
+            }
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    assert_eq!(rows_written[index], rows[index]);
+                    for row in 0..rows_written[index] {
+                        let actual_start = row * strides[index];
+                        let expected_start = (component_rows[index] + row) * layout[index].stride;
+                        assert_eq!(
+                            &storage[index][actual_start..actual_start + layout[index].width],
+                            &whole[index][expected_start..expected_start + layout[index].width],
+                            "{name}: component {index}, row {}",
+                            component_rows[index] + row
+                        );
+                    }
+                    assert!(storage[index][required[index]..]
+                        .iter()
+                        .all(|byte| *byte == SENTINEL));
+                    component_rows[index] += rows_written[index];
+                }
+            }
+            RawImcuRowStatus::Complete => break,
+            _ => unreachable!("unknown raw iMCU-row status"),
+        }
+    }
+
+    assert!(
+        suspensions >= minimum_suspensions,
+        "{name}: expected at least {minimum_suspensions} suspensions, got {suspensions}"
+    );
+    for index in 0..count {
+        assert_eq!(component_rows[index], layout[index].height);
+    }
+}
+
+#[test]
+fn exact_minimum_lengths_cover_sampling_modes_and_final_stripes() {
+    for bytes in [
+        &include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg")[..],
+        &include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg")[..],
+        &include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg")[..],
+        &include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg")[..],
+        &include_bytes!("../../../test-images/jpeg/fox410.jpg")[..],
+    ] {
+        assert_exact_sized_pull_matches_whole(bytes);
+    }
+
+    let sampling_411 = with_luma_sampling(
+        include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg"),
+        0x41,
+    );
+    assert_exact_sized_pull_matches_whole(&sampling_411);
+}
+
+#[test]
+fn suspension_cut_points_are_atomic_and_retry_exactly() {
+    assert_incremental_pull_is_atomic(
+        "baseline_bytewise",
+        include_bytes!("../../../test-images/jpeg/app14/baseline_rgb_interleaved.jpg"),
+        1,
+        100,
+    );
+    assert_incremental_pull_is_atomic(
+        "progressive_restart",
+        include_bytes!("../../../test-images/jpeg/progressive_restart_420.jpg"),
+        1,
+        100,
+    );
+    assert_incremental_pull_is_atomic(
+        "multi_sos",
+        include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg"),
+        1,
+        10,
+    );
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_suspension_cut_points_are_atomic_and_retry_exactly() {
+    assert_incremental_pull_is_atomic(
+        "arithmetic_restart",
+        include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg"),
+        1,
+        10,
+    );
+    assert_incremental_pull_is_atomic(
+        "arithmetic_progressive",
+        include_bytes!("../../../test-images/jpeg/arith/prog.jpg"),
+        1,
+        10,
+    );
+}
+
+#[test]
+fn exact_minimum_plane_lengths_succeed() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let expected_rows: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.vertical_sampling_factor * 8)
+        .collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| {
+            vec![0xCD; pull_required_len(expected_rows[index], strides[index], plane.width)]
+        })
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+    let RawImcuRowStatus::RowReady { rows_written } =
+        raw.decode_next_imcu_row(&mut refs, &strides).unwrap()
+    else {
+        panic!("first iMCU row was not ready")
+    };
+    assert_eq!(&rows_written[..count], expected_rows);
+}
+
+#[test]
+fn one_byte_short_of_minimum_is_rejected() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+
+    for short_index in 0..3 {
+        let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+        decoder.decode_headers().unwrap();
+        let mut raw = decoder.raw_output();
+        let layout = raw.layout().unwrap();
+        let count = raw.num_components().unwrap();
+        let strides: Vec<usize> = layout[..count]
+            .iter()
+            .map(|plane| plane.width + 13)
+            .collect();
+        let rows: Vec<usize> = layout[..count]
+            .iter()
+            .map(|plane| plane.vertical_sampling_factor * 8)
+            .collect();
+        let required: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+            .collect();
+        let mut storage: Vec<Vec<u8>> = required
+            .iter()
+            .enumerate()
+            .map(|(index, length)| vec![0xCD; length - usize::from(index == short_index)])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        assert!(matches!(
+            raw.decode_next_imcu_row(&mut refs, &strides),
+            Err(DecodeErrors::TooSmallOutput(needed, actual))
+                if needed == required[short_index] && actual + 1 == needed
+        ));
+        assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+    }
+}
+
+#[test]
+fn overflowing_minimum_length_is_rejected() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let mut strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    strides[0] = usize::MAX;
+    let mut storage: Vec<Vec<u8>> = (0..count).map(|_| Vec::new()).collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut refs, &strides),
+        Err(DecodeErrors::FormatStatic(
+            "raw iMCU-row plane size overflow"
+        ))
+    ));
+}
+
+#[test]
+fn one_byte_short_of_final_clipped_stripe_is_rejected() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let mut component_rows = [0usize; 4];
+
+    loop {
+        let rows: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| {
+                (plane.height - component_rows[index]).min(plane.vertical_sampling_factor * 8)
+            })
+            .collect();
+        let required: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+            .collect();
+        let final_stripe = rows
+            .iter()
+            .enumerate()
+            .all(|(index, rows)| component_rows[index] + rows == layout[index].height);
+        let mut storage: Vec<Vec<u8>> = required
+            .iter()
+            .enumerate()
+            .map(|(index, length)| vec![0xCD; length - usize::from(final_stripe && index == 0)])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        if final_stripe {
+            assert!(matches!(
+                raw.decode_next_imcu_row(&mut refs, &strides),
+                Err(DecodeErrors::TooSmallOutput(needed, actual))
+                    if needed == required[0] && actual + 1 == needed
+            ));
+            assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+            break;
+        }
+
+        let RawImcuRowStatus::RowReady { rows_written } =
+            raw.decode_next_imcu_row(&mut refs, &strides).unwrap()
+        else {
+            panic!("non-final stripe was not ready")
+        };
+        for index in 0..count {
+            component_rows[index] += rows_written[index];
+        }
+    }
+}
+
 #[test]
 fn recreated_session_continues_from_the_next_imcu_row() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
@@ -252,6 +709,16 @@ fn completion_is_sticky_and_new_session_replays() {
         raw.decode_next_imcu_row(&mut empty, &[]).unwrap(),
         RawImcuRowStatus::Complete
     );
+    let mut exhausted_storage: Vec<Vec<u8>> = (0..count).map(|_| Vec::new()).collect();
+    let mut exhausted_planes: Vec<&mut [u8]> = exhausted_storage
+        .iter_mut()
+        .map(Vec::as_mut_slice)
+        .collect();
+    assert_eq!(
+        raw.decode_next_imcu_row(&mut exhausted_planes, &strides)
+            .unwrap(),
+        RawImcuRowStatus::Complete
+    );
     drop(raw);
 
     let mut replay = decoder.raw_output();
@@ -289,6 +756,64 @@ fn cancellation_does_not_publish_a_row() {
     let error = raw.decode_next_imcu_row(&mut refs, &strides).unwrap_err();
     assert!(matches!(error, DecodeErrors::Cancelled));
     assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+}
+
+#[test]
+fn cancellation_during_a_stripe_is_atomic_and_retryable() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let (whole, layout, count) = decode_whole(bytes);
+    let polls = Arc::new(AtomicUsize::new(0));
+    let cancel_after = Arc::new(AtomicUsize::new(1));
+    let check_polls = Arc::clone(&polls);
+    let check_cancel_after = Arc::clone(&cancel_after);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    decoder.set_cancel(move || {
+        check_polls.fetch_add(1, Ordering::SeqCst) >= check_cancel_after.load(Ordering::SeqCst)
+    });
+    decoder.set_cancel_interval(1);
+    let mut raw = decoder.raw_output();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 9)
+        .collect();
+    let rows: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.vertical_sampling_factor * 8)
+        .collect();
+    let required: Vec<usize> = layout[..count]
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+        .collect();
+    let mut cancelled: Vec<Vec<u8>> = required.iter().map(|length| vec![0xCD; *length]).collect();
+    let mut cancelled_refs: Vec<&mut [u8]> = cancelled.iter_mut().map(Vec::as_mut_slice).collect();
+
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut cancelled_refs, &strides),
+        Err(DecodeErrors::Cancelled)
+    ));
+    assert!(polls.load(Ordering::SeqCst) > 1);
+    assert!(cancelled.iter().flatten().all(|byte| *byte == 0xCD));
+
+    cancel_after.store(usize::MAX, Ordering::SeqCst);
+    let mut retry: Vec<Vec<u8>> = required.iter().map(|length| vec![0; *length]).collect();
+    let mut retry_refs: Vec<&mut [u8]> = retry.iter_mut().map(Vec::as_mut_slice).collect();
+    let RawImcuRowStatus::RowReady { rows_written } =
+        raw.decode_next_imcu_row(&mut retry_refs, &strides).unwrap()
+    else {
+        panic!("retry did not produce the first stripe")
+    };
+    for index in 0..count {
+        assert_eq!(rows_written[index], rows[index]);
+        for row in 0..rows[index] {
+            assert_eq!(
+                &retry[index][row * strides[index]..row * strides[index] + layout[index].width],
+                &whole[index]
+                    [row * layout[index].stride..row * layout[index].stride + layout[index].width]
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This is the second PR in the JPEG raw output API work.

It is stacked on #386 and adds pull-based raw iMCU-row output through `RawDecodeSession::decode_next_imcu_row`.

The caller provides component-plane storage for the next iMCU row. The decoder reports completed component rows, completion, or a recoverable need-more-input state. Upsampling and color conversion remain disabled.

Interleaved baseline images are decoded one iMCU row at a time. Progressive and multi-SOS images buffer the coefficients required for stable final samples before returning rows.

Normal `decode()`, `decode_into()`, and whole-image raw output behavior remains unchanged.

## Public API

```rust
loop {
    match raw.decode_next_imcu_row(&mut planes, &strides)? {
        RawImcuRowStatus::RowReady { rows_written } => {
            // Consume rows_written[index] rows from each component.
        }
        RawImcuRowStatus::NeedMoreInput => break,
        RawImcuRowStatus::Complete => break,
    }
}
```

Pull state is owned by the decoder and survives recreated borrowing sessions. `NeedMoreInput` does not publish a partial iMCU row.

## Next step

#441  adds converted scanline reads and skips on top of this output plumbing.

Part of #379 