### PR TITLE
[WIP] JpegDecoder: Add pull-based converted scanline output

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -62,6 +62,10 @@ name = "decode_jpeg"
 harness = false
 
 [[bench]]
+name = "decode_jpeg_allocations"
+harness = false
+
+[[bench]]
 name = "decode_hdr"
 harness = false
 

--- a/benchmarks/benches/decode_jpeg.rs
+++ b/benchmarks/benches/decode_jpeg.rs
@@ -16,7 +16,9 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use zune_benches::sample_path;
 use zune_jpeg::zune_core::colorspace::ColorSpace;
 use zune_jpeg::zune_core::options::DecoderOptions;
-use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
+use zune_jpeg::{
+    JpegDecoder, RawImcuRowStatus, ScanlineReadStatus, ScanlineStatus
+};
 use zune_png::zune_core::bytestream::ZCursor;
 
 fn decode_jpeg(buf: &[u8]) -> Vec<u8> {
@@ -63,7 +65,7 @@ fn decode_no_samp(c: &mut Criterion) {
     generic_bench(
         c,
         sample_path().join("test-images/jpeg/benchmarks/speed_bench.jpg"),
-        "jpeg: No sampling Baseline decode",
+        "jpeg: No sampling Baseline decode"
     );
 }
 
@@ -71,7 +73,7 @@ fn decode_h_samp(c: &mut Criterion) {
     generic_bench(
         c,
         sample_path().join("test-images/jpeg/benchmarks/speed_bench_horizontal_subsampling.jpg"),
-        "jpeg: Horizontal Sub Sampling",
+        "jpeg: Horizontal Sub Sampling"
     );
 }
 
@@ -79,7 +81,7 @@ fn decode_v_samp(c: &mut Criterion) {
     generic_bench(
         c,
         sample_path().join("test-images/jpeg/benchmarks/speed_bench_vertical_subsampling.jpg"),
-        "jpeg: Vertical sub sampling",
+        "jpeg: Vertical sub sampling"
     );
 }
 
@@ -87,7 +89,7 @@ fn decode_hv_samp(c: &mut Criterion) {
     generic_bench(
         c,
         sample_path().join("test-images/jpeg/benchmarks/speed_bench_hv_subsampling.jpg"),
-        "jpeg: HV sampling",
+        "jpeg: HV sampling"
     );
 }
 
@@ -141,7 +143,7 @@ fn decode_no_samp_prog(c: &mut Criterion) {
     generic_bench(
         c,
         sample_path().join("test-images/jpeg/benchmarks/speed_bench_prog.jpg"),
-        "jpeg: No sampling Progressive decoding",
+        "jpeg: No sampling Progressive decoding"
     );
 }
 
@@ -149,7 +151,7 @@ fn decode_h_samp_prog(c: &mut Criterion) {
     generic_bench(
         c,
         sample_path().join("test-images/jpeg/benchmarks/speed_bench_prog_h_sampling.jpg"),
-        "jpeg: Progressive Horizontal Sub Sampling",
+        "jpeg: Progressive Horizontal Sub Sampling"
     )
 }
 
@@ -157,7 +159,7 @@ fn decode_v_samp_prog(c: &mut Criterion) {
     generic_bench(
         c,
         sample_path().join("test-images/jpeg/benchmarks/speed_bench_prog_v_sampling.jpg"),
-        "jpeg: Progressive Vertical sub sampling",
+        "jpeg: Progressive Vertical sub sampling"
     )
 }
 
@@ -165,7 +167,7 @@ fn decode_hv_samp_prog(c: &mut Criterion) {
     generic_bench(
         c,
         sample_path().join("test-images/jpeg/benchmarks/speed_bench_prog_hv_sampling.jpg"),
-        "jpeg: Progressive HV sampling",
+        "jpeg: Progressive HV sampling"
     )
 }
 
@@ -228,9 +230,9 @@ use std::rc::Rc;
 /// bench grows `limit` via the shared `Rc<Cell<usize>>` to simulate more
 /// data arriving on the same decoder.
 struct GrowableCursor<'a> {
-    data: &'a [u8],
+    data:     &'a [u8],
     position: usize,
-    limit: Rc<Cell<usize>>,
+    limit:    Rc<Cell<usize>>
 }
 
 impl<'a> GrowableCursor<'a> {
@@ -238,7 +240,7 @@ impl<'a> GrowableCursor<'a> {
         Self {
             data,
             position: 0,
-            limit,
+            limit
         }
     }
 
@@ -280,12 +282,12 @@ impl Seek for GrowableCursor<'_> {
         let new_pos = match pos {
             SeekFrom::Start(p) => p as i64,
             SeekFrom::Current(p) => self.position as i64 + p,
-            SeekFrom::End(p) => self.visible() as i64 + p,
+            SeekFrom::End(p) => self.visible() as i64 + p
         };
         if new_pos < 0 {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
-                "seek before start",
+                "seek before start"
             ));
         }
         self.position = new_pos as usize;
@@ -330,7 +332,7 @@ fn decode_restart_resume(c: &mut Criterion) {
             // First scan attempt: expect recoverable EOF.
             match decoder.decode_into(&mut out) {
                 Ok(()) => panic!("scan should not complete at 80% visibility"),
-                Err(e) => assert!(e.is_recoverable_eof(), "got: {e:?}"),
+                Err(e) => assert!(e.is_recoverable_eof(), "got: {e:?}")
             }
 
             // Expose remaining bytes and resume from the latest checkpoint.
@@ -344,8 +346,9 @@ fn decode_restart_resume(c: &mut Criterion) {
 }
 
 fn decode_streaming_mode(c: &mut Criterion) {
-    let data = read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_hv_subsampling.jpg"))
-        .unwrap();
+    let data =
+        read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_hv_subsampling.jpg"))
+            .unwrap();
     let mut group = c.benchmark_group("jpeg: Incremental mode checkpoints");
     group.throughput(Throughput::Bytes(data.len() as u64));
 
@@ -369,7 +372,7 @@ fn decode_streaming_mode(c: &mut Criterion) {
 
             match decoder.decode_into(&mut out) {
                 Ok(()) => panic!("scan should not complete at 80% visibility"),
-                Err(e) => assert!(e.is_recoverable_eof(), "got: {e:?}"),
+                Err(e) => assert!(e.is_recoverable_eof(), "got: {e:?}")
             }
 
             limit.set(data.len());
@@ -391,7 +394,7 @@ fn decode_streaming_mode(c: &mut Criterion) {
 
             match decoder.decode_into(&mut out) {
                 Ok(()) => panic!("scan should not complete at 80% visibility"),
-                Err(e) => assert!(e.is_recoverable_eof(), "got: {e:?}"),
+                Err(e) => assert!(e.is_recoverable_eof(), "got: {e:?}")
             }
 
             limit.set(data.len());
@@ -457,6 +460,49 @@ fn decode_raw_pull_output(c: &mut Criterion) {
     });
 }
 
+fn decode_jpeg_scanlines(buf: &[u8], rows_per_read: usize) -> u64 {
+    let mut decoder = JpegDecoder::new(ZCursor::new(buf));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let mut rows = vec![0; row_bytes * rows_per_read];
+    let mut checksum = 0u64;
+
+    while scanlines.output_scanline() < height {
+        match scanlines.read_scanlines(&mut rows, row_bytes).unwrap() {
+            ScanlineReadStatus::RowsProcessed { rows: written } => {
+                checksum = rows[..written * row_bytes]
+                    .iter()
+                    .fold(checksum, |sum, byte| sum.wrapping_add(u64::from(*byte)));
+            }
+            ScanlineReadStatus::NeedMoreInput => panic!("one-shot benchmark input suspended"),
+            ScanlineReadStatus::Complete => break,
+            _ => unreachable!()
+        }
+    }
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+    checksum
+}
+
+fn decode_scanline_output(c: &mut Criterion) {
+    let data =
+        read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_hv_subsampling.jpg"))
+            .unwrap();
+    let mut group = c.benchmark_group("jpeg: converted scanline output");
+    group.throughput(Throughput::Bytes(data.len() as u64));
+
+    group.bench_function("full decode output", |b| {
+        b.iter(|| black_box(decode_jpeg(data.as_slice())));
+    });
+    group.bench_function("one-row caller storage", |b| {
+        b.iter(|| black_box(decode_jpeg_scanlines(data.as_slice(), 1)));
+    });
+    group.bench_function("64-row caller storage", |b| {
+        b.iter(|| black_box(decode_jpeg_scanlines(data.as_slice(), 64)));
+    });
+}
+
 criterion_group!(name=benches;
       config={
       let c = Criterion::default();
@@ -466,6 +512,7 @@ criterion_group!(name=benches;
     decode_hv_samp,criterion_benchmark_grayscale,
     decode_hv_samp_prog,decode_h_samp_prog,decode_no_samp_prog,decode_v_samp_prog,
     decode_no_samp_opts,
-    decode_restart_full,decode_restart_resume,decode_streaming_mode,decode_raw_pull_output);
+    decode_restart_full,decode_restart_resume,decode_streaming_mode,
+    decode_raw_pull_output,decode_scanline_output);
 
 criterion_main!(benches);

--- a/benchmarks/benches/decode_jpeg.rs
+++ b/benchmarks/benches/decode_jpeg.rs
@@ -16,7 +16,7 @@ use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use zune_benches::sample_path;
 use zune_jpeg::zune_core::colorspace::ColorSpace;
 use zune_jpeg::zune_core::options::DecoderOptions;
-use zune_jpeg::JpegDecoder;
+use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
 use zune_png::zune_core::bytestream::ZCursor;
 
 fn decode_jpeg(buf: &[u8]) -> Vec<u8> {
@@ -403,6 +403,60 @@ fn decode_streaming_mode(c: &mut Criterion) {
     });
 }
 
+fn decode_jpeg_raw_pull(buf: &[u8]) -> u64 {
+    let mut decoder = JpegDecoder::new(ZCursor::new(buf));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| vec![0; strides[index] * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut checksum = 0_u64;
+
+    loop {
+        let mut planes: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+        match raw.decode_next_imcu_row(&mut planes, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    for row in 0..rows_written[index] {
+                        checksum = storage[index]
+                            [row * strides[index]..row * strides[index] + layout[index].width]
+                            .iter()
+                            .fold(checksum, |sum, byte| sum.wrapping_add(u64::from(*byte)));
+                    }
+                }
+            }
+            RawImcuRowStatus::Complete => break,
+            RawImcuRowStatus::NeedMoreInput => panic!("one-shot benchmark input suspended"),
+            _ => unreachable!(),
+        }
+    }
+    checksum
+}
+
+fn decode_raw_pull_output(c: &mut Criterion) {
+    let baseline =
+        read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_hv_subsampling.jpg"))
+            .unwrap();
+    let progressive =
+        read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_prog.jpg")).unwrap();
+    let mut group = c.benchmark_group("jpeg: raw iMCU-row output");
+
+    group.bench_function("baseline", |b| {
+        b.iter(|| black_box(decode_jpeg_raw_pull(baseline.as_slice())));
+    });
+    group.bench_function("progressive", |b| {
+        b.iter(|| black_box(decode_jpeg_raw_pull(progressive.as_slice())));
+    });
+}
+
 criterion_group!(name=benches;
       config={
       let c = Criterion::default();
@@ -412,6 +466,6 @@ criterion_group!(name=benches;
     decode_hv_samp,criterion_benchmark_grayscale,
     decode_hv_samp_prog,decode_h_samp_prog,decode_no_samp_prog,decode_v_samp_prog,
     decode_no_samp_opts,
-    decode_restart_full,decode_restart_resume,decode_streaming_mode);
+    decode_restart_full,decode_restart_resume,decode_streaming_mode,decode_raw_pull_output);
 
 criterion_main!(benches);

--- a/benchmarks/benches/decode_jpeg_allocations.rs
+++ b/benchmarks/benches/decode_jpeg_allocations.rs
@@ -1,0 +1,143 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::fs::read;
+use std::hint::black_box;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use zune_benches::sample_path;
+use zune_jpeg::zune_core::bytestream::ZCursor;
+use zune_jpeg::{JpegDecoder, ScanlineReadStatus, ScanlineStatus};
+
+struct TrackingAllocator;
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+static ALLOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+fn record_growth(size: usize) {
+    let live = LIVE_BYTES.fetch_add(size, Ordering::Relaxed) + size;
+    let mut peak = PEAK_BYTES.load(Ordering::Relaxed);
+    while live > peak {
+        match PEAK_BYTES.compare_exchange_weak(peak, live, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(current) => peak = current
+        }
+    }
+}
+
+fn record_allocation(size: usize) {
+    ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+    record_growth(size);
+}
+
+fn record_deallocation(size: usize) {
+    LIVE_BYTES.fetch_sub(size, Ordering::Relaxed);
+}
+
+unsafe impl GlobalAlloc for TrackingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc(layout) };
+        if !pointer.is_null() {
+            record_allocation(layout.size());
+        }
+        pointer
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let pointer = unsafe { System.alloc_zeroed(layout) };
+        if !pointer.is_null() {
+            record_allocation(layout.size());
+        }
+        pointer
+    }
+
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        record_deallocation(layout.size());
+        unsafe { System.dealloc(pointer, layout) };
+    }
+
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_pointer = unsafe { System.realloc(pointer, layout, new_size) };
+        if !new_pointer.is_null() {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            if new_size >= layout.size() {
+                record_growth(new_size - layout.size());
+            } else {
+                record_deallocation(layout.size() - new_size);
+            }
+        }
+        new_pointer
+    }
+}
+
+#[derive(Clone, Copy)]
+struct AllocationProfile {
+    peak_live_bytes: usize,
+    allocations:     usize
+}
+
+fn profile<T>(operation: impl FnOnce() -> T) -> AllocationProfile {
+    let baseline = LIVE_BYTES.load(Ordering::SeqCst);
+    let allocation_start = ALLOCATIONS.load(Ordering::SeqCst);
+    PEAK_BYTES.store(baseline, Ordering::SeqCst);
+    let value = operation();
+    black_box(&value);
+    let result = AllocationProfile {
+        peak_live_bytes: PEAK_BYTES.load(Ordering::SeqCst).saturating_sub(baseline),
+        allocations:     ALLOCATIONS.load(Ordering::SeqCst) - allocation_start
+    };
+    drop(value);
+    assert_eq!(LIVE_BYTES.load(Ordering::SeqCst), baseline);
+    result
+}
+
+fn decode_scanlines(data: &[u8], rows_per_read: usize) -> u64 {
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let mut rows = vec![0; row_bytes * rows_per_read];
+    let mut checksum = 0_u64;
+
+    while scanlines.output_scanline() < height {
+        match scanlines.read_scanlines(&mut rows, row_bytes).unwrap() {
+            ScanlineReadStatus::RowsProcessed { rows: written } => {
+                checksum = rows[..written * row_bytes]
+                    .iter()
+                    .fold(checksum, |sum, byte| sum.wrapping_add(u64::from(*byte)));
+            }
+            status => panic!("unexpected scanline status {status:?}")
+        }
+    }
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+    checksum
+}
+
+fn main() {
+    let data =
+        read(sample_path().join("test-images/jpeg/benchmarks/speed_bench_hv_subsampling.jpg"))
+            .unwrap();
+
+    let full = profile(|| JpegDecoder::new(ZCursor::new(&data)).decode().unwrap());
+    let one_row = profile(|| decode_scanlines(&data, 1));
+    let direct = profile(|| decode_scanlines(&data, 64));
+
+    println!(
+        "full output: peak={} bytes, allocations={}",
+        full.peak_live_bytes, full.allocations
+    );
+    println!(
+        "one-row scanlines: peak={} bytes, allocations={}",
+        one_row.peak_live_bytes, one_row.allocations
+    );
+    println!(
+        "64-row scanlines: peak={} bytes, allocations={}",
+        direct.peak_live_bytes, direct.allocations
+    );
+
+    assert!(one_row.peak_live_bytes < full.peak_live_bytes);
+    assert!(direct.peak_live_bytes < full.peak_live_bytes);
+}

--- a/benchmarks/benches/decode_jpeg_allocations.rs
+++ b/benchmarks/benches/decode_jpeg_allocations.rs
@@ -140,4 +140,6 @@ fn main() {
 
     assert!(one_row.peak_live_bytes < full.peak_live_bytes);
     assert!(direct.peak_live_bytes < full.peak_live_bytes);
+    assert!(one_row.allocations <= full.allocations + 4);
+    assert!(direct.allocations <= full.allocations + 4);
 }

--- a/benchmarks/tests/jpeg_scanline_parity.rs
+++ b/benchmarks/tests/jpeg_scanline_parity.rs
@@ -1,0 +1,100 @@
+use std::fs::read;
+
+use zune_benches::sample_path;
+use zune_jpeg::zune_core::bytestream::ZCursor;
+use zune_jpeg::zune_core::colorspace::ColorSpace;
+use zune_jpeg::zune_core::options::DecoderOptions;
+use zune_jpeg::{JpegDecoder, ScanlineReadStatus, ScanlineStatus};
+
+#[derive(Clone, Copy, Debug)]
+enum ReferenceColor {
+    Rgb,
+    Luma
+}
+
+fn decode_zune_scanlines(data: &[u8], color: ReferenceColor) -> Vec<u8> {
+    let output = match color {
+        ReferenceColor::Rgb => ColorSpace::RGB,
+        ReferenceColor::Luma => ColorSpace::Luma
+    };
+    let options = DecoderOptions::default().jpeg_set_out_colorspace(output);
+    let mut decoder = JpegDecoder::new_with_options(ZCursor::new(data), options);
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let mut output = vec![0; row_bytes * height];
+
+    while scanlines.output_scanline() < height {
+        let row = scanlines.output_scanline();
+        match scanlines
+            .read_scanlines(&mut output[row * row_bytes..], row_bytes)
+            .unwrap()
+        {
+            ScanlineReadStatus::RowsProcessed { rows } => assert!(rows > 0),
+            status => panic!("unexpected scanline status {status:?}")
+        }
+    }
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+    output
+}
+
+fn decode_libjpeg(data: &[u8], color: ReferenceColor) -> Vec<u8> {
+    let decoder = mozjpeg::Decompress::with_markers(mozjpeg::ALL_MARKERS)
+        .from_mem(data)
+        .unwrap();
+    match color {
+        ReferenceColor::Rgb => {
+            let mut image = decoder.rgb().unwrap();
+            let rows: Vec<[u8; 3]> = image.read_scanlines().unwrap();
+            image.finish().unwrap();
+            rows.into_iter().flatten().collect()
+        }
+        ReferenceColor::Luma => {
+            let mut image = decoder.grayscale().unwrap();
+            let rows: Vec<[u8; 1]> = image.read_scanlines().unwrap();
+            image.finish().unwrap();
+            rows.into_iter().flatten().collect()
+        }
+    }
+}
+
+#[test]
+fn converted_scanlines_match_libjpeg_across_sampling_modes() {
+    for (name, fixture) in [
+        ("none", "speed_bench.jpg"),
+        ("horizontal", "speed_bench_horizontal_subsampling.jpg"),
+        ("vertical", "speed_bench_vertical_subsampling.jpg"),
+        ("hv", "speed_bench_hv_subsampling.jpg")
+    ] {
+        let data = read(
+            sample_path()
+                .join("test-images/jpeg/benchmarks")
+                .join(fixture)
+        )
+        .unwrap();
+        for color in [ReferenceColor::Rgb, ReferenceColor::Luma] {
+            let actual = decode_zune_scanlines(&data, color);
+            let reference = decode_libjpeg(&data, color);
+            assert_eq!(actual.len(), reference.len(), "{name}/{color:?}");
+
+            let mut max_delta = 0;
+            let mut total_delta = 0_u64;
+            for (&actual, &reference) in actual.iter().zip(&reference) {
+                let delta = actual.abs_diff(reference);
+                max_delta = max_delta.max(delta);
+                total_delta += u64::from(delta);
+            }
+            let average_delta = total_delta as f64 / actual.len() as f64;
+            eprintln!("{name}/{color:?}: max delta {max_delta}, average delta {average_delta}");
+            assert!(
+                max_delta <= 4,
+                "{name}/{color:?}: max channel delta {max_delta} exceeds 4"
+            );
+            assert!(
+                average_delta < 0.1,
+                "{name}/{color:?}: average channel delta {average_delta} exceeds 0.1"
+            );
+        }
+    }
+}

--- a/crates/zune-jpeg/src/bitstream_arith.rs
+++ b/crates/zune-jpeg/src/bitstream_arith.rs
@@ -563,15 +563,22 @@ impl BitStreamArithmetic {
     }
 }
 
-/// Minimal snapshot for arithmetic bitstream — only captures enough to detect
-/// whether the stream was exhausted. True per-MCU resume is not feasible for
-/// arithmetic coding due to statistical context coupling.
+/// Arithmetic bitstream registers captured at a stable pull-row boundary.
+/// Statistical contexts remain in `EntropyTables` and are preserved separately
+/// by the borrowing raw-output session.
 #[derive(Clone, Copy)]
 pub(crate) struct ArithBitstreamState {
-    pub(crate) marker:      Option<Marker>,
-    pub(crate) overread_by: usize,
-    pub(crate) seen_eoi:    bool,
-    pub(crate) eob_run:     i32
+    initialized:         bool,
+    a:                   u32,
+    c:                   u32,
+    ct:                  u8,
+    marker:              Option<Marker>,
+    successive_low_mask: i16,
+    spec_start:          u8,
+    spec_end:            u8,
+    overread_by:         usize,
+    seen_eoi:            bool,
+    eob_run:             i32
 }
 
 impl BitStream for BitStreamArithmetic {
@@ -708,19 +715,30 @@ impl BitStream for BitStreamArithmetic {
     #[inline(always)]
     fn save_state(&self) -> ArithBitstreamState {
         ArithBitstreamState {
-            marker:      self.marker,
-            overread_by: self.overread_by,
-            seen_eoi:    self.seen_eoi,
-            eob_run:     self.eob_run
+            initialized:         self.initialized,
+            a:                   self.a,
+            c:                   self.c,
+            ct:                  self.ct,
+            marker:              self.marker,
+            successive_low_mask: self.successive_low_mask,
+            spec_start:          self.spec_start,
+            spec_end:            self.spec_end,
+            overread_by:         self.overread_by,
+            seen_eoi:            self.seen_eoi,
+            eob_run:             self.eob_run
         }
     }
 
-    /// Arithmetic restore is a no-op for the A/C/CT registers — those are
-    /// only reset via `reset()` at RST/scan boundaries. This restores the
-    /// marker/EOF detection state only.
     #[inline(always)]
     fn restore_state(&mut self, state: ArithBitstreamState) {
+        self.initialized = state.initialized;
+        self.a = state.a;
+        self.c = state.c;
+        self.ct = state.ct;
         self.marker = state.marker;
+        self.successive_low_mask = state.successive_low_mask;
+        self.spec_start = state.spec_start;
+        self.spec_end = state.spec_end;
         self.overread_by = state.overread_by;
         self.seen_eoi = state.seen_eoi;
         self.eob_run = state.eob_run;

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -2137,6 +2137,9 @@ where
     ///
     /// # Examples
     ///
+    /// Decode a JPEG into raw YCbCr planes (libjpeg-turbo style) and access
+    /// individual component data:
+    ///
     /// ```no_run
     /// use zune_core::bytestream::ZCursor;
     /// use zune_jpeg::JpegDecoder;
@@ -2145,15 +2148,30 @@ where
     /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
     /// decoder.decode_headers().unwrap();
     ///
+    /// // Query the plane geometry (DCT-block-padded sizes).
     /// let layout = decoder.planar_layout().unwrap();
     /// let n = decoder.num_components().unwrap();
+    ///
+    /// // Allocate one buffer per component, sized to the full padded plane.
     /// let mut buffers: Vec<Vec<u8>> = (0..n)
     ///     .map(|i| vec![0u8; layout[i].byte_size])
     ///     .collect();
     /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
     ///
     /// decoder.decode_raw(&mut planes).unwrap();
-    /// // planes[0] = Y, planes[1] = Cb, planes[2] = Cr (for YCbCr)
+    ///
+    /// // For a 4:2:0 YCbCr image:
+    /// //   planes[0] = Y  (full resolution, padded to DCT blocks)
+    /// //   planes[1] = Cb (half resolution)
+    /// //   planes[2] = Cr (half resolution)
+    /// //
+    /// // Access a specific pixel's Y value:
+    /// let y_stride = layout[0].stride; // row pitch in bytes
+    /// let y_value = planes[0][/* row */ 10 * y_stride + /* col */ 20];
+    ///
+    /// // Identify component order for non-standard JPEGs:
+    /// let ids = decoder.component_ids().unwrap();
+    /// println!("Component order: {:?}", ids);
     /// ```
     ///
     /// # Errors
@@ -2246,8 +2264,10 @@ where
     ///
     /// # Examples
     ///
-    /// Skia-style: allocate with custom stride (e.g. GPU-aligned), decode
-    /// only the logical image area, leave padding untouched.
+    /// Skia-style: decode into GPU-aligned buffers where each row has a
+    /// power-of-two stride, then upload the planes as textures. Only the
+    /// logical image area is written; padding bytes are left untouched so
+    /// the caller can pre-fill them with a known value (e.g. for debugging).
     ///
     /// ```no_run
     /// use zune_core::bytestream::ZCursor;
@@ -2264,14 +2284,24 @@ where
     /// let strides: Vec<usize> = (0..n)
     ///     .map(|i| (layout[i].width + 63) & !63)
     ///     .collect();
+    ///
+    /// // Allocate buffers sized to logical height × custom stride.
+    /// // Only layout[i].width × layout[i].height pixels are written;
+    /// // the gap between width and stride is never touched.
     /// let mut buffers: Vec<Vec<u8>> = (0..n)
     ///     .map(|i| vec![0u8; strides[i] * layout[i].height])
     ///     .collect();
     /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
     ///
     /// decoder.decode_raw_strided(&mut planes, &strides).unwrap();
-    /// // Each planes[i] now contains the component data with the custom stride.
-    /// // Upload planes[i] to a GPU texture with row pitch = strides[i].
+    ///
+    /// // Upload each plane to a GPU texture:
+    /// for i in 0..n {
+    ///     let width = layout[i].width;
+    ///     let height = layout[i].height;
+    ///     let row_pitch = strides[i];
+    ///     // gpu.upload_texture(planes[i], width, height, row_pitch);
+    /// }
     /// ```
     ///
     /// # Errors

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -499,7 +499,14 @@ pub(crate) struct RawPlanesSink<'planes, 'buf> {
 /// skips upsampling and color conversion and returns one post-IDCT plane per
 /// JPEG component. The configured output colorspace is therefore ignored.
 pub struct RawDecodeSession<'decoder, T> {
-    decoder: &'decoder mut JpegDecoder<T>
+    decoder: &'decoder mut JpegDecoder<T>,
+    previous_incremental_mode: bool,
+}
+
+impl<T> Drop for RawDecodeSession<'_, T> {
+    fn drop(&mut self) {
+        self.decoder.incremental_mode = self.previous_incremental_mode;
+    }
 }
 
 impl<T> RawDecodeSession<'_, T>
@@ -874,6 +881,7 @@ where
         if let Some(state) = self.scan_state.as_deref_mut() {
             state.scan_checkpoint = None;
             state.progressive_checkpoint = None;
+            state.progressive_fine_checkpoint = None;
         }
     }
 
@@ -1190,7 +1198,12 @@ where
     /// pixel output or option changes until the session is dropped.
     pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
         self.clear_scan_checkpoints();
-        RawDecodeSession { decoder: self }
+        let previous_incremental_mode = self.incremental_mode;
+        self.incremental_mode = true;
+        RawDecodeSession {
+            decoder: self,
+            previous_incremental_mode,
+        }
     }
 
     /// Number of components present in the JPEG scan (1..=4).

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -961,8 +961,9 @@ where
                 "converted scanline staging size overflow"
             ))?;
         let mut staging = core::mem::take(&mut self.decoder.scanline_state.staging);
-        staging.clear();
-        staging.resize(staging_len, 0);
+        if staging.len() != staging_len {
+            staging.resize(staging_len, 0);
+        }
         let result = self.decode_scanline_stripe(&mut staging, row_bytes);
         self.decoder.scanline_state.staging = staging;
         let status = result?;

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -2133,6 +2133,27 @@ where
     /// meaningful; trailing padding columns / rows contain
     /// implementation-defined data.
     ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    ///
+    /// let layout = decoder.planar_layout().unwrap();
+    /// let n = decoder.num_components();
+    /// let mut buffers: Vec<Vec<u8>> = (0..n)
+    ///     .map(|i| vec![0u8; layout[i].byte_size])
+    ///     .collect();
+    /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
+    ///
+    /// decoder.decode_raw(&mut planes).unwrap();
+    /// // planes[0] = Y, planes[1] = Cb, planes[2] = Cr (for YCbCr)
+    /// ```
+    ///
     /// # Errors
     /// - [`DecodeErrors::TooSmallOutput`]: a plane buffer is shorter than
     ///   its `byte_size`.
@@ -2185,7 +2206,7 @@ where
         // Raw mode writes into the plane sink; downstream pixel bookkeeping
         // only needs a placeholder slice.
         let mut sink: [u8; 0] = [];
-        let result = if self.is_arithmetic {
+        if self.is_arithmetic {
             #[cfg(feature = "arith")]
             {
                 if self.is_progressive {
@@ -2200,10 +2221,8 @@ where
             self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
         } else {
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
-        };
-
+        }
         // Guard clears `raw_planes_sink` on drop.
-        result
     }
 
     /// Decode raw planes using caller-supplied row strides.
@@ -2216,6 +2235,36 @@ where
     ///
     /// Only the logical plane area is written. Padding columns in the caller's
     /// stride and trailing DCT rows are left untouched.
+    ///
+    /// # Examples
+    ///
+    /// Skia-style: allocate with custom stride (e.g. GPU-aligned), decode
+    /// only the logical image area, leave padding untouched.
+    ///
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    ///
+    /// let layout = decoder.planar_layout().unwrap();
+    /// let n = decoder.num_components();
+    ///
+    /// // Use a 64-byte aligned stride (common for GPU upload).
+    /// let strides: Vec<usize> = (0..n)
+    ///     .map(|i| (layout[i].width + 63) & !63)
+    ///     .collect();
+    /// let mut buffers: Vec<Vec<u8>> = (0..n)
+    ///     .map(|i| vec![0u8; strides[i] * layout[i].height])
+    ///     .collect();
+    /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
+    ///
+    /// decoder.decode_raw_strided(&mut planes, &strides).unwrap();
+    /// // Each planes[i] now contains the component data with the custom stride.
+    /// // Upload planes[i] to a GPU texture with row pitch = strides[i].
+    /// ```
     ///
     /// # Errors
     /// - [`DecodeErrors::Format`] if `planes.len()` or `strides.len()`
@@ -2284,7 +2333,7 @@ where
         };
 
         let mut sink: [u8; 0] = [];
-        let result = if self.is_arithmetic {
+        if self.is_arithmetic {
             #[cfg(feature = "arith")]
             {
                 if self.is_progressive {
@@ -2299,9 +2348,7 @@ where
             self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
         } else {
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
-        };
-
-        result
+        }
     }
 
     /// Per-component [`ComponentID`] in declaration order
@@ -2383,7 +2430,11 @@ where
                     let dst_offset = (row_start + r) * target_stride;
                     let dst = plane_ptr.add(dst_offset);
                     for (i, sample) in src.iter().enumerate() {
-                        *dst.add(i) = *sample as u8;
+                        // Post-IDCT samples are already clamped to [0, 255].
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        {
+                            *dst.add(i) = *sample as u8;
+                        }
                     }
                 }
             }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -403,6 +403,8 @@ pub struct JpegDecoder<T> {
     /// capacity. Safe first-DC scans also keep its contents so a later retry can
     /// resume from a fine checkpoint without committing partial scan data.
     pub(crate) progressive_scan_buffer: [Vec<i16>; MAX_COMPONENTS],
+    /// Reusable baseline upsampling scratch retained across pull calls.
+    pub(crate) upsampler_scratch: Vec<i16>,
     /// Number of progressive scans committed into `progressive_mcus_buffer`.
     pub(crate) progressive_completed_scans: usize,
     /// Number of committed progressive scans currently rendered as preview
@@ -1461,6 +1463,7 @@ where
             scan_decode_attempted:       false,
             progressive_mcus_buffer:     core::array::from_fn(|_| Vec::new()),
             progressive_scan_buffer: core::array::from_fn(|_| Vec::new()),
+            upsampler_scratch: Vec::new(),
             progressive_completed_scans: 0,
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -29,7 +29,7 @@ use crate::bitstream::{BitstreamStateSnapshot, BitStreamHuffman};
 #[cfg(feature = "arith")]
 use crate::bitstream_arith::{ArithACTables, ArithDCTables, BitStreamArithmetic};
 use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
-use crate::components::{ComponentID, Components, SampleRatios};
+use crate::components::{Components, SampleRatios};
 use crate::errors::{DecodeErrors, UnsupportedSchemes};
 #[cfg(feature = "arith")]
 use crate::headers::parse_dac;
@@ -63,23 +63,29 @@ pub(crate) const MAX_DIMENSIONS: usize = 1 << 27;
 /// (`DCTSIZE = 8`). The logical `width`/`height` describe the meaningful
 /// sample area inside that buffer; trailing padding columns and rows
 /// contain implementation-defined data and should be ignored by the
-/// caller.
+/// caller. The sampling-factor fields preserve the exact SOF values so
+/// callers do not need to infer subsampling from rounded plane dimensions.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct PlaneInfo {
+    /// Horizontal sampling factor from the component's SOF entry.
+    pub horizontal_sampling_factor: usize,
+    /// Vertical sampling factor from the component's SOF entry.
+    pub vertical_sampling_factor:   usize,
     /// Logical component width in samples.
     /// `ceil(image_width * h_samp / h_max)`.
-    pub width:            usize,
+    pub width:                      usize,
     /// Logical component height in samples.
     /// `ceil(image_height * v_samp / v_max)`.
-    pub height:           usize,
+    pub height:                     usize,
     /// Allocated plane width (row stride) in bytes.
     /// `ceil(width / 8) * 8`.
-    pub stride:           usize,
+    pub stride:                     usize,
     /// Allocated plane height in rows.
     /// `ceil(height / 8) * 8`.
-    pub allocated_height: usize,
+    pub allocated_height:           usize,
     /// Required slice length for this plane: `stride * allocated_height`.
-    pub byte_size:        usize
+    pub byte_size:                  usize
 }
 
 /// Round `n` up to the next multiple of `align` (which must be non-zero).
@@ -480,6 +486,161 @@ pub(crate) struct RawPlanesSink<'planes, 'buf> {
     pub(crate) target_heights: [usize; MAX_COMPONENTS],
     /// Number of valid components.
     pub(crate) n_components:   usize
+}
+
+/// Exclusive borrowing session for whole-image raw component output.
+///
+/// Create a session with [`JpegDecoder::raw_output`] after decoding headers.
+/// While the session exists, its exclusive borrow prevents switching to pixel
+/// output or changing decoder options during a raw retry sequence. Entropy,
+/// MCU, checkpoint, and replay state remain owned by the borrowed decoder.
+///
+/// Unlike [`JpegDecoder::decode`] and [`JpegDecoder::decode_into`], raw output
+/// skips upsampling and color conversion and returns one post-IDCT plane per
+/// JPEG component. The configured output colorspace is therefore ignored.
+pub struct RawDecodeSession<'decoder, T> {
+    decoder: &'decoder mut JpegDecoder<T>
+}
+
+impl<T> RawDecodeSession<'_, T>
+where
+    T: ZByteReaderTrait
+{
+    /// Number of components in SOF declaration order.
+    ///
+    /// Returns `None` when headers have not been decoded yet.
+    #[must_use]
+    pub fn num_components(&self) -> Option<usize> {
+        self.decoder.raw_num_components()
+    }
+
+    /// Component selector bytes from the SOF marker, in declaration order.
+    ///
+    /// Common YCbCr files usually use `[1, 2, 3]`, while RGB files may use
+    /// `[b'R', b'G', b'B']`. Selectors are returned exactly as encoded so
+    /// callers can identify nonstandard component layouts.
+    ///
+    /// Returns `None` when headers have not been decoded yet or contain no
+    /// components.
+    #[must_use]
+    pub fn component_ids(&self) -> Option<Vec<u8>> {
+        self.decoder.raw_component_ids()
+    }
+
+    /// Per-component raw plane geometry and sampling metadata.
+    ///
+    /// Indices `0..num_components()` are populated in SOF declaration order;
+    /// trailing entries are [`PlaneInfo::default`]. The sampling-factor fields
+    /// preserve the exact SOF values, so callers can identify subsampling
+    /// without inferring it from rounded dimensions.
+    ///
+    /// ```text
+    /// width            = ceil(image_width  * h_samp / h_max)
+    /// height           = ceil(image_height * v_samp / v_max)
+    /// stride           = ceil(width  / 8) * 8
+    /// allocated_height = ceil(height / 8) * 8
+    /// byte_size        = stride * allocated_height
+    /// ```
+    ///
+    /// Returns `None` when headers have not been decoded or layout arithmetic
+    /// overflows `usize`.
+    #[must_use]
+    pub fn layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
+        self.decoder.raw_planar_layout()
+    }
+
+    /// Decode the complete image into DCT-block-padded component planes.
+    ///
+    /// Plane contents and geometry are compatible with libjpeg-turbo raw
+    /// output. This whole-image convenience method is not operationally
+    /// equivalent to one call to `jpeg_read_raw_data`, which returns one iMCU
+    /// row at a time.
+    ///
+    /// Supply one mutable plane per component in SOF declaration order. Each
+    /// plane must contain at least the corresponding [`PlaneInfo::byte_size`]
+    /// bytes from [`Self::layout`]. The configured output colorspace is
+    /// ignored. Samples within each plane's logical `width * height` area are
+    /// meaningful; trailing DCT padding is implementation-defined.
+    ///
+    /// On a recoverable EOF, call this method again on the same session after
+    /// exposing more input. Successful calls can also be replayed and produce
+    /// bit-identical planes.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    /// let mut raw = decoder.raw_output();
+    /// let layout = raw.layout().unwrap();
+    /// let count = raw.num_components().unwrap();
+    /// let mut buffers: Vec<Vec<u8>> = (0..count)
+    ///     .map(|index| vec![0; layout[index].byte_size])
+    ///     .collect();
+    /// let mut planes: Vec<&mut [u8]> =
+    ///     buffers.iter_mut().map(Vec::as_mut_slice).collect();
+    /// raw.decode_into(&mut planes).unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`DecodeErrors::TooSmallOutput`] for an undersized plane,
+    /// [`DecodeErrors::Format`] for the wrong plane count, or an error from
+    /// the underlying decode pipeline.
+    pub fn decode_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
+        self.decoder.decode_raw_into(planes)
+    }
+
+    /// Decode the complete image into component planes with caller row strides.
+    ///
+    /// Logical plane contents and geometry are compatible with libjpeg-turbo
+    /// raw output. This whole-image convenience method is not operationally
+    /// equivalent to one call to `jpeg_read_raw_data`, which returns one iMCU
+    /// row at a time. Only each plane's logical `width * height` area is
+    /// written; stride padding is left untouched.
+    ///
+    /// Supply one mutable plane and stride per component in SOF declaration
+    /// order. Each stride must be at least the corresponding logical
+    /// [`PlaneInfo::width`], and each plane must contain at least
+    /// `stride * PlaneInfo::height` bytes.
+    ///
+    /// On a recoverable EOF, call this method again on the same session after
+    /// exposing more input. Successful calls can also be replayed and produce
+    /// bit-identical logical samples.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::JpegDecoder;
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    /// let mut raw = decoder.raw_output();
+    /// let layout = raw.layout().unwrap();
+    /// let count = raw.num_components().unwrap();
+    /// let strides: Vec<usize> = (0..count)
+    ///     .map(|index| layout[index].width.div_ceil(64) * 64)
+    ///     .collect();
+    /// let mut buffers: Vec<Vec<u8>> = (0..count)
+    ///     .map(|index| vec![0; strides[index] * layout[index].height])
+    ///     .collect();
+    /// let mut planes: Vec<&mut [u8]> =
+    ///     buffers.iter_mut().map(Vec::as_mut_slice).collect();
+    /// raw.decode_into_strided(&mut planes, &strides).unwrap();
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`DecodeErrors::TooSmallOutput`] for an undersized plane,
+    /// [`DecodeErrors::Format`] for invalid plane counts or strides, or an
+    /// error from the underlying decode pipeline.
+    pub fn decode_into_strided(
+        &mut self, planes: &mut [&mut [u8]], strides: &[usize]
+    ) -> Result<(), DecodeErrors> {
+        self.decoder.decode_raw_into_strided(planes, strides)
+    }
 }
 
 impl<T> JpegDecoder<T>
@@ -1014,6 +1175,16 @@ where
         Some((decoded_output_bytes / row_stride).min(usize::from(self.height())))
     }
 
+    /// Begin an exclusive raw component-output session.
+    ///
+    /// Decode headers first when the caller needs to query
+    /// [`RawDecodeSession::layout`] or component metadata before allocating
+    /// output planes. The session borrows this decoder mutably, preventing
+    /// pixel output or option changes until the session is dropped.
+    pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
+        RawDecodeSession { decoder: self }
+    }
+
     /// Number of components present in the JPEG scan (1..=4).
     ///
     /// Valid only after [`decode_headers`](Self::decode_headers).
@@ -1022,7 +1193,7 @@ where
     /// - `Some(n)`: number of components in the input scan
     /// - `None`: headers have not been decoded yet
     #[must_use]
-    pub fn num_components(&self) -> Option<usize> {
+    fn raw_num_components(&self) -> Option<usize> {
         if self.headers_decoded {
             Some(self.components.len())
         } else {
@@ -1036,6 +1207,9 @@ where
     /// (Y, Cb, Cr for YCbCr; Y for grayscale; C, M, Y, K for CMYK; etc.).
     /// Indices `0..num_components()` are populated; trailing entries are
     /// the default zero-sized [`PlaneInfo`].
+    /// [`PlaneInfo::horizontal_sampling_factor`] and
+    /// [`PlaneInfo::vertical_sampling_factor`] expose each component's exact
+    /// SOF sampling factors.
     ///
     /// Plane dimensions are computed using the same rules as libjpeg-turbo's
     /// `jpeg_read_raw_data`:
@@ -1054,7 +1228,7 @@ where
     /// - `Some([PlaneInfo; MAX_COMPONENTS])`: per-component layout
     /// - `None`: headers have not been decoded yet, or layout overflows `usize`
     #[must_use]
-    pub fn planar_layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
+    fn raw_planar_layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
         if !self.headers_decoded || self.components.is_empty() {
             return None;
         }
@@ -1082,6 +1256,8 @@ where
             let allocated_height = round_up_pow2(comp_h, DCT_BLOCK_SIZE)?;
             let byte_size = stride.checked_mul(allocated_height)?;
             *slot = PlaneInfo {
+                horizontal_sampling_factor: comp.horizontal_sample,
+                vertical_sampling_factor: comp.vertical_sample,
                 width: comp_w,
                 height: comp_h,
                 stride,
@@ -2133,100 +2309,19 @@ where
         }
     }
 
-    /// Decode the image into per-component raw planes, skipping upsampling
-    /// and color conversion.
-    ///
-    /// Mirrors libjpeg-turbo's `jpeg_read_raw_data`: each component's
-    /// post-IDCT samples are written directly into its own plane buffer.
-    /// A 4:2:0 YCbCr image yields a full-resolution Y plane and
-    /// half-resolution Cb / Cr planes, each rounded up to DCT-block
-    /// boundaries.
-    ///
-    /// Plane order matches `self.components[i]` declaration order, i.e.
-    /// the order from the SOF marker (`[Y, Cb, Cr]` for YCbCr,
-    /// `[Y]` for grayscale, `[C, M, Y, K]` for CMYK, etc.). The configured
-    /// output colorspace is **ignored** in raw mode.
-    ///
-    /// Each `planes[i]` must be at least
-    /// [`PlaneInfo::byte_size`](`PlaneInfo::byte_size`) bytes
-    /// (`stride * allocated_height`), i.e. dimensions rounded up to
-    /// 8-sample DCT-block boundaries. For a 388×477 4:2:0 image:
-    /// `392 * 480 = 188_160` for Y and `200 * 240 = 48_000` for Cb / Cr.
-    /// See [`decode_raw_strided`](Self::decode_raw_strided) for accepting
-    /// logically-sized buffers.
-    ///
-    /// Samples within `[0, width) × [0, height)` of each plane are
-    /// meaningful; trailing padding columns / rows contain
-    /// implementation-defined data.
-    ///
-    /// # Resumability
-    ///
-    /// On a recoverable EOF (`DecodeErrors::is_recoverable_eof()`) the
-    /// decoder keeps enough state to resume; the caller can grow the input
-    /// stream and call `decode_raw` again with plane buffers sized from the
-    /// same [`planar_layout`](Self::planar_layout).
-    ///
-    /// On success the decoder keeps scan-start replay state, so a later
-    /// `decode_raw` call is well-defined and produces bit-identical planes.
-    /// Replay re-runs entropy decoding from the first SOS.
-    ///
-    /// # Examples
-    ///
-    /// Decode a JPEG into raw YCbCr planes (libjpeg-turbo style) and access
-    /// individual component data:
-    ///
-    /// ```no_run
-    /// use zune_core::bytestream::ZCursor;
-    /// use zune_jpeg::JpegDecoder;
-    ///
-    /// let data = std::fs::read("photo.jpg").unwrap();
-    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
-    /// decoder.decode_headers().unwrap();
-    ///
-    /// // Query the plane geometry (DCT-block-padded sizes).
-    /// let layout = decoder.planar_layout().unwrap();
-    /// let n = decoder.num_components().unwrap();
-    ///
-    /// // Allocate one buffer per component, sized to the full padded plane.
-    /// let mut buffers: Vec<Vec<u8>> = (0..n)
-    ///     .map(|i| vec![0u8; layout[i].byte_size])
-    ///     .collect();
-    /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
-    ///
-    /// decoder.decode_raw(&mut planes).unwrap();
-    ///
-    /// // For a 4:2:0 YCbCr image:
-    /// //   planes[0] = Y  (full resolution, padded to DCT blocks)
-    /// //   planes[1] = Cb (half resolution)
-    /// //   planes[2] = Cr (half resolution)
-    /// //
-    /// // Access a specific pixel's Y value:
-    /// let y_stride = layout[0].stride; // row pitch in bytes
-    /// let y_value = planes[0][/* row */ 10 * y_stride + /* col */ 20];
-    ///
-    /// // Identify component order for non-standard JPEGs:
-    /// let ids = decoder.component_ids().unwrap();
-    /// println!("Component order: {:?}", ids);
-    /// ```
-    ///
-    /// # Errors
-    /// - [`DecodeErrors::TooSmallOutput`]: a plane buffer is shorter than
-    ///   its `byte_size`.
-    /// - [`DecodeErrors::Format`]: `planes.len()` does not match the number
-    ///   of components.
-    /// - Any error from the underlying decode pipeline.
-    pub fn decode_raw(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
+    // Shared implementation for `RawDecodeSession::decode_into`.
+    fn decode_raw_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
         self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
         if planes.len() != n {
             return Err(DecodeErrors::Format(format!(
-                "decode_raw expected {n} plane buffer(s), got {}",
+                "RawDecodeSession::decode_into expected {n} plane buffer(s), got {}",
                 planes.len()
             )));
         }
-        let layout = self.planar_layout().ok_or(DecodeErrors::FormatStatic(
-            "planar_layout unavailable after decode_headers"
+        let layout = self.raw_planar_layout().ok_or(DecodeErrors::FormatStatic(
+            "raw layout unavailable after decode_headers"
         ))?;
         for (i, plane) in planes.iter().enumerate() {
             let need = layout[i].byte_size;
@@ -2257,78 +2352,8 @@ where
         self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
-    /// Decode raw planes using caller-supplied row strides.
-    ///
-    /// For each component `i` the caller must supply:
-    /// - `planes[i]`: a mutable byte slice of length at least
-    ///   `strides[i] * planar_layout()[i].height` bytes.
-    /// - `strides[i]`: the destination row stride in bytes. Must satisfy
-    ///   `strides[i] >= planar_layout()[i].width`.
-    ///
-    /// Only the logical plane area is written. Padding columns in the caller's
-    /// stride and trailing DCT rows are left untouched.
-    ///
-    /// # Resumability
-    ///
-    /// On a recoverable EOF (`DecodeErrors::is_recoverable_eof()`) the
-    /// decoder keeps enough state to resume; the caller can grow the input
-    /// stream and call `decode_raw_strided` again with the same plane layout.
-    ///
-    /// On success the decoder keeps scan-start replay state, so a later
-    /// `decode_raw_strided` call is well-defined and produces bit-identical
-    /// logical plane samples. Replay re-runs entropy decoding from the first
-    /// SOS.
-    ///
-    /// # Examples
-    ///
-    /// Skia-style: decode into GPU-aligned buffers where each row has a
-    /// power-of-two stride, then upload the planes as textures. Only the
-    /// logical image area is written; padding bytes are left untouched so
-    /// the caller can pre-fill them with a known value (e.g. for debugging).
-    ///
-    /// ```no_run
-    /// use zune_core::bytestream::ZCursor;
-    /// use zune_jpeg::JpegDecoder;
-    ///
-    /// let data = std::fs::read("photo.jpg").unwrap();
-    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
-    /// decoder.decode_headers().unwrap();
-    ///
-    /// let layout = decoder.planar_layout().unwrap();
-    /// let n = decoder.num_components().unwrap();
-    ///
-    /// // Use a 64-byte aligned stride (common for GPU upload).
-    /// let strides: Vec<usize> = (0..n)
-    ///     .map(|i| (layout[i].width + 63) & !63)
-    ///     .collect();
-    ///
-    /// // Allocate buffers sized to logical height × custom stride.
-    /// // Only layout[i].width × layout[i].height pixels are written;
-    /// // the gap between width and stride is never touched.
-    /// let mut buffers: Vec<Vec<u8>> = (0..n)
-    ///     .map(|i| vec![0u8; strides[i] * layout[i].height])
-    ///     .collect();
-    /// let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(|b| b.as_mut_slice()).collect();
-    ///
-    /// decoder.decode_raw_strided(&mut planes, &strides).unwrap();
-    ///
-    /// // Upload each plane to a GPU texture:
-    /// for i in 0..n {
-    ///     let width = layout[i].width;
-    ///     let height = layout[i].height;
-    ///     let row_pitch = strides[i];
-    ///     // gpu.upload_texture(planes[i], width, height, row_pitch);
-    /// }
-    /// ```
-    ///
-    /// # Errors
-    /// - [`DecodeErrors::Format`] if `planes.len()` or `strides.len()`
-    ///   doesn't match the number of components, or if any
-    ///   `strides[i] < width[i]`.
-    /// - [`DecodeErrors::TooSmallOutput`] if any plane buffer is shorter
-    ///   than `strides[i] * height[i]`.
-    /// - Any error from the underlying decode pipeline.
-    pub fn decode_raw_strided(
+    // Shared implementation for `RawDecodeSession::decode_into_strided`.
+    fn decode_raw_into_strided(
         &mut self, planes: &mut [&mut [u8]], strides: &[usize]
     ) -> Result<(), DecodeErrors> {
         self.prepare_for_scan_decode()?;
@@ -2336,18 +2361,18 @@ where
         let n = self.components.len();
         if planes.len() != n {
             return Err(DecodeErrors::Format(format!(
-                "decode_raw_strided expected {n} plane buffer(s), got {}",
+                "RawDecodeSession::decode_into_strided expected {n} plane buffer(s), got {}",
                 planes.len()
             )));
         }
         if strides.len() != n {
             return Err(DecodeErrors::Format(format!(
-                "decode_raw_strided expected {n} stride(s), got {}",
+                "RawDecodeSession::decode_into_strided expected {n} stride(s), got {}",
                 strides.len()
             )));
         }
-        let layout = self.planar_layout().ok_or(DecodeErrors::FormatStatic(
-            "planar_layout unavailable after decode_headers"
+        let layout = self.raw_planar_layout().ok_or(DecodeErrors::FormatStatic(
+            "raw layout unavailable after decode_headers"
         ))?;
         for (i, plane) in planes.iter().enumerate() {
             if strides[i] < layout[i].width {
@@ -2386,22 +2411,11 @@ where
         self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
-    /// Per-component [`ComponentID`] in declaration order
-    /// (`Y, Cb, Cr` for YCbCr; `Y` for grayscale; `Y, Cb, Cr, Q` for
-    /// 4-component scans, etc.).
-    ///
-    /// Useful when consuming the planes returned by
-    /// [`decode_raw`](Self::decode_raw) /
-    /// [`decode_raw_strided`](Self::decode_raw_strided) on non-conforming
-    /// JPEGs whose component order differs from the canonical layout.
-    ///
-    /// Valid only after [`decode_headers`](Self::decode_headers).
-    #[must_use]
-    pub fn component_ids(&self) -> Option<Vec<ComponentID>> {
+    fn raw_component_ids(&self) -> Option<Vec<u8>> {
         if !self.headers_decoded || self.components.is_empty() {
             return None;
         }
-        Some(self.components.iter().map(|c| c.component_id).collect())
+        Some(self.components.iter().map(|component| component.id).collect())
     }
 
     /// Copy one MCU stripe (`mcu_stripe_index`) of post-IDCT samples from

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -447,7 +447,9 @@ pub struct JpegDecoder<T> {
     /// scan's entropy data. The MCU decode loop will intercept that marker
     /// and store the real height; if it never arrives, decoding returns an
     /// error.
-    pub(crate) expects_dnl: bool
+    pub(crate) expects_dnl: bool,
+    /// Sequential raw iMCU-row progress shared across borrowing sessions.
+    raw_pull_state: RawPullState
 }
 
 /// Output target for one MCU decode call.
@@ -470,22 +472,105 @@ impl McuDecodeOutput<'_, '_> {
             Self::RawPlanes(_) => None
         }
     }
+
+    pub(crate) const fn requested_raw_stripe(&self) -> Option<usize> {
+        match self {
+            Self::RawPlanes(sink) => sink.requested_stripe,
+            Self::Pixels(_) => None
+        }
+    }
+
+    pub(crate) fn mark_raw_source_complete(&mut self) {
+        if let Self::RawPlanes(sink) = self {
+            sink.source_complete = true;
+        }
+    }
 }
 
 /// Caller-provided raw planar buffers for one decode call.
 pub(crate) struct RawPlanesSink<'planes, 'buf> {
     /// Caller plane buffers, one per component.
-    pub(crate) planes:         &'planes mut [&'buf mut [u8]],
+    pub(crate) planes:           &'planes mut [&'buf mut [u8]],
     /// Total byte length of each caller buffer.
-    pub(crate) lengths:        [usize; MAX_COMPONENTS],
+    pub(crate) lengths:          [usize; MAX_COMPONENTS],
     /// Bytes between successive destination rows (used for strided output).
-    pub(crate) target_strides: [usize; MAX_COMPONENTS],
+    pub(crate) target_strides:   [usize; MAX_COMPONENTS],
     /// Maximum bytes to write per destination row.
-    pub(crate) target_widths:  [usize; MAX_COMPONENTS],
+    pub(crate) target_widths:    [usize; MAX_COMPONENTS],
     /// Number of destination rows per plane.
-    pub(crate) target_heights: [usize; MAX_COMPONENTS],
+    pub(crate) target_heights:   [usize; MAX_COMPONENTS],
     /// Number of valid components.
-    pub(crate) n_components:   usize
+    pub(crate) n_components:     usize,
+    /// Pull mode requests exactly this sequential iMCU row.
+    pub(crate) requested_stripe: Option<usize>,
+    /// Logical rows copied for each component in pull mode.
+    pub(crate) rows_written:     [usize; MAX_COMPONENTS],
+    /// Whether a complete requested stripe was copied.
+    pub(crate) stripe_ready:     bool,
+    /// Whether entropy/coefficient production has completed.
+    pub(crate) source_complete:  bool
+}
+
+/// Result of requesting the next sequential raw iMCU row.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RawImcuRowStatus {
+    /// One complete iMCU row was written to the caller's planes.
+    RowReady {
+        /// Logical rows written for each component in SOF declaration order.
+        /// Entries after [`RawDecodeSession::num_components`] are zero.
+        rows_written: [usize; MAX_COMPONENTS]
+    },
+    /// The next iMCU row could not be completed with the currently visible input.
+    NeedMoreInput,
+    /// All raw component rows have been emitted.
+    Complete
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RawPullPhase {
+    Start,
+    StreamingBaseline,
+    BufferedRows,
+    Complete
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RawPullOwner {
+    None,
+    Pull,
+    WholeImage
+}
+
+struct RawPullState {
+    owner:                    RawPullOwner,
+    phase:                    RawPullPhase,
+    next_stripe:              usize,
+    entropy_tables:           Option<EntropyTables>,
+    layout:                   Option<[PlaneInfo; MAX_COMPONENTS]>,
+    rows_per_stripe:          [usize; MAX_COMPONENTS],
+    buffered_source_complete: bool
+}
+
+struct RawPullTargets {
+    lengths:        [usize; MAX_COMPONENTS],
+    strides:        [usize; MAX_COMPONENTS],
+    widths:         [usize; MAX_COMPONENTS],
+    heights:        [usize; MAX_COMPONENTS]
+}
+
+impl Default for RawPullState {
+    fn default() -> Self {
+        Self {
+            owner:                    RawPullOwner::None,
+            phase:                    RawPullPhase::Start,
+            next_stripe:              0,
+            entropy_tables:           None,
+            layout:                   None,
+            rows_per_stripe:          [0; MAX_COMPONENTS],
+            buffered_source_complete: false
+        }
+    }
 }
 
 /// Exclusive borrowing session for whole-image raw component output.
@@ -553,7 +638,301 @@ where
     /// overflows `usize`.
     #[must_use]
     pub fn layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
-        self.decoder.raw_planar_layout()
+        self.decoder
+            .raw_pull_state
+            .layout
+            .or_else(|| self.decoder.raw_planar_layout())
+    }
+
+    /// Decode the next sequential raw iMCU row into caller-provided planes.
+    ///
+    /// Each stride must be at least the corresponding logical plane width.
+    /// Each plane must be large enough for
+    /// `stride * vertical_sampling_factor * 8` bytes. The returned
+    /// `rows_written` count identifies the meaningful prefix; the final iMCU
+    /// row is clipped to the logical component height. Components that exhaust
+    /// their logical height before other components report zero rows on later
+    /// calls.
+    ///
+    /// A recoverable input suspension returns [`RawImcuRowStatus::NeedMoreInput`]
+    /// and leaves caller planes untouched. Expose more input through the same
+    /// decoder stream, then retry with the same session and plane layout. The
+    /// caller cannot select a stripe index.
+    ///
+    /// Images whose SOF height is zero and whose line count is supplied later
+    /// by a DNL marker are currently rejected because the caller-visible plane
+    /// geometry is not known when the pull sequence begins.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use zune_core::bytestream::ZCursor;
+    /// use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
+    ///
+    /// let data = std::fs::read("photo.jpg").unwrap();
+    /// let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+    /// decoder.decode_headers().unwrap();
+    /// let mut raw = decoder.raw_output();
+    /// let layout = raw.layout().unwrap();
+    /// let count = raw.num_components().unwrap();
+    /// let strides: Vec<usize> = layout[..count]
+    ///     .iter()
+    ///     .map(|plane| plane.width)
+    ///     .collect();
+    ///
+    /// loop {
+    ///     let mut storage: Vec<Vec<u8>> = layout[..count]
+    ///         .iter()
+    ///         .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+    ///         .collect();
+    ///     let mut planes: Vec<&mut [u8]> =
+    ///         storage.iter_mut().map(Vec::as_mut_slice).collect();
+    ///     match raw.decode_next_imcu_row(&mut planes, &strides).unwrap() {
+    ///         RawImcuRowStatus::RowReady { rows_written } => {
+    ///             // Consume `rows_written[index]` rows from each plane.
+    ///             let _ = rows_written;
+    ///         }
+    ///         RawImcuRowStatus::NeedMoreInput => break,
+    ///         RawImcuRowStatus::Complete => break,
+    ///         _ => unreachable!()
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    /// Returns [`DecodeErrors::Format`] for invalid plane counts or strides,
+    /// [`DecodeErrors::TooSmallOutput`] for an undersized plane, or a
+    /// non-recoverable decode error.
+    pub fn decode_next_imcu_row(
+        &mut self, planes: &mut [&mut [u8]], strides: &[usize]
+    ) -> Result<RawImcuRowStatus, DecodeErrors> {
+        self.decode_next_imcu_row_for(RawPullOwner::Pull, planes, strides)
+    }
+
+    fn decode_next_imcu_row_for(
+        &mut self, owner: RawPullOwner, planes: &mut [&mut [u8]], strides: &[usize]
+    ) -> Result<RawImcuRowStatus, DecodeErrors> {
+        if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
+            return Ok(RawImcuRowStatus::Complete);
+        }
+
+        let layout = self.pull_layout()?;
+        let n = self.decoder.components.len();
+        if self.decoder.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
+        if planes.len() != n || strides.len() != n {
+            return Err(DecodeErrors::Format(format!(
+                "raw iMCU-row output expected {n} plane(s) and stride(s), got {} plane(s) and {} stride(s)",
+                planes.len(),
+                strides.len()
+            )));
+        }
+
+        let total_stripes = self.decoder.raw_imcu_row_count(&layout, n);
+        if self.decoder.raw_pull_state.next_stripe >= total_stripes {
+            self.decoder.finish_raw_pull_source();
+            self.decoder.raw_pull_state.phase = RawPullPhase::Complete;
+            return Ok(RawImcuRowStatus::Complete);
+        }
+
+        let targets = self.pull_targets(planes, strides, &layout, n)?;
+        match self.decoder.raw_pull_state.owner {
+            RawPullOwner::None => self.decoder.raw_pull_state.owner = owner,
+            active if active == owner => {}
+            _ => {
+                return Err(DecodeErrors::FormatStatic(
+                    "cannot switch raw output API during an active decode sequence"
+                ))
+            }
+        }
+        let requested_stripe = self.decoder.raw_pull_state.next_stripe;
+        let raw_planes = RawPlanesSink {
+            planes,
+            lengths: targets.lengths,
+            target_strides: targets.strides,
+            target_widths: targets.widths,
+            target_heights: targets.heights,
+            n_components: n,
+            requested_stripe: Some(requested_stripe),
+            rows_written: [0; MAX_COMPONENTS],
+            stripe_ready: false,
+            source_complete: false
+        };
+        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
+
+        if let Err(error) = self.decode_pull_phase(&mut output, &layout, n) {
+            if error.is_recoverable_eof() {
+                return Ok(RawImcuRowStatus::NeedMoreInput);
+            }
+            return Err(error);
+        }
+
+        let sink = match output {
+            McuDecodeOutput::RawPlanes(sink) => sink,
+            McuDecodeOutput::Pixels(_) => unreachable!()
+        };
+        if sink.source_complete {
+            self.decoder.raw_pull_state.buffered_source_complete = true;
+            self.decoder.finish_raw_pull_source();
+        }
+        if !sink.stripe_ready {
+            self.decoder.raw_pull_state.phase = RawPullPhase::Complete;
+            return Ok(RawImcuRowStatus::Complete);
+        }
+
+        self.decoder.raw_pull_state.next_stripe += 1;
+        for (index, rows) in sink.rows_written.iter().copied().enumerate().take(n) {
+            if rows != 0 && self.decoder.raw_pull_state.rows_per_stripe[index] == 0 {
+                self.decoder.raw_pull_state.rows_per_stripe[index] = rows;
+            }
+        }
+        if self.decoder.raw_pull_state.phase == RawPullPhase::StreamingBaseline
+            && self.decoder.is_arithmetic
+        {
+            self.decoder.raw_pull_state.entropy_tables = Some(self.decoder.entropy_tables.clone());
+        }
+        Ok(RawImcuRowStatus::RowReady {
+            rows_written: sink.rows_written
+        })
+    }
+
+    fn pull_layout(&mut self) -> Result<[PlaneInfo; MAX_COMPONENTS], DecodeErrors> {
+        if let Some(layout) = self.decoder.raw_pull_state.layout {
+            return Ok(layout);
+        }
+        let layout = self.decoder.raw_planar_layout().ok_or(
+            DecodeErrors::FormatStatic("raw layout unavailable before headers are decoded")
+        )?;
+        self.decoder.raw_pull_state.layout = Some(layout);
+        Ok(layout)
+    }
+
+    fn pull_targets(
+        &self, planes: &[&mut [u8]], strides: &[usize],
+        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+    ) -> Result<RawPullTargets, DecodeErrors> {
+        let mut targets = RawPullTargets {
+            lengths: [0; MAX_COMPONENTS],
+            strides: [0; MAX_COMPONENTS],
+            widths: [0; MAX_COMPONENTS],
+            heights: [0; MAX_COMPONENTS]
+        };
+        for i in 0..n {
+            if strides[i] < layout[i].width {
+                return Err(DecodeErrors::Format(format!(
+                    "stride[{i}] = {} is smaller than logical width {}",
+                    strides[i], layout[i].width
+                )));
+            }
+            let configured_rows = self.decoder.raw_pull_state.rows_per_stripe[i];
+            let stripe_rows = if configured_rows == 0 {
+                layout[i].vertical_sampling_factor * DCT_BLOCK_SIZE
+            } else {
+                configured_rows
+            };
+            let row_start = self.decoder.raw_pull_state.next_stripe * stripe_rows;
+            let rows = layout[i].height.saturating_sub(row_start).min(stripe_rows);
+            let need = strides[i]
+                .checked_mul(rows)
+                .ok_or(DecodeErrors::FormatStatic(
+                    "raw iMCU-row plane size overflow"
+                ))?;
+            if planes[i].len() < need {
+                return Err(DecodeErrors::TooSmallOutput(need, planes[i].len()));
+            }
+            targets.lengths[i] = planes[i].len();
+            targets.strides[i] = strides[i];
+            targets.widths[i] = layout[i].width;
+            targets.heights[i] = rows;
+        }
+        Ok(targets)
+    }
+
+    fn decode_pull_phase(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>,
+        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+    ) -> Result<(), DecodeErrors> {
+        match self.decoder.raw_pull_state.phase {
+            RawPullPhase::Start => self.start_pull(output, layout, n),
+            RawPullPhase::StreamingBaseline => {
+                self.prepare_pull_scan()?;
+                #[cfg(feature = "arith")]
+                self.restore_arithmetic_pull_context()?;
+                self.decoder.decode_mcu_output(output)
+            }
+            RawPullPhase::BufferedRows => {
+                if self.decoder.raw_pull_state.buffered_source_complete {
+                    self.decoder.render_buffered_raw_stripe(output)
+                } else {
+                    self.prepare_pull_scan()?;
+                    self.decode_buffered_source_and_render(output, layout, n)
+                }
+            }
+            RawPullPhase::Complete => unreachable!()
+        }
+    }
+
+    fn start_pull(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>,
+        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+    ) -> Result<(), DecodeErrors> {
+        self.prepare_pull_scan()?;
+        let buffered = self.decoder.is_progressive
+            || usize::from(self.decoder.num_scans) != self.decoder.components.len();
+        self.decoder.raw_pull_state.phase = if buffered {
+            RawPullPhase::BufferedRows
+        } else {
+            RawPullPhase::StreamingBaseline
+        };
+        if buffered {
+            self.decode_buffered_source_and_render(output, layout, n)
+        } else {
+            self.decoder.decode_mcu_output(output)
+        }
+    }
+
+    fn prepare_pull_scan(&mut self) -> Result<(), DecodeErrors> {
+        self.decoder.prepare_for_scan_decode()?;
+        self.decoder.mcu_checkpoints_enabled = true;
+        Ok(())
+    }
+
+    fn decode_buffered_source_and_render(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>,
+        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+    ) -> Result<(), DecodeErrors> {
+        let stripe = self.decoder.raw_pull_state.next_stripe;
+        self.decoder.decode_buffered_raw_source(stripe, layout, n)?;
+        self.decoder.raw_pull_state.buffered_source_complete = true;
+        self.decoder.render_buffered_raw_stripe(output)
+    }
+
+    #[cfg(feature = "arith")]
+    fn restore_arithmetic_pull_context(&mut self) -> Result<(), DecodeErrors> {
+        if !self.decoder.is_arithmetic {
+            return Ok(());
+        }
+        let resumes_completed_row = match self.decoder.scan_checkpoint() {
+            Some(checkpoint) => matches!(
+                checkpoint.bitstream_state,
+                BitstreamStateSnapshot::Arithmetic(_)
+            ),
+            None => false
+        };
+        if resumes_completed_row {
+            let tables = self
+                .decoder
+                .raw_pull_state
+                .entropy_tables
+                .as_ref()
+                .ok_or(DecodeErrors::FormatStatic(
+                    "missing arithmetic contexts for raw iMCU-row resume"
+                ))?;
+            self.decoder.entropy_tables = tables.clone();
+        }
+        Ok(())
     }
 
     /// Decode the complete image into DCT-block-padded component planes.
@@ -597,7 +976,36 @@ where
     /// [`DecodeErrors::Format`] for the wrong plane count, or an error from
     /// the underlying decode pipeline.
     pub fn decode_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
-        self.decoder.decode_raw_into(planes)
+        if self.decoder.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
+        if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
+            self.decoder.raw_pull_state = RawPullState::default();
+        }
+        let layout = self.layout().ok_or(DecodeErrors::FormatStatic(
+            "raw layout unavailable before headers are decoded"
+        ))?;
+        let count = self.num_components().ok_or(DecodeErrors::FormatStatic(
+            "raw components unavailable before headers are decoded"
+        ))?;
+        if planes.len() != count {
+            return Err(DecodeErrors::Format(format!(
+                "RawDecodeSession::decode_into expected {count} plane buffer(s), got {}",
+                planes.len()
+            )));
+        }
+        for (index, plane) in planes.iter().enumerate() {
+            if plane.len() < layout[index].byte_size {
+                return Err(DecodeErrors::TooSmallOutput(
+                    layout[index].byte_size,
+                    plane.len()
+                ));
+            }
+        }
+        let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.stride).collect();
+        self.decode_whole_with_strides(planes, &strides, &layout)
     }
 
     /// Decode the complete image into component planes with caller row strides.
@@ -646,7 +1054,86 @@ where
     pub fn decode_into_strided(
         &mut self, planes: &mut [&mut [u8]], strides: &[usize]
     ) -> Result<(), DecodeErrors> {
-        self.decoder.decode_raw_into_strided(planes, strides)
+        if self.decoder.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
+        if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
+            self.decoder.raw_pull_state = RawPullState::default();
+        }
+        let layout = self.layout().ok_or(DecodeErrors::FormatStatic(
+            "raw layout unavailable before headers are decoded"
+        ))?;
+        let count = self.num_components().ok_or(DecodeErrors::FormatStatic(
+            "raw components unavailable before headers are decoded"
+        ))?;
+        if planes.len() != count || strides.len() != count {
+            return Err(DecodeErrors::Format(format!(
+                "RawDecodeSession::decode_into_strided expected {count} plane(s) and stride(s), got {} plane(s) and {} stride(s)",
+                planes.len(),
+                strides.len()
+            )));
+        }
+        for index in 0..count {
+            if strides[index] < layout[index].width {
+                return Err(DecodeErrors::Format(format!(
+                    "stride[{index}] = {} is smaller than logical width {}",
+                    strides[index], layout[index].width
+                )));
+            }
+            let need = strides[index]
+                .checked_mul(layout[index].height)
+                .ok_or(DecodeErrors::FormatStatic("plane size overflow"))?;
+            if planes[index].len() < need {
+                return Err(DecodeErrors::TooSmallOutput(need, planes[index].len()));
+            }
+        }
+        self.decode_whole_with_strides(planes, strides, &layout)
+    }
+
+    fn decode_whole_with_strides(
+        &mut self, planes: &mut [&mut [u8]], strides: &[usize],
+        layout: &[PlaneInfo; MAX_COMPONENTS]
+    ) -> Result<(), DecodeErrors> {
+        let count = planes.len();
+        loop {
+            let stripe = self.decoder.raw_pull_state.next_stripe;
+            if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
+                self.decoder.finish_raw_pull_source();
+                return Ok(());
+            }
+            let mut stripe_planes: Vec<&mut [u8]> = planes
+                .iter_mut()
+                .enumerate()
+                .map(|(index, plane)| {
+                    let configured_rows = self.decoder.raw_pull_state.rows_per_stripe[index];
+                    let stripe_rows = if configured_rows == 0 {
+                        layout[index].vertical_sampling_factor * DCT_BLOCK_SIZE
+                    } else {
+                        configured_rows
+                    };
+                    let row_start = stripe * stripe_rows;
+                    let rows = layout[index]
+                        .height
+                        .saturating_sub(row_start)
+                        .min(stripe_rows);
+                    let start = (row_start * strides[index]).min(plane.len());
+                    let end = start + rows * strides[index];
+                    &mut plane[start..end]
+                })
+                .collect();
+
+            match self.decode_next_imcu_row_for(
+                RawPullOwner::WholeImage,
+                &mut stripe_planes,
+                &strides[..count]
+            )? {
+                RawImcuRowStatus::RowReady { .. } => {}
+                RawImcuRowStatus::NeedMoreInput => return Err(DecodeErrors::ExhaustedData),
+                RawImcuRowStatus::Complete => return Ok(())
+            }
+        }
     }
 }
 
@@ -973,7 +1460,8 @@ where
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,
             marker_body_scratch:         Vec::new(),
-            expects_dnl:                 false
+            expects_dnl:                 false,
+            raw_pull_state:              RawPullState::default()
         }
     }
     /// Decode a buffer already in memory
@@ -984,6 +1472,7 @@ where
     /// # Errors
     /// See DecodeErrors for an explanation
     pub fn decode(&mut self) -> Result<Vec<u8>, DecodeErrors> {
+        self.abort_raw_pull_sequence();
         self.decode_headers()?;
         self.ensure_supported_encoding()?;
 
@@ -1197,13 +1686,32 @@ where
     /// output planes. The session borrows this decoder mutably, preventing
     /// pixel output or option changes until the session is dropped.
     pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
-        self.clear_scan_checkpoints();
+        if self.raw_pull_state.phase == RawPullPhase::Complete {
+            self.raw_pull_state = RawPullState::default();
+        }
+        if self.raw_pull_state.owner == RawPullOwner::None {
+            self.clear_scan_checkpoints();
+        }
         let previous_incremental_mode = self.incremental_mode;
         self.incremental_mode = true;
         RawDecodeSession {
             decoder: self,
             previous_incremental_mode,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn raw_buffer_capacities(
+        &self
+    ) -> ([usize; MAX_COMPONENTS], [usize; MAX_COMPONENTS]) {
+        (
+            core::array::from_fn(|index| {
+                self.components
+                    .get(index)
+                    .map_or(0, |component| component.raw_coeff.capacity())
+            }),
+            core::array::from_fn(|index| self.progressive_mcus_buffer[index].capacity())
+        )
     }
 
     /// Number of components present in the JPEG scan (1..=4).
@@ -1289,6 +1797,23 @@ where
         Some(out)
     }
 
+    fn raw_imcu_row_count(&self, layout: &[PlaneInfo; MAX_COMPONENTS], n: usize) -> usize {
+        layout[..n]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| {
+                let configured_rows = self.raw_pull_state.rows_per_stripe[index];
+                let rows = if configured_rows == 0 {
+                    plane.vertical_sampling_factor * DCT_BLOCK_SIZE
+                } else {
+                    configured_rows
+                };
+                plane.height.div_ceil(rows)
+            })
+            .max()
+            .unwrap_or(0)
+    }
+
     /// Get an immutable reference to the decoder options
     /// for the decoder instance
     ///
@@ -1328,8 +1853,10 @@ where
     }
     /// Set decoder options
     ///
-    /// This can be used after initialization or a partial decode. The next
-    /// output operation replays from scan start with the new options.
+    /// This can be used to set new options even after initialization
+    /// but before decoding.
+    ///
+    /// This does not bear any significance after decoding an image
     ///
     /// # Arguments
     /// - `options`: New decoder options
@@ -1411,6 +1938,7 @@ where
     }
 
     pub fn set_options(&mut self, options: DecoderOptions) {
+        self.abort_raw_pull_sequence();
         self.clear_scan_checkpoints();
         self.options = options;
         self.coeff = 1;
@@ -2298,6 +2826,7 @@ where
     }
 
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
+        self.abort_raw_pull_sequence();
         self.prepare_for_scan_decode()?;
 
         let expected_size = self.output_buffer_size().unwrap();
@@ -2336,116 +2865,66 @@ where
         }
     }
 
-    // Shared implementation for `RawDecodeSession::decode_into`.
-    fn decode_raw_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
-        if self.expects_dnl {
-            return Err(DecodeErrors::FormatStatic(
-                "raw output does not support DNL images"
-            ));
+    fn render_buffered_raw_stripe(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        if self.is_progressive {
+            self.render_buffered_progressive_raw_stripe(output)
+        } else {
+            self.render_buffered_baseline_raw_stripe(output)
         }
-        self.prepare_for_scan_decode()?;
-
-        let n = self.components.len();
-        if planes.len() != n {
-            return Err(DecodeErrors::Format(format!(
-                "RawDecodeSession::decode_into expected {n} plane buffer(s), got {}",
-                planes.len()
-            )));
-        }
-        let layout = self.raw_planar_layout().ok_or(DecodeErrors::FormatStatic(
-            "raw layout unavailable after decode_headers"
-        ))?;
-        for (i, plane) in planes.iter().enumerate() {
-            let need = layout[i].byte_size;
-            if plane.len() < need {
-                return Err(DecodeErrors::TooSmallOutput(need, plane.len()));
-            }
-        }
-
-        let mut lengths = [0usize; MAX_COMPONENTS];
-        let mut target_strides = [0usize; MAX_COMPONENTS];
-        let mut target_widths = [0usize; MAX_COMPONENTS];
-        let mut target_heights = [0usize; MAX_COMPONENTS];
-        for i in 0..n {
-            lengths[i] = planes[i].len();
-            target_strides[i] = layout[i].stride;
-            target_widths[i] = layout[i].stride;
-            target_heights[i] = layout[i].allocated_height;
-        }
-        let raw_planes = RawPlanesSink {
-            planes,
-            lengths,
-            target_strides,
-            target_widths,
-            target_heights,
-            n_components: n
-        };
-        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
-        self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
-    // Shared implementation for `RawDecodeSession::decode_into_strided`.
-    fn decode_raw_into_strided(
-        &mut self, planes: &mut [&mut [u8]], strides: &[usize]
+    fn decode_buffered_raw_source(
+        &mut self, requested_stripe: usize, layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
     ) -> Result<(), DecodeErrors> {
-        if self.expects_dnl {
-            return Err(DecodeErrors::FormatStatic(
-                "raw output does not support DNL images"
-            ));
-        }
-        self.prepare_for_scan_decode()?;
-
-        let n = self.components.len();
-        if planes.len() != n {
-            return Err(DecodeErrors::Format(format!(
-                "RawDecodeSession::decode_into_strided expected {n} plane buffer(s), got {}",
-                planes.len()
-            )));
-        }
-        if strides.len() != n {
-            return Err(DecodeErrors::Format(format!(
-                "RawDecodeSession::decode_into_strided expected {n} stride(s), got {}",
-                strides.len()
-            )));
-        }
-        let layout = self.raw_planar_layout().ok_or(DecodeErrors::FormatStatic(
-            "raw layout unavailable after decode_headers"
-        ))?;
-        for (i, plane) in planes.iter().enumerate() {
-            if strides[i] < layout[i].width {
-                return Err(DecodeErrors::Format(format!(
-                    "stride[{i}] = {} is smaller than logical width {}",
-                    strides[i], layout[i].width
-                )));
-            }
-            let need = strides[i]
-                .checked_mul(layout[i].height)
-                .ok_or(DecodeErrors::FormatStatic("plane size overflow"))?;
-            if plane.len() < need {
-                return Err(DecodeErrors::TooSmallOutput(need, plane.len()));
-            }
-        }
-
+        let mut buffers: Vec<Vec<u8>> = layout[..n]
+            .iter()
+            .map(|plane| {
+                let rows = plane.vertical_sampling_factor * DCT_BLOCK_SIZE;
+                vec![0; plane.width * rows]
+            })
+            .collect();
+        let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(Vec::as_mut_slice).collect();
         let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        for i in 0..n {
-            lengths[i] = planes[i].len();
-            target_strides[i] = strides[i];
-            target_widths[i] = layout[i].width;
-            target_heights[i] = layout[i].height;
+        for index in 0..n {
+            lengths[index] = planes[index].len();
+            target_strides[index] = layout[index].width;
+            target_widths[index] = layout[index].width;
+            target_heights[index] = layout[index].vertical_sampling_factor * DCT_BLOCK_SIZE;
         }
-        let raw_planes = RawPlanesSink {
-            planes,
+        let sink = RawPlanesSink {
+            planes: &mut planes,
             lengths,
             target_strides,
             target_widths,
             target_heights,
-            n_components: n
+            n_components: n,
+            requested_stripe: Some(requested_stripe),
+            rows_written: [0; MAX_COMPONENTS],
+            stripe_ready: false,
+            source_complete: false
         };
-        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
-        self.decode_mcu_output_with_success_cleanup(&mut output)
+        let mut output = McuDecodeOutput::RawPlanes(sink);
+        self.decode_mcu_output(&mut output)
+    }
+
+    fn finish_raw_pull_source(&mut self) {
+        self.clear_scan_checkpoints();
+        if self.is_progressive {
+            self.progressive_displayed_scans = self.progressive_completed_scans;
+        }
+    }
+
+    fn abort_raw_pull_sequence(&mut self) {
+        if self.raw_pull_state.owner == RawPullOwner::None {
+            return;
+        }
+        self.raw_pull_state = RawPullState::default();
+        self.clear_scan_checkpoints();
     }
 
     fn raw_component_ids(&self) -> Option<Vec<u8>> {
@@ -2466,6 +2945,14 @@ where
     pub(crate) fn copy_raw_planes_for_mcu_stripe(
         &self, mcu_stripe_index: usize, sink: &mut RawPlanesSink<'_, '_>
     ) -> Result<(), DecodeErrors> {
+        if let Some(requested_stripe) = sink.requested_stripe {
+            if requested_stripe != mcu_stripe_index {
+                return Err(DecodeErrors::FormatStatic(
+                    "raw iMCU-row output advanced out of sequence"
+                ));
+            }
+        }
+
         for (idx, comp) in self.components.iter().enumerate() {
             if idx >= sink.n_components {
                 break;
@@ -2475,14 +2962,38 @@ where
             let target_height = sink.target_heights[idx];
 
             let stripe_rows = comp.vertical_sample * DCT_BLOCK_SIZE;
-            let row_start = mcu_stripe_index * stripe_rows;
+            let source_row_start = mcu_stripe_index * stripe_rows;
+            let row_start = if sink.requested_stripe.is_some() { 0 } else { source_row_start };
             // Clip rows to the plane height.
             if row_start >= target_height {
                 continue;
             }
-            let rows_to_copy = core::cmp::min(stripe_rows, target_height - row_start);
-
             let src_stride = comp.width_stride;
+            let available_source_rows = comp.raw_coeff.len() / src_stride;
+            let logical_rows = if let Some(requested_stripe) = sink.requested_stripe {
+                if self.expects_dnl {
+                    target_height
+                } else {
+                    self.raw_planar_layout().map_or(target_height, |layout| {
+                        layout[idx]
+                            .height
+                            .saturating_sub(requested_stripe * available_source_rows)
+                            .min(target_height)
+                    })
+                }
+            } else {
+                target_height - row_start
+            };
+            let rows_to_copy = if sink.requested_stripe.is_some() {
+                core::cmp::min(logical_rows, available_source_rows)
+            } else {
+                core::cmp::min(
+                    core::cmp::min(stripe_rows, target_height - row_start),
+                    available_source_rows
+                )
+            };
+            sink.rows_written[idx] = rows_to_copy;
+
             let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
             let len = sink.lengths[idx];
 
@@ -2510,6 +3021,7 @@ where
                 }
             }
         }
+        sink.stripe_ready = true;
         Ok(())
     }
 
@@ -2739,8 +3251,7 @@ mod planar_layout_helpers {
 
     use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
     use crate::idct::{choose_idct_1x1_func, choose_idct_4x4_func, choose_idct_func};
-
-    use super::{round_up_pow2, JpegDecoder};
+    use super::{round_up_pow2, JpegDecoder, RawImcuRowStatus};
 
     #[test]
     fn div_ceil_basic() {
@@ -2800,6 +3311,38 @@ mod planar_layout_helpers {
                 decoder.color_convert_16 as usize,
                 choose_ycbcr_to_rgb_convert_func(colorspace, &replacement).unwrap() as usize
             );
+        }
+    }
+
+    #[test]
+    fn baseline_pull_memory_is_stripe_bounded() {
+        let data = include_bytes!("../../../test-images/jpeg/2029.jpg");
+        let mut decoder = JpegDecoder::new(ZCursor::new(data));
+        decoder.decode_headers().unwrap();
+        let mut raw = decoder.raw_output();
+        let layout = raw.layout().unwrap();
+        let count = raw.num_components().unwrap();
+        let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+        let mut buffers: Vec<Vec<u8>> = layout[..count]
+            .iter()
+            .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+            .collect();
+        let mut planes: Vec<&mut [u8]> = buffers.iter_mut().map(Vec::as_mut_slice).collect();
+        assert!(matches!(
+            raw.decode_next_imcu_row(&mut planes, &strides).unwrap(),
+            RawImcuRowStatus::RowReady { .. }
+        ));
+        drop(raw);
+
+        let (stripe_buffers, full_buffers) = decoder.raw_buffer_capacities();
+        assert!(full_buffers[..count].iter().all(|length| *length == 0));
+        for index in 0..count {
+            let rows = layout[index].vertical_sampling_factor * 8;
+            assert!(
+                stripe_buffers[index] <= (layout[index].stride + 8) * rows,
+                "component {index} exceeded one-iMCU-row scratch bound"
+            );
+            assert!(stripe_buffers[index] < layout[index].byte_size);
         }
     }
 }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -870,6 +870,13 @@ where
         }
     }
 
+    fn clear_scan_checkpoints(&mut self) {
+        if let Some(state) = self.scan_state.as_deref_mut() {
+            state.scan_checkpoint = None;
+            state.progressive_checkpoint = None;
+        }
+    }
+
     // Match output colorspace; we only care for ycbcr to rgb/rgba here, in
     // case one is using another colorspace may god help you.
     fn set_color_convert_from_options(&mut self) {
@@ -1182,6 +1189,7 @@ where
     /// output planes. The session borrows this decoder mutably, preventing
     /// pixel output or option changes until the session is dropped.
     pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
+        self.clear_scan_checkpoints();
         RawDecodeSession { decoder: self }
     }
 
@@ -1307,10 +1315,8 @@ where
     }
     /// Set decoder options
     ///
-    /// This can be used to set new options even after initialization
-    /// but before decoding.
-    ///
-    /// This does not bear any significance after decoding an image
+    /// This can be used after initialization or a partial decode. The next
+    /// output operation replays from scan start with the new options.
     ///
     /// # Arguments
     /// - `options`: New decoder options
@@ -1392,7 +1398,15 @@ where
     }
 
     pub fn set_options(&mut self, options: DecoderOptions) {
+        self.clear_scan_checkpoints();
         self.options = options;
+        self.coeff = 1;
+        self.pixels_decoded = 0;
+        self.progressive_displayed_scans = 0;
+        self.set_color_convert_from_options();
+        self.idct_func = choose_idct_func(&self.options);
+        self.idct_4x4_func = choose_idct_4x4_func(&self.options);
+        self.idct_1x1_func = choose_idct_1x1_func(&self.options);
     }
     #[allow(clippy::cast_possible_truncation)]
     fn reassemble_extended_xmp(&mut self) {
@@ -2311,6 +2325,11 @@ where
 
     // Shared implementation for `RawDecodeSession::decode_into`.
     fn decode_raw_into(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
+        if self.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
         self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
@@ -2356,6 +2375,11 @@ where
     fn decode_raw_into_strided(
         &mut self, planes: &mut [&mut [u8]], strides: &[usize]
     ) -> Result<(), DecodeErrors> {
+        if self.expects_dnl {
+            return Err(DecodeErrors::FormatStatic(
+                "raw output does not support DNL images"
+            ));
+        }
         self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
@@ -2696,7 +2720,14 @@ impl ImageInfo {
 
 #[cfg(test)]
 mod planar_layout_helpers {
-    use super::round_up_pow2;
+    use zune_core::bytestream::ZCursor;
+    use zune_core::colorspace::ColorSpace;
+    use zune_core::options::DecoderOptions;
+
+    use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
+    use crate::idct::{choose_idct_1x1_func, choose_idct_4x4_func, choose_idct_func};
+
+    use super::{round_up_pow2, JpegDecoder};
 
     #[test]
     fn div_ceil_basic() {
@@ -2722,5 +2753,40 @@ mod planar_layout_helpers {
     #[test]
     fn round_up_pow2_overflow() {
         assert_eq!(round_up_pow2(usize::MAX, 8), None);
+    }
+
+    #[test]
+    fn set_options_refreshes_cached_dispatch() {
+        for (initial, replacement) in [
+            (DecoderOptions::new_fast(), DecoderOptions::new_safe()),
+            (DecoderOptions::new_safe(), DecoderOptions::new_fast())
+        ] {
+            let mut decoder = JpegDecoder::new_with_options(ZCursor::new(&[]), initial);
+            decoder.set_options(replacement);
+            assert_eq!(decoder.idct_func as usize, choose_idct_func(&replacement) as usize);
+            assert_eq!(
+                decoder.idct_4x4_func as usize,
+                choose_idct_4x4_func(&replacement) as usize
+            );
+            assert_eq!(
+                decoder.idct_1x1_func as usize,
+                choose_idct_1x1_func(&replacement) as usize
+            );
+        }
+
+        for colorspace in [
+            ColorSpace::RGB,
+            ColorSpace::BGR,
+            ColorSpace::RGBA,
+            ColorSpace::BGRA
+        ] {
+            let replacement = DecoderOptions::default().jpeg_set_out_colorspace(colorspace);
+            let mut decoder = JpegDecoder::new(ZCursor::new(&[]));
+            decoder.set_options(replacement);
+            assert_eq!(
+                decoder.color_convert_16 as usize,
+                choose_ycbcr_to_rgb_convert_func(colorspace, &replacement).unwrap() as usize
+            );
+        }
     }
 }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -441,29 +441,32 @@ pub struct JpegDecoder<T> {
     /// scan's entropy data. The MCU decode loop will intercept that marker
     /// and store the real height; if it never arrives, decoding returns an
     /// error.
-    pub(crate) expects_dnl: bool,
-    /// When `Some`, the decoder is in raw planar output mode and
-    /// `post_process()` is bypassed in favour of copying each component's
-    /// post-IDCT samples directly into the caller-provided plane buffers.
-    ///
-    /// Always set/cleared inside [`JpegDecoder::decode_raw`]; `None`
-    /// during normal interleaved-pixel decoding.
-    pub(crate) raw_planes_sink: Option<RawPlanesSink>
+    pub(crate) expects_dnl: bool
 }
 
-/// Internal sink for one raw planar decode call.
-///
-/// Holds raw pointers into the caller-provided plane buffers so that MCU-stripe
-/// processing can write decoded samples directly without an intermediate copy.
-///
-/// # Safety
-/// The pointers are valid for the lifetime of the `decode_raw` / `decode_raw_strided`
-/// call that sets up this sink.  The sink is always cleared (set to `None`) before
-/// those functions return, so the pointers never outlive the caller's slices.
-#[allow(unsafe_code)]
-pub(crate) struct RawPlanesSink {
-    /// Raw pointers into the caller's plane buffers (one per component).
-    pub(crate) ptrs:           [*mut u8; MAX_COMPONENTS],
+/// Output target for one MCU decode call.
+pub(crate) enum McuDecodeOutput<'planes, 'buf> {
+    Pixels(&'planes mut [u8]),
+    RawPlanes(RawPlanesSink<'planes, 'buf>)
+}
+
+impl McuDecodeOutput<'_, '_> {
+    pub(crate) const fn is_raw(&self) -> bool {
+        matches!(self, Self::RawPlanes(_))
+    }
+
+    pub(crate) fn pixels_mut(&mut self) -> Option<&mut [u8]> {
+        match self {
+            Self::Pixels(pixels) => Some(pixels),
+            Self::RawPlanes(_) => None
+        }
+    }
+}
+
+/// Caller-provided raw planar buffers for one decode call.
+pub(crate) struct RawPlanesSink<'planes, 'buf> {
+    /// Caller plane buffers, one per component.
+    pub(crate) planes:         &'planes mut [&'buf mut [u8]],
     /// Total byte length of each caller buffer.
     pub(crate) lengths:        [usize; MAX_COMPONENTS],
     /// Bytes between successive destination rows (used for strided output).
@@ -475,15 +478,6 @@ pub(crate) struct RawPlanesSink {
     /// Number of valid components.
     pub(crate) n_components:   usize
 }
-
-/// SAFETY: The pointers in `RawPlanesSink` are derived from `&mut [u8]` references
-/// that live on the calling thread's stack.  The sink is only alive for the duration
-/// of a single `decode_raw*` call, never sent across threads.
-#[allow(unsafe_code)]
-unsafe impl Send for RawPlanesSink {}
-/// SAFETY: No shared-mutable state; see `Send` impl above.
-#[allow(unsafe_code)]
-unsafe impl Sync for RawPlanesSink {}
 
 impl<T> JpegDecoder<T>
 where
@@ -800,8 +794,7 @@ where
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,
             marker_body_scratch:         Vec::new(),
-                expects_dnl:                 false,
-                raw_planes_sink:             None
+            expects_dnl:                 false
         }
     }
     /// Decode a buffer already in memory
@@ -2078,23 +2071,8 @@ where
         }
         self.scan_decode_attempted = true;
 
-        let result: Result<(), DecodeErrors>;
-        if self.is_arithmetic {
-            #[cfg(feature = "arith")]
-            {
-                result = if self.is_progressive {
-                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(out)
-                } else {
-                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(out)
-                };
-            }
-            #[cfg(not(feature = "arith"))]
-            unreachable!();
-        } else if self.is_progressive {
-            result = self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(out);
-        } else {
-            result = self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(out);
-        }
+        let mut output = McuDecodeOutput::Pixels(out);
+        let result = self.decode_mcu_output(&mut output);
 
         match result {
             Ok(()) => {
@@ -2116,6 +2094,27 @@ where
                 Ok(())
             }
             Err(e) => Err(e)
+        }
+    }
+
+    fn decode_mcu_output(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        if self.is_arithmetic {
+            #[cfg(feature = "arith")]
+            {
+                if self.is_progressive {
+                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(output)
+                } else {
+                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(output)
+                }
+            }
+            #[cfg(not(feature = "arith"))]
+            unreachable!();
+        } else if self.is_progressive {
+            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(output)
+        } else {
+            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(output)
         }
     }
 
@@ -2210,55 +2209,26 @@ where
             }
         }
 
-        // Set up the raw-planes sink pointing directly into the caller's slices.
-        // SAFETY: The pointers are derived from the mutable slice references in
-        // `planes`, which are guaranteed to remain valid and exclusively borrowed
-        // for the duration of this call.  The sink is cleared before we return.
-        let mut ptrs = [core::ptr::null_mut(); MAX_COMPONENTS];
         let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
         for i in 0..n {
-            ptrs[i] = planes[i].as_mut_ptr();
             lengths[i] = planes[i].len();
             target_strides[i] = layout[i].stride;
             target_widths[i] = layout[i].stride;
             target_heights[i] = layout[i].allocated_height;
         }
-        self.raw_planes_sink = Some(RawPlanesSink {
-            ptrs,
+        let raw_planes = RawPlanesSink {
+            planes,
             lengths,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
-        });
-
-        // Raw mode writes directly into the caller's buffers; downstream pixel
-        // bookkeeping only needs a placeholder slice.
-        let mut sink: [u8; 0] = [];
-        let result = if self.is_arithmetic {
-            #[cfg(feature = "arith")]
-            {
-                if self.is_progressive {
-                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(&mut sink)
-                } else {
-                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(&mut sink)
-                }
-            }
-            #[cfg(not(feature = "arith"))]
-            unreachable!();
-        } else if self.is_progressive {
-            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
-        } else {
-            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
         };
-
-        // Clear the sink so pointers don't outlive the caller's slices.
-        self.raw_planes_sink = None;
-
-        result
+        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
+        self.decode_mcu_output(&mut output)
     }
 
     /// Decode raw planes using caller-supplied row strides.
@@ -2357,52 +2327,26 @@ where
             }
         }
 
-        // Set up the raw-planes sink pointing directly into the caller's slices.
-        // SAFETY: Same guarantees as `decode_raw` — pointers derived from exclusive
-        // mutable borrows, valid for the entire call, cleared before return.
-        let mut ptrs = [core::ptr::null_mut(); MAX_COMPONENTS];
         let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
         for i in 0..n {
-            ptrs[i] = planes[i].as_mut_ptr();
             lengths[i] = planes[i].len();
             target_strides[i] = strides[i];
             target_widths[i] = layout[i].width;
             target_heights[i] = layout[i].height;
         }
-        self.raw_planes_sink = Some(RawPlanesSink {
-            ptrs,
+        let raw_planes = RawPlanesSink {
+            planes,
             lengths,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
-        });
-
-        let mut sink: [u8; 0] = [];
-        let result = if self.is_arithmetic {
-            #[cfg(feature = "arith")]
-            {
-                if self.is_progressive {
-                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(&mut sink)
-                } else {
-                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(&mut sink)
-                }
-            }
-            #[cfg(not(feature = "arith"))]
-            unreachable!();
-        } else if self.is_progressive {
-            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
-        } else {
-            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
         };
-
-        // Clear the sink so pointers don't outlive the caller's slices.
-        self.raw_planes_sink = None;
-
-        result
+        let mut output = McuDecodeOutput::RawPlanes(raw_planes);
+        self.decode_mcu_output(&mut output)
     }
 
     /// Per-component [`ComponentID`] in declaration order
@@ -2427,20 +2371,13 @@ where
     /// each component's `raw_coeff` into the caller-provided plane buffers.
     ///
     /// Called from the baseline / progressive paths in place of
-    /// `post_process()` when [`raw_planes_sink`](Self::raw_planes_sink)
-    /// is `Some` (i.e. inside [`decode_raw`](Self::decode_raw)).
+    /// `post_process()` when decoding raw planes.
     ///
     /// The IDCT outputs are already clamped to `[0, 255]` so the `i16 -> u8`
     /// truncation here is exact.
-    #[allow(unsafe_code)]
     pub(crate) fn copy_raw_planes_for_mcu_stripe(
-        &mut self, mcu_stripe_index: usize
+        &self, mcu_stripe_index: usize, sink: &mut RawPlanesSink<'_, '_>
     ) -> Result<(), DecodeErrors> {
-        let sink = self
-            .raw_planes_sink
-            .as_mut()
-            .expect("copy_raw_planes_for_mcu_stripe called without active sink");
-
         for (idx, comp) in self.components.iter().enumerate() {
             if idx >= sink.n_components {
                 break;
@@ -2459,8 +2396,6 @@ where
 
             let src_stride = comp.width_stride;
             let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
-
-            let ptr = sink.ptrs[idx];
             let len = sink.lengths[idx];
 
             for r in 0..rows_to_copy {
@@ -2474,18 +2409,15 @@ where
                 let src = &comp.raw_coeff[src_row_start..src_row_end];
 
                 let dst_offset = (row_start + r) * target_stride;
-                debug_assert!(dst_offset + copy_w <= len);
-                // SAFETY: `ptr` points into the caller's `&mut [u8]` which is
-                // guaranteed to be at least `len` bytes.  The bounds check above
-                // (via `target_height` / `target_stride` validation in decode_raw*)
-                // ensures `dst_offset + copy_w <= len`.
-                unsafe {
-                    let dst = core::slice::from_raw_parts_mut(ptr.add(dst_offset), copy_w);
-                    for (i, sample) in src.iter().enumerate() {
-                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                        {
-                            dst[i] = *sample as u8;
-                        }
+                let dst_end = dst_offset + copy_w;
+                if dst_end > len {
+                    return Err(DecodeErrors::TooSmallOutput(dst_end, len));
+                }
+                let dst = &mut sink.planes[idx][dst_offset..dst_end];
+                for (sample, dst) in src.iter().zip(dst.iter_mut()) {
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    {
+                        *dst = *sample as u8;
                     }
                 }
             }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -646,6 +646,11 @@ where
 
     /// Decode the next sequential raw iMCU row into caller-provided planes.
     ///
+    /// Interleaved baseline images decode and deliver one iMCU row at a time.
+    /// Progressive and multi-SOS images must first buffer all coefficient data
+    /// needed for final samples; their rows are still pulled sequentially, but
+    /// compressed input consumption is not row-streaming.
+    ///
     /// Each stride must be at least the corresponding logical plane width.
     /// Each plane must be large enough for
     /// `stride * vertical_sampling_factor * 8` bytes. The returned

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -15,6 +15,7 @@ use alloc::vec::Vec;
 use alloc::sync::Arc;
 use alloc::{format, vec};
 use core::num::NonZeroU32;
+use core::ptr::NonNull;
 
 use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::colorspace::ColorSpace;
@@ -29,7 +30,7 @@ use crate::bitstream::{BitstreamStateSnapshot, BitStreamHuffman};
 #[cfg(feature = "arith")]
 use crate::bitstream_arith::{ArithACTables, ArithDCTables, BitStreamArithmetic};
 use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
-use crate::components::{Components, SampleRatios};
+use crate::components::{ComponentID, Components, SampleRatios};
 use crate::errors::{DecodeErrors, UnsupportedSchemes};
 #[cfg(feature = "arith")]
 use crate::headers::parse_dac;
@@ -49,8 +50,58 @@ use crate::upsampler::{
 /// Maximum components
 pub(crate) const MAX_COMPONENTS: usize = 4;
 
+/// DCT block side, in samples. JPEG always uses 8x8 blocks.
+pub(crate) const DCT_BLOCK_SIZE: usize = 8;
+
 /// Maximum image dimensions supported.
 pub(crate) const MAX_DIMENSIONS: usize = 1 << 27;
+
+/// Geometry of a single component plane for raw post-IDCT output.
+///
+/// Mirrors the padded buffer layout libjpeg-turbo's `jpeg_read_raw_data` expects:
+/// each component owns a plane sized to `stride * allocated_height` bytes,
+/// with both dimensions rounded up to DCT-block boundaries
+/// (`DCTSIZE = 8`). The logical `width`/`height` describe the meaningful
+/// sample area inside that buffer; trailing padding columns and rows
+/// contain implementation-defined data and should be ignored by the
+/// caller.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct PlaneInfo {
+    /// Logical component width in samples.
+    /// `ceil(image_width * h_samp / h_max)`.
+    pub width:            usize,
+    /// Logical component height in samples.
+    /// `ceil(image_height * v_samp / v_max)`.
+    pub height:           usize,
+    /// Allocated plane width (row stride) in bytes.
+    /// `ceil(width / 8) * 8`.
+    pub stride:           usize,
+    /// Allocated plane height in rows.
+    /// `ceil(height / 8) * 8`.
+    pub allocated_height: usize,
+    /// Required slice length for this plane: `stride * allocated_height`.
+    pub byte_size:        usize
+}
+
+/// Ceiling division: `ceil(a / b)` without overflow on the addition.
+#[inline]
+fn ceil_div(a: usize, b: usize) -> usize {
+    debug_assert!(b != 0);
+    a / b + usize::from(a % b != 0)
+}
+
+/// Round `n` up to the next multiple of `align` (which must be non-zero).
+/// Returns `None` on overflow.
+#[inline]
+fn round_up_pow2(n: usize, align: usize) -> Option<usize> {
+    debug_assert!(align != 0);
+    let rem = n % align;
+    if rem == 0 {
+        Some(n)
+    } else {
+        n.checked_add(align - rem)
+    }
+}
 
 /// Color conversion function that can convert YCbCr colorspace to RGB(A/X) for
 /// 16 values
@@ -398,7 +449,28 @@ pub struct JpegDecoder<T> {
     /// scan's entropy data. The MCU decode loop will intercept that marker
     /// and store the real height; if it never arrives, decoding returns an
     /// error.
-    pub(crate) expects_dnl: bool
+    pub(crate) expects_dnl: bool,
+    /// When `Some`, the decoder is in raw planar output mode and
+    /// `post_process()` is bypassed in favour of copying each component's
+    /// post-IDCT samples directly into the caller-provided plane buffers.
+    ///
+    /// Always set/cleared inside [`JpegDecoder::decode_raw`]; `None`
+    /// during normal interleaved-pixel decoding.
+    pub(crate) raw_planes_sink: Option<RawPlanesSink>
+}
+
+/// Internal sink for one raw planar decode call.
+pub(crate) struct RawPlanesSink {
+    /// Per-component plane base pointer (only `0..n_components` are valid).
+    pub(crate) ptrs:           [*mut u8; MAX_COMPONENTS],
+    /// Bytes between successive destination rows.
+    pub(crate) target_strides: [usize; MAX_COMPONENTS],
+    /// Maximum bytes to write per destination row.
+    pub(crate) target_widths:  [usize; MAX_COMPONENTS],
+    /// Number of destination rows the caller's buffer can accept.
+    pub(crate) target_heights: [usize; MAX_COMPONENTS],
+    /// Number of valid components in `ptrs`.
+    pub(crate) n_components:   usize
 }
 
 impl<T> JpegDecoder<T>
@@ -716,7 +788,8 @@ where
             progressive_displayed_scans: 0,
             progressive_render_incomplete: false,
             marker_body_scratch:         Vec::new(),
-            expects_dnl:                 false
+                expects_dnl:                 false,
+                raw_planes_sink:             None
         }
     }
     /// Decode a buffer already in memory
@@ -931,6 +1004,84 @@ where
         }
 
         Some((decoded_output_bytes / row_stride).min(usize::from(self.height())))
+    }
+
+    /// Number of components present in the JPEG scan (1..=4).
+    ///
+    /// Valid only after [`decode_headers`](Self::decode_headers).
+    ///
+    /// # Returns
+    /// - `Some(n)`: number of components in the input scan
+    /// - `None`: headers have not been decoded yet
+    #[must_use]
+    pub fn num_components(&self) -> Option<usize> {
+        if self.headers_decoded {
+            Some(self.components.len())
+        } else {
+            None
+        }
+    }
+
+    /// Per-component plane geometry for raw planar output.
+    ///
+    /// Returns one [`PlaneInfo`] per component in declaration order
+    /// (Y, Cb, Cr for YCbCr; Y for grayscale; C, M, Y, K for CMYK; etc.).
+    /// Indices `0..num_components()` are populated; trailing entries are
+    /// the default zero-sized [`PlaneInfo`].
+    ///
+    /// Plane dimensions are computed using the same rules as libjpeg-turbo's
+    /// `jpeg_read_raw_data`:
+    ///
+    /// ```text
+    /// comp_width       = ceil(image_width  * h_samp / h_max)
+    /// comp_height      = ceil(image_height * v_samp / v_max)
+    /// stride           = ceil(comp_width  / 8) * 8
+    /// allocated_height = ceil(comp_height / 8) * 8
+    /// byte_size        = stride * allocated_height
+    /// ```
+    ///
+    /// Valid only after [`decode_headers`](Self::decode_headers).
+    ///
+    /// # Returns
+    /// - `Some([PlaneInfo; MAX_COMPONENTS])`: per-component layout
+    /// - `None`: headers have not been decoded yet, or layout overflows `usize`
+    #[must_use]
+    pub fn planar_layout(&self) -> Option<[PlaneInfo; MAX_COMPONENTS]> {
+        if !self.headers_decoded || self.components.is_empty() {
+            return None;
+        }
+        let img_w = usize::from(self.width());
+        let img_h = usize::from(self.height());
+        // `self.h_max` / `self.v_max` aren't populated until `decode()` runs
+        // `setup_component_params`, so derive the maxima directly from the
+        // parsed component list (which is available right after
+        // `decode_headers`).
+        let mut h_max = 1usize;
+        let mut v_max = 1usize;
+        for comp in &self.components {
+            if comp.horizontal_sample > h_max {
+                h_max = comp.horizontal_sample;
+            }
+            if comp.vertical_sample > v_max {
+                v_max = comp.vertical_sample;
+            }
+        }
+        let mut out = [PlaneInfo::default(); MAX_COMPONENTS];
+        for (slot, comp) in out.iter_mut().zip(self.components.iter()) {
+            let comp_w = ceil_div(img_w.checked_mul(comp.horizontal_sample)?, h_max);
+            let comp_h = ceil_div(img_h.checked_mul(comp.vertical_sample)?, v_max);
+            let stride = round_up_pow2(comp_w, DCT_BLOCK_SIZE)?;
+            let allocated_height = round_up_pow2(comp_h, DCT_BLOCK_SIZE)?;
+            let byte_size = stride.checked_mul(allocated_height)?;
+            *slot = PlaneInfo {
+                width: comp_w,
+                height: comp_h,
+                stride,
+                allocated_height,
+                byte_size
+            };
+        }
+        Some(out)
     }
 
     /// Get an immutable reference to the decoder options
@@ -1956,6 +2107,290 @@ where
         }
     }
 
+    /// Decode the image into per-component raw planes, skipping upsampling
+    /// and color conversion.
+    ///
+    /// Mirrors libjpeg-turbo's `jpeg_read_raw_data`: each component's
+    /// post-IDCT samples are written directly into its own plane buffer.
+    /// A 4:2:0 YCbCr image yields a full-resolution Y plane and
+    /// half-resolution Cb / Cr planes, each rounded up to DCT-block
+    /// boundaries.
+    ///
+    /// Plane order matches `self.components[i]` declaration order, i.e.
+    /// the order from the SOF marker (`[Y, Cb, Cr]` for YCbCr,
+    /// `[Y]` for grayscale, `[C, M, Y, K]` for CMYK, etc.). The configured
+    /// output colorspace is **ignored** in raw mode.
+    ///
+    /// Each `planes[i]` must be at least
+    /// [`PlaneInfo::byte_size`](`PlaneInfo::byte_size`) bytes
+    /// (`stride * allocated_height`), i.e. dimensions rounded up to
+    /// 8-sample DCT-block boundaries. For a 388×477 4:2:0 image:
+    /// `392 * 480 = 188_160` for Y and `200 * 240 = 48_000` for Cb / Cr.
+    /// See [`decode_raw_strided`](Self::decode_raw_strided) for accepting
+    /// logically-sized buffers.
+    ///
+    /// Samples within `[0, width) × [0, height)` of each plane are
+    /// meaningful; trailing padding columns / rows contain
+    /// implementation-defined data.
+    ///
+    /// # Errors
+    /// - [`DecodeErrors::TooSmallOutput`]: a plane buffer is shorter than
+    ///   its `byte_size`.
+    /// - [`DecodeErrors::Format`]: `planes.len()` does not match the number
+    ///   of components.
+    /// - Any error from the underlying decode pipeline.
+    pub fn decode_raw(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
+        self.decode_headers_internal()?;
+
+        let n = self.components.len();
+        if planes.len() != n {
+            return Err(DecodeErrors::Format(format!(
+                "decode_raw expected {n} plane buffer(s), got {}",
+                planes.len()
+            )));
+        }
+        let layout = self.planar_layout().ok_or(DecodeErrors::FormatStatic(
+            "planar_layout unavailable after decode_headers"
+        ))?;
+        for (i, plane) in planes.iter().enumerate() {
+            let need = layout[i].byte_size;
+            if plane.len() < need {
+                return Err(DecodeErrors::TooSmallOutput(need, plane.len()));
+            }
+        }
+
+        // Each plane is mutably borrowed for this call; the guard clears the
+        // raw pointers before returning.
+        let mut ptrs: [*mut u8; MAX_COMPONENTS] = [core::ptr::null_mut(); MAX_COMPONENTS];
+        let mut target_strides = [0usize; MAX_COMPONENTS];
+        let mut target_widths = [0usize; MAX_COMPONENTS];
+        let mut target_heights = [0usize; MAX_COMPONENTS];
+        for (i, plane) in planes.iter_mut().enumerate() {
+            ptrs[i] = plane.as_mut_ptr();
+            target_strides[i] = layout[i].stride;
+            target_widths[i] = layout[i].stride;
+            target_heights[i] = layout[i].allocated_height;
+        }
+        self.raw_planes_sink = Some(RawPlanesSink {
+            ptrs,
+            target_strides,
+            target_widths,
+            target_heights,
+            n_components: n
+        });
+        let _guard = RawPlanesGuard {
+            dec: NonNull::from(&mut *self)
+        };
+
+        // Raw mode writes into the plane sink; downstream pixel bookkeeping
+        // only needs a placeholder slice.
+        let mut sink: [u8; 0] = [];
+        let result = if self.is_arithmetic {
+            #[cfg(feature = "arith")]
+            {
+                if self.is_progressive {
+                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(&mut sink)
+                } else {
+                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(&mut sink)
+                }
+            }
+            #[cfg(not(feature = "arith"))]
+            unreachable!();
+        } else if self.is_progressive {
+            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
+        } else {
+            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
+        };
+
+        // Guard clears `raw_planes_sink` on drop.
+        result
+    }
+
+    /// Decode raw planes using caller-supplied row strides.
+    ///
+    /// For each component `i` the caller must supply:
+    /// - `planes[i]`: a mutable byte slice of length at least
+    ///   `strides[i] * planar_layout()[i].height` bytes.
+    /// - `strides[i]`: the destination row stride in bytes. Must satisfy
+    ///   `strides[i] >= planar_layout()[i].width`.
+    ///
+    /// Only the logical plane area is written. Padding columns in the caller's
+    /// stride and trailing DCT rows are left untouched.
+    ///
+    /// # Errors
+    /// - [`DecodeErrors::Format`] if `planes.len()` or `strides.len()`
+    ///   doesn't match the number of components, or if any
+    ///   `strides[i] < width[i]`.
+    /// - [`DecodeErrors::TooSmallOutput`] if any plane buffer is shorter
+    ///   than `strides[i] * height[i]`.
+    /// - Any error from the underlying decode pipeline.
+    pub fn decode_raw_strided(
+        &mut self, planes: &mut [&mut [u8]], strides: &[usize]
+    ) -> Result<(), DecodeErrors> {
+        self.decode_headers_internal()?;
+
+        let n = self.components.len();
+        if planes.len() != n {
+            return Err(DecodeErrors::Format(format!(
+                "decode_raw_strided expected {n} plane buffer(s), got {}",
+                planes.len()
+            )));
+        }
+        if strides.len() != n {
+            return Err(DecodeErrors::Format(format!(
+                "decode_raw_strided expected {n} stride(s), got {}",
+                strides.len()
+            )));
+        }
+        let layout = self.planar_layout().ok_or(DecodeErrors::FormatStatic(
+            "planar_layout unavailable after decode_headers"
+        ))?;
+        for (i, plane) in planes.iter().enumerate() {
+            if strides[i] < layout[i].width {
+                return Err(DecodeErrors::Format(format!(
+                    "stride[{i}] = {} is smaller than logical width {}",
+                    strides[i], layout[i].width
+                )));
+            }
+            let need = strides[i]
+                .checked_mul(layout[i].height)
+                .ok_or(DecodeErrors::FormatStatic("plane size overflow"))?;
+            if plane.len() < need {
+                return Err(DecodeErrors::TooSmallOutput(need, plane.len()));
+            }
+        }
+
+        // Each plane is mutably borrowed for this call; the guard clears the
+        // raw pointers before returning.
+        let mut ptrs: [*mut u8; MAX_COMPONENTS] = [core::ptr::null_mut(); MAX_COMPONENTS];
+        let mut target_strides = [0usize; MAX_COMPONENTS];
+        let mut target_widths = [0usize; MAX_COMPONENTS];
+        let mut target_heights = [0usize; MAX_COMPONENTS];
+        for (i, plane) in planes.iter_mut().enumerate() {
+            ptrs[i] = plane.as_mut_ptr();
+            target_strides[i] = strides[i];
+            target_widths[i] = layout[i].width;
+            target_heights[i] = layout[i].height;
+        }
+        self.raw_planes_sink = Some(RawPlanesSink {
+            ptrs,
+            target_strides,
+            target_widths,
+            target_heights,
+            n_components: n
+        });
+        let _guard = RawPlanesGuard {
+            dec: NonNull::from(&mut *self)
+        };
+
+        let mut sink: [u8; 0] = [];
+        let result = if self.is_arithmetic {
+            #[cfg(feature = "arith")]
+            {
+                if self.is_progressive {
+                    self.decode_mcu_ycbcr_progressive::<BitStreamArithmetic>(&mut sink)
+                } else {
+                    self.decode_mcu_ycbcr_baseline::<BitStreamArithmetic>(&mut sink)
+                }
+            }
+            #[cfg(not(feature = "arith"))]
+            unreachable!();
+        } else if self.is_progressive {
+            self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
+        } else {
+            self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
+        };
+
+        result
+    }
+
+    /// Per-component [`ComponentID`] in declaration order
+    /// (`Y, Cb, Cr` for YCbCr; `Y` for grayscale; `Y, Cb, Cr, Q` for
+    /// 4-component scans, etc.).
+    ///
+    /// Useful when consuming the planes returned by
+    /// [`decode_raw`](Self::decode_raw) /
+    /// [`decode_raw_strided`](Self::decode_raw_strided) on non-conforming
+    /// JPEGs whose component order differs from the canonical layout.
+    ///
+    /// Valid only after [`decode_headers`](Self::decode_headers).
+    #[must_use]
+    pub fn component_ids(&self) -> Option<Vec<ComponentID>> {
+        if !self.headers_decoded || self.components.is_empty() {
+            return None;
+        }
+        Some(self.components.iter().map(|c| c.component_id).collect())
+    }
+
+    /// Copy one MCU stripe (`mcu_stripe_index`) of post-IDCT samples from
+    /// each component's `raw_coeff` into the caller-provided plane buffers.
+    ///
+    /// Called from the baseline / progressive paths in place of
+    /// `post_process()` when [`raw_planes_sink`](Self::raw_planes_sink)
+    /// is `Some` (i.e. inside [`decode_raw`](Self::decode_raw)).
+    ///
+    /// The IDCT outputs are already clamped to `[0, 255]` so the `i16 -> u8`
+    /// truncation here is exact.
+    pub(crate) fn copy_raw_planes_for_mcu_stripe(
+        &mut self, mcu_stripe_index: usize
+    ) -> Result<(), DecodeErrors> {
+        let sink = self
+            .raw_planes_sink
+            .as_ref()
+            .expect("copy_raw_planes_for_mcu_stripe called without active sink");
+
+        for (idx, comp) in self.components.iter().enumerate() {
+            if idx >= sink.n_components {
+                break;
+            }
+            let plane_ptr = sink.ptrs[idx];
+            if plane_ptr.is_null() {
+                continue;
+            }
+            let target_stride = sink.target_strides[idx];
+            let target_width = sink.target_widths[idx];
+            let target_height = sink.target_heights[idx];
+
+            let stripe_rows = comp.vertical_sample * DCT_BLOCK_SIZE;
+            let row_start = mcu_stripe_index * stripe_rows;
+            // Clip rows to the caller-provided plane height.
+            if row_start >= target_height {
+                continue;
+            }
+            let rows_to_copy = core::cmp::min(stripe_rows, target_height - row_start);
+
+            let src_stride = comp.width_stride;
+            let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
+
+            for r in 0..rows_to_copy {
+                let src_row_start = r * src_stride;
+                let src_row_end = src_row_start + copy_w;
+                if src_row_end > comp.raw_coeff.len() {
+                    return Err(DecodeErrors::FormatStatic(
+                        "raw_coeff shorter than expected for MCU stripe"
+                    ));
+                }
+                let src = &comp.raw_coeff[src_row_start..src_row_end];
+
+                // SAFETY: `plane_ptr` came from a `&mut [u8]` of length at
+                // least `target_stride * target_height` (validated in
+                // `decode_raw` / `decode_raw_strided`). `(row_start + r) <
+                // target_height` and `copy_w <= target_stride`, so
+                // `dst_offset + copy_w <= target_stride * target_height`.
+                // No other code path borrows the plane buffer while
+                // `raw_planes_sink` is set.
+                unsafe {
+                    let dst_offset = (row_start + r) * target_stride;
+                    let dst = plane_ptr.add(dst_offset);
+                    for (i, sample) in src.iter().enumerate() {
+                        *dst.add(i) = *sample as u8;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Read only headers from a jpeg image buffer
     ///
     /// This allows you to extract important information like
@@ -2171,5 +2606,61 @@ impl ImageInfo {
     #[allow(dead_code)]
     pub(crate) fn set_y(&mut self, sample: u16) {
         self.y_density = sample;
+    }
+}
+
+// SAFETY: `RawPlanesSink` only ever holds raw pointers into caller-owned
+// buffers for the duration of a single `decode_raw` call (which takes
+// `&mut self`). No other code path can observe or alias the pointers, so
+// these auto-trait restorations are defensive — they let `JpegDecoder<T>`
+// retain whatever Send/Sync it would have had without this field, when
+// `T: Send + Sync`.
+unsafe impl Send for RawPlanesSink {}
+unsafe impl Sync for RawPlanesSink {}
+
+/// RAII guard that clears [`JpegDecoder::raw_planes_sink`] when dropped,
+/// including on panic / early `?` returns from inside `decode_raw`.
+pub(crate) struct RawPlanesGuard<T: ZByteReaderTrait> {
+    pub(crate) dec: NonNull<JpegDecoder<T>>
+}
+
+impl<T: ZByteReaderTrait> Drop for RawPlanesGuard<T> {
+    fn drop(&mut self) {
+        // SAFETY: `dec` was created from `&mut *self` inside `decode_raw`
+        // and the guard does not outlive that borrow.
+        unsafe {
+            self.dec.as_mut().raw_planes_sink = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod planar_layout_helpers {
+    use super::{ceil_div, round_up_pow2};
+
+    #[test]
+    fn ceil_div_basic() {
+        assert_eq!(ceil_div(0, 8), 0);
+        assert_eq!(ceil_div(1, 8), 1);
+        assert_eq!(ceil_div(8, 8), 1);
+        assert_eq!(ceil_div(9, 8), 2);
+        assert_eq!(ceil_div(64, 8), 8);
+        assert_eq!(ceil_div(65, 8), 9);
+        assert_eq!(ceil_div(101, 8), 13);
+    }
+
+    #[test]
+    fn round_up_pow2_basic() {
+        assert_eq!(round_up_pow2(0, 8), Some(0));
+        assert_eq!(round_up_pow2(1, 8), Some(8));
+        assert_eq!(round_up_pow2(8, 8), Some(8));
+        assert_eq!(round_up_pow2(9, 8), Some(16));
+        assert_eq!(round_up_pow2(64, 8), Some(64));
+        assert_eq!(round_up_pow2(101, 8), Some(104));
+    }
+
+    #[test]
+    fn round_up_pow2_overflow() {
+        assert_eq!(round_up_pow2(usize::MAX, 8), None);
     }
 }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -1845,7 +1845,7 @@ where
     ///
     ///
     #[allow(clippy::too_many_lines)]
-    pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
+    fn prepare_for_scan_decode(&mut self) -> Result<(), DecodeErrors> {
         // Pull the scan-resume state out into owned locals so the restore
         // below can freely mutate `self`. When headers haven't completed
         // yet, `scan_plan` is `None` and we just run header decoding below.
@@ -2046,17 +2046,6 @@ where
 
         self.ensure_supported_encoding()?;
 
-        let expected_size = self.output_buffer_size().unwrap();
-
-        if out.len() < expected_size {
-            // too small of a size
-            return Err(DecodeErrors::TooSmallOutput(expected_size, out.len()));
-        }
-
-        // ensure we don't touch anyone else's scratch space
-        let out_len = core::cmp::min(out.len(), expected_size);
-        let out = &mut out[0..out_len];
-
         // By default, enable per-row checkpointing only after a previous
         // scan decode attempt has run. Incremental mode opts into the same
         // checkpoints on the first scan attempt so a streaming caller avoids
@@ -2071,10 +2060,13 @@ where
         }
         self.scan_decode_attempted = true;
 
-        let mut output = McuDecodeOutput::Pixels(out);
-        let result = self.decode_mcu_output(&mut output);
+        Ok(())
+    }
 
-        match result {
+    fn decode_mcu_output_with_success_cleanup(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        match self.decode_mcu_output(output) {
             Ok(()) => {
                 // Drop the scan checkpoint so a post-success replay starts
                 // from scan-start with zeroed DC predictors instead of
@@ -2087,7 +2079,9 @@ where
                     state.scan_checkpoint = None;
                     state.progressive_checkpoint = None;
                 }
-                self.pixels_decoded = expected_size;
+                if let Some(pixels) = output.pixels_mut() {
+                    self.pixels_decoded = pixels.len();
+                }
                 if self.is_progressive {
                     self.progressive_displayed_scans = self.progressive_completed_scans;
                 }
@@ -2095,6 +2089,24 @@ where
             }
             Err(e) => Err(e)
         }
+    }
+
+    pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
+        self.prepare_for_scan_decode()?;
+
+        let expected_size = self.output_buffer_size().unwrap();
+
+        if out.len() < expected_size {
+            // too small of a size
+            return Err(DecodeErrors::TooSmallOutput(expected_size, out.len()));
+        }
+
+        // ensure we don't touch anyone else's scratch space
+        let out_len = core::cmp::min(out.len(), expected_size);
+        let out = &mut out[0..out_len];
+
+        let mut output = McuDecodeOutput::Pixels(out);
+        self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
     fn decode_mcu_output(
@@ -2144,6 +2156,17 @@ where
     /// meaningful; trailing padding columns / rows contain
     /// implementation-defined data.
     ///
+    /// # Resumability
+    ///
+    /// On a recoverable EOF (`DecodeErrors::is_recoverable_eof()`) the
+    /// decoder keeps enough state to resume; the caller can grow the input
+    /// stream and call `decode_raw` again with plane buffers sized from the
+    /// same [`planar_layout`](Self::planar_layout).
+    ///
+    /// On success the decoder keeps scan-start replay state, so a later
+    /// `decode_raw` call is well-defined and produces bit-identical planes.
+    /// Replay re-runs entropy decoding from the first SOS.
+    ///
     /// # Examples
     ///
     /// Decode a JPEG into raw YCbCr planes (libjpeg-turbo style) and access
@@ -2190,7 +2213,7 @@ where
     ///   of components.
     /// - Any error from the underlying decode pipeline.
     pub fn decode_raw(&mut self, planes: &mut [&mut [u8]]) -> Result<(), DecodeErrors> {
-        self.decode_headers_internal()?;
+        self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
         if planes.len() != n {
@@ -2228,7 +2251,7 @@ where
             n_components: n
         };
         let mut output = McuDecodeOutput::RawPlanes(raw_planes);
-        self.decode_mcu_output(&mut output)
+        self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
     /// Decode raw planes using caller-supplied row strides.
@@ -2241,6 +2264,17 @@ where
     ///
     /// Only the logical plane area is written. Padding columns in the caller's
     /// stride and trailing DCT rows are left untouched.
+    ///
+    /// # Resumability
+    ///
+    /// On a recoverable EOF (`DecodeErrors::is_recoverable_eof()`) the
+    /// decoder keeps enough state to resume; the caller can grow the input
+    /// stream and call `decode_raw_strided` again with the same plane layout.
+    ///
+    /// On success the decoder keeps scan-start replay state, so a later
+    /// `decode_raw_strided` call is well-defined and produces bit-identical
+    /// logical plane samples. Replay re-runs entropy decoding from the first
+    /// SOS.
     ///
     /// # Examples
     ///
@@ -2294,7 +2328,7 @@ where
     pub fn decode_raw_strided(
         &mut self, planes: &mut [&mut [u8]], strides: &[usize]
     ) -> Result<(), DecodeErrors> {
-        self.decode_headers_internal()?;
+        self.prepare_for_scan_decode()?;
 
         let n = self.components.len();
         if planes.len() != n {
@@ -2346,7 +2380,7 @@ where
             n_components: n
         };
         let mut output = McuDecodeOutput::RawPlanes(raw_planes);
-        self.decode_mcu_output(&mut output)
+        self.decode_mcu_output_with_success_cleanup(&mut output)
     }
 
     /// Per-component [`ComponentID`] in declaration order

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -452,7 +452,10 @@ pub(crate) enum McuDecodeOutput<'planes, 'buf> {
 
 impl McuDecodeOutput<'_, '_> {
     pub(crate) const fn is_raw(&self) -> bool {
-        matches!(self, Self::RawPlanes(_))
+        match self {
+            Self::Pixels(_) => false,
+            Self::RawPlanes(_) => true
+        }
     }
 
     pub(crate) fn pixels_mut(&mut self) -> Option<&mut [u8]> {

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -82,13 +82,6 @@ pub struct PlaneInfo {
     pub byte_size:        usize
 }
 
-/// Ceiling division: `ceil(a / b)` without overflow on the addition.
-#[inline]
-fn ceil_div(a: usize, b: usize) -> usize {
-    debug_assert!(b != 0);
-    a / b + usize::from(a % b != 0)
-}
-
 /// Round `n` up to the next multiple of `align` (which must be non-zero).
 /// Returns `None` on overflow.
 #[inline]
@@ -460,11 +453,19 @@ pub struct JpegDecoder<T> {
 
 /// Internal sink for one raw planar decode call.
 ///
-/// Holds owned per-component plane buffers that MCU-stripe copies write into.
-/// After decoding completes, the caller copies from these into its output slices.
+/// Holds raw pointers into the caller-provided plane buffers so that MCU-stripe
+/// processing can write decoded samples directly without an intermediate copy.
+///
+/// # Safety
+/// The pointers are valid for the lifetime of the `decode_raw` / `decode_raw_strided`
+/// call that sets up this sink.  The sink is always cleared (set to `None`) before
+/// those functions return, so the pointers never outlive the caller's slices.
+#[allow(unsafe_code)]
 pub(crate) struct RawPlanesSink {
-    /// Internal plane buffers (one per component, sized to full plane).
-    pub(crate) planes:         Vec<Vec<u8>>,
+    /// Raw pointers into the caller's plane buffers (one per component).
+    pub(crate) ptrs:           [*mut u8; MAX_COMPONENTS],
+    /// Total byte length of each caller buffer.
+    pub(crate) lengths:        [usize; MAX_COMPONENTS],
     /// Bytes between successive destination rows (used for strided output).
     pub(crate) target_strides: [usize; MAX_COMPONENTS],
     /// Maximum bytes to write per destination row.
@@ -474,6 +475,15 @@ pub(crate) struct RawPlanesSink {
     /// Number of valid components.
     pub(crate) n_components:   usize
 }
+
+/// SAFETY: The pointers in `RawPlanesSink` are derived from `&mut [u8]` references
+/// that live on the calling thread's stack.  The sink is only alive for the duration
+/// of a single `decode_raw*` call, never sent across threads.
+#[allow(unsafe_code)]
+unsafe impl Send for RawPlanesSink {}
+/// SAFETY: No shared-mutable state; see `Send` impl above.
+#[allow(unsafe_code)]
+unsafe impl Sync for RawPlanesSink {}
 
 impl<T> JpegDecoder<T>
 where
@@ -1070,8 +1080,8 @@ where
         }
         let mut out = [PlaneInfo::default(); MAX_COMPONENTS];
         for (slot, comp) in out.iter_mut().zip(self.components.iter()) {
-            let comp_w = ceil_div(img_w.checked_mul(comp.horizontal_sample)?, h_max);
-            let comp_h = ceil_div(img_h.checked_mul(comp.vertical_sample)?, v_max);
+            let comp_w = img_w.checked_mul(comp.horizontal_sample)?.div_ceil(h_max);
+            let comp_h = img_h.checked_mul(comp.vertical_sample)?.div_ceil(v_max);
             let stride = round_up_pow2(comp_w, DCT_BLOCK_SIZE)?;
             let allocated_height = round_up_pow2(comp_h, DCT_BLOCK_SIZE)?;
             let byte_size = stride.checked_mul(allocated_height)?;
@@ -2200,27 +2210,32 @@ where
             }
         }
 
-        // Each plane is mutably borrowed for this call; internal buffers
-        // collect the MCU stripe outputs, then are copied to the caller at the end.
+        // Set up the raw-planes sink pointing directly into the caller's slices.
+        // SAFETY: The pointers are derived from the mutable slice references in
+        // `planes`, which are guaranteed to remain valid and exclusively borrowed
+        // for the duration of this call.  The sink is cleared before we return.
+        let mut ptrs = [core::ptr::null_mut(); MAX_COMPONENTS];
+        let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        let mut internal_planes: Vec<Vec<u8>> = Vec::with_capacity(n);
         for i in 0..n {
+            ptrs[i] = planes[i].as_mut_ptr();
+            lengths[i] = planes[i].len();
             target_strides[i] = layout[i].stride;
             target_widths[i] = layout[i].stride;
             target_heights[i] = layout[i].allocated_height;
-            internal_planes.push(vec![0u8; layout[i].byte_size]);
         }
         self.raw_planes_sink = Some(RawPlanesSink {
-            planes: internal_planes,
+            ptrs,
+            lengths,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
         });
 
-        // Raw mode writes into the internal plane buffers; downstream pixel
+        // Raw mode writes directly into the caller's buffers; downstream pixel
         // bookkeeping only needs a placeholder slice.
         let mut sink: [u8; 0] = [];
         let result = if self.is_arithmetic {
@@ -2240,13 +2255,8 @@ where
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
         };
 
-        // Copy from internal buffers to the caller's output slices.
-        if let Some(raw_sink) = self.raw_planes_sink.take() {
-            for (i, internal) in raw_sink.planes.into_iter().enumerate() {
-                let dst = &mut planes[i][..internal.len()];
-                dst.copy_from_slice(&internal);
-            }
-        }
+        // Clear the sink so pointers don't outlive the caller's slices.
+        self.raw_planes_sink = None;
 
         result
     }
@@ -2347,20 +2357,24 @@ where
             }
         }
 
-        // Each plane is mutably borrowed for this call; internal buffers
-        // collect the MCU stripe outputs, then are copied to the caller at the end.
+        // Set up the raw-planes sink pointing directly into the caller's slices.
+        // SAFETY: Same guarantees as `decode_raw` — pointers derived from exclusive
+        // mutable borrows, valid for the entire call, cleared before return.
+        let mut ptrs = [core::ptr::null_mut(); MAX_COMPONENTS];
+        let mut lengths = [0usize; MAX_COMPONENTS];
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        let mut internal_planes: Vec<Vec<u8>> = Vec::with_capacity(n);
         for i in 0..n {
+            ptrs[i] = planes[i].as_mut_ptr();
+            lengths[i] = planes[i].len();
             target_strides[i] = strides[i];
             target_widths[i] = layout[i].width;
             target_heights[i] = layout[i].height;
-            internal_planes.push(vec![0u8; strides[i] * layout[i].height]);
         }
         self.raw_planes_sink = Some(RawPlanesSink {
-            planes: internal_planes,
+            ptrs,
+            lengths,
             target_strides,
             target_widths,
             target_heights,
@@ -2385,20 +2399,8 @@ where
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
         };
 
-        // Copy from internal buffers to the caller's output slices.
-        // Only copy logical width per row to preserve caller's padding bytes.
-        if let Some(raw_sink) = self.raw_planes_sink.take() {
-            for (i, internal) in raw_sink.planes.into_iter().enumerate() {
-                let stride = raw_sink.target_strides[i];
-                let width = raw_sink.target_widths[i];
-                let height = raw_sink.target_heights[i];
-                for y in 0..height {
-                    let off = y * stride;
-                    planes[i][off..off + width]
-                        .copy_from_slice(&internal[off..off + width]);
-                }
-            }
-        }
+        // Clear the sink so pointers don't outlive the caller's slices.
+        self.raw_planes_sink = None;
 
         result
     }
@@ -2430,6 +2432,7 @@ where
     ///
     /// The IDCT outputs are already clamped to `[0, 255]` so the `i16 -> u8`
     /// truncation here is exact.
+    #[allow(unsafe_code)]
     pub(crate) fn copy_raw_planes_for_mcu_stripe(
         &mut self, mcu_stripe_index: usize
     ) -> Result<(), DecodeErrors> {
@@ -2457,7 +2460,8 @@ where
             let src_stride = comp.width_stride;
             let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
 
-            let plane = &mut sink.planes[idx];
+            let ptr = sink.ptrs[idx];
+            let len = sink.lengths[idx];
 
             for r in 0..rows_to_copy {
                 let src_row_start = r * src_stride;
@@ -2470,11 +2474,18 @@ where
                 let src = &comp.raw_coeff[src_row_start..src_row_end];
 
                 let dst_offset = (row_start + r) * target_stride;
-                let dst = &mut plane[dst_offset..dst_offset + copy_w];
-                for (i, sample) in src.iter().enumerate() {
-                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                    {
-                        dst[i] = *sample as u8;
+                debug_assert!(dst_offset + copy_w <= len);
+                // SAFETY: `ptr` points into the caller's `&mut [u8]` which is
+                // guaranteed to be at least `len` bytes.  The bounds check above
+                // (via `target_height` / `target_stride` validation in decode_raw*)
+                // ensures `dst_offset + copy_w <= len`.
+                unsafe {
+                    let dst = core::slice::from_raw_parts_mut(ptr.add(dst_offset), copy_w);
+                    for (i, sample) in src.iter().enumerate() {
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        {
+                            dst[i] = *sample as u8;
+                        }
                     }
                 }
             }
@@ -2702,17 +2713,17 @@ impl ImageInfo {
 
 #[cfg(test)]
 mod planar_layout_helpers {
-    use super::{ceil_div, round_up_pow2};
+    use super::round_up_pow2;
 
     #[test]
-    fn ceil_div_basic() {
-        assert_eq!(ceil_div(0, 8), 0);
-        assert_eq!(ceil_div(1, 8), 1);
-        assert_eq!(ceil_div(8, 8), 1);
-        assert_eq!(ceil_div(9, 8), 2);
-        assert_eq!(ceil_div(64, 8), 8);
-        assert_eq!(ceil_div(65, 8), 9);
-        assert_eq!(ceil_div(101, 8), 13);
+    fn div_ceil_basic() {
+        assert_eq!(0usize.div_ceil(8), 0);
+        assert_eq!(1usize.div_ceil(8), 1);
+        assert_eq!(8usize.div_ceil(8), 1);
+        assert_eq!(9usize.div_ceil(8), 2);
+        assert_eq!(64usize.div_ceil(8), 8);
+        assert_eq!(65usize.div_ceil(8), 9);
+        assert_eq!(101usize.div_ceil(8), 13);
     }
 
     #[test]

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -2144,7 +2144,7 @@ where
     /// decoder.decode_headers().unwrap();
     ///
     /// let layout = decoder.planar_layout().unwrap();
-    /// let n = decoder.num_components();
+    /// let n = decoder.num_components().unwrap();
     /// let mut buffers: Vec<Vec<u8>> = (0..n)
     ///     .map(|i| vec![0u8; layout[i].byte_size])
     ///     .collect();
@@ -2250,7 +2250,7 @@ where
     /// decoder.decode_headers().unwrap();
     ///
     /// let layout = decoder.planar_layout().unwrap();
-    /// let n = decoder.num_components();
+    /// let n = decoder.num_components().unwrap();
     ///
     /// // Use a 64-byte aligned stride (common for GPU upload).
     /// let strides: Vec<usize> = (0..n)

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -11,8 +11,8 @@
 
 use alloc::boxed::Box;
 use alloc::string::ToString;
-use alloc::vec::Vec;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::num::NonZeroU32;
 
@@ -21,13 +21,12 @@ use zune_core::colorspace::ColorSpace;
 use zune_core::log::{error, trace, warn};
 use zune_core::options::DecoderOptions;
 
-use crate::cancel::{CancelCheck, Debounced, CANCEL_POLL_INTERVAL_MCUS};
-
 #[cfg(feature = "arith")]
 use crate::bitstream::BitStream;
-use crate::bitstream::{BitstreamStateSnapshot, BitStreamHuffman};
+use crate::bitstream::{BitStreamHuffman, BitstreamStateSnapshot};
 #[cfg(feature = "arith")]
 use crate::bitstream_arith::{ArithACTables, ArithDCTables, BitStreamArithmetic};
+use crate::cancel::{CancelCheck, Debounced, CANCEL_POLL_INTERVAL_MCUS};
 use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
 use crate::components::{Components, SampleRatios};
 use crate::errors::{DecodeErrors, UnsupportedSchemes};
@@ -216,23 +215,23 @@ pub(crate) struct ScanHeaderStateSnapshot {
 #[derive(Clone, Copy)]
 pub(crate) struct ScanCheckpoint {
     /// Stream position immediately after the RST marker.
-    pub(crate) stream_position:  usize,
+    pub(crate) stream_position: usize,
     /// Next MCU row to decode.
-    pub(crate) mcu_row:          usize,
+    pub(crate) mcu_row:         usize,
     /// Next MCU column to decode in `mcu_row`.
-    pub(crate) mcu_col:          usize,
+    pub(crate) mcu_col:         usize,
     /// Restart countdown at this checkpoint.
-    pub(crate) todo:             usize,
+    pub(crate) todo:            usize,
     /// Number of output bytes stable at this checkpoint.
-    pub(crate) pixels_written:   usize,
+    pub(crate) pixels_written:  usize,
     /// SOS/component table state at this checkpoint.
-    pub(crate) sos_snapshot:     SosParamsSnapshot,
+    pub(crate) sos_snapshot:    SosParamsSnapshot,
     /// Append-only metadata state at this checkpoint.
-    pub(crate) append_snapshot:  HeaderAppendStateSnapshot,
+    pub(crate) append_snapshot: HeaderAppendStateSnapshot,
     /// Per-component DC predictor state at the checkpoint: `(dc_pred, dc_diff)`.
-    pub(crate) dc_predictions:   [(i32, i32); MAX_COMPONENTS],
+    pub(crate) dc_predictions:  [(i32, i32); MAX_COMPONENTS],
     /// Bitstream decoder state at the checkpoint (for fine-grained resume).
-    pub(crate) bitstream_state:  BitstreamStateSnapshot
+    pub(crate) bitstream_state: BitstreamStateSnapshot
 }
 
 // Snapshot append-only metadata so marker or scan replay can roll it back.
@@ -349,8 +348,8 @@ pub struct JpegDecoder<T> {
     /// Specialized IDCT when we can guarantee only few coefficients are non-zero.
     ///
     /// **The callee must uphold a contract**. See [`choose_idct_4x4_func`].
-    pub(crate) idct_4x4_func: IDCTPtr,
-    pub(crate) idct_1x1_func: IDCTPtr,
+    pub(crate) idct_4x4_func:    IDCTPtr,
+    pub(crate) idct_1x1_func:    IDCTPtr,
     // Color convert function which acts on 16 YCbCr values
     pub(crate) color_convert_16: ColorConvert16Ptr,
     pub(crate) z_order:          [usize; MAX_COMPONENTS],
@@ -370,24 +369,24 @@ pub struct JpegDecoder<T> {
     pub(crate) seen_sof:         bool,
 
     // exif data, lifted from app2
-    pub(crate) icc_data: Vec<ICCChunk>,
-    pub(crate) is_mjpeg: bool,
-    pub(crate) coeff:    usize, // Solves some weird bug :)
+    pub(crate) icc_data:                    Vec<ICCChunk>,
+    pub(crate) is_mjpeg:                    bool,
+    pub(crate) coeff:                       usize, // Solves some weird bug :)
     /// Extended XMP segments
-    pub(crate) extended_xmp_segments: Vec<ExtendedXmpSegment>,
+    pub(crate) extended_xmp_segments:       Vec<ExtendedXmpSegment>,
     /// Stream position where the header parser should resume on a future
     /// call after a recoverable EOF. Zero means "start from SOI".
     ///
     /// This is intentionally a plain scalar (not an enum variant or boxed
     /// payload) so that one-shot decoding pays no per-call match cost.
-    header_resume_position: usize,
+    header_resume_position:                 usize,
     /// Scan-phase resume state. `Some` from SOS onward; `None` during
     /// header parsing. Boxed so the decoder struct stays compact for the
     /// common one-shot path.
-    scan_state: Option<Box<ScanDecodeState>>,
+    scan_state:                             Option<Box<ScanDecodeState>>,
     /// Number of output bytes known to be stable after the most recent
     /// `decode_into` attempt.
-    pub(crate) pixels_decoded: usize,
+    pub(crate) pixels_decoded:              usize,
     /// Persistent coefficient buffers for multi-SOS baseline decoding.
     ///
     /// Owned by the decoder so contents survive a recoverable EOF and the
@@ -419,7 +418,7 @@ pub struct JpegDecoder<T> {
     /// keeping one-shot decode free of per-row overhead. `incremental_mode`
     /// enables the same checkpoints on the first scan attempt for streaming
     /// callers.
-    pub(crate) mcu_checkpoints_enabled: bool,
+    pub(crate) mcu_checkpoints_enabled:     bool,
     /// Whether row checkpoints should also be recorded on the first scan
     /// decode attempt.
     ///
@@ -427,14 +426,14 @@ pub struct JpegDecoder<T> {
     /// non-strict mode and keep one-shot decode free of checkpoint work.
     /// Streaming callers opt in before `decode_into` to receive recoverable
     /// scan EOF and avoid replaying from scan start.
-    incremental_mode: bool,
+    incremental_mode:                       bool,
     /// Whether this decoder has already attempted scan decoding.
     ///
     /// `scan_state` becomes `Some` as soon as headers reach SOS, including
     /// after an explicit `decode_headers` call. This flag tracks the narrower
     /// condition needed for default checkpoint gating: a previous
     /// `decode_into` scan attempt actually ran.
-    scan_decode_attempted: bool,
+    scan_decode_attempted:                  bool,
     /// Scratch buffer that header marker parsers fill with the marker body
     /// before mutating decoder state.
     ///
@@ -443,50 +442,74 @@ pub struct JpegDecoder<T> {
     /// committed to the decoder; a retry replays the same marker bytes
     /// idempotently. The buffer is reused across markers so header parsing
     /// stays allocation-free in steady state.
-    pub(crate) marker_body_scratch: Vec<u8>,
+    pub(crate) marker_body_scratch:         Vec<u8>,
     /// True when the SOF header carried a height of 0, meaning the actual
     /// number of lines is defined by a DNL marker that follows the first
     /// scan's entropy data. The MCU decode loop will intercept that marker
     /// and store the real height; if it never arrives, decoding returns an
     /// error.
-    pub(crate) expects_dnl: bool,
+    pub(crate) expects_dnl:                 bool,
     /// Sequential raw iMCU-row progress shared across borrowing sessions.
-    raw_pull_state: RawPullState
+    raw_pull_state:                         RawPullState,
+    /// Sequential converted scanline progress shared across borrowing sessions.
+    scanline_state:                         ScanlineState
 }
 
 /// Output target for one MCU decode call.
 pub(crate) enum McuDecodeOutput<'planes, 'buf> {
     Pixels(&'planes mut [u8]),
-    RawPlanes(RawPlanesSink<'planes, 'buf>)
+    RawPlanes(RawPlanesSink<'planes, 'buf>),
+    Scanlines(ConvertedScanlineSink<'planes>)
 }
 
 impl McuDecodeOutput<'_, '_> {
     pub(crate) const fn is_raw(&self) -> bool {
         match self {
             Self::Pixels(_) => false,
-            Self::RawPlanes(_) => true
+            Self::RawPlanes(_) => true,
+            Self::Scanlines(_) => false
         }
     }
 
     pub(crate) fn pixels_mut(&mut self) -> Option<&mut [u8]> {
         match self {
             Self::Pixels(pixels) => Some(pixels),
+            Self::Scanlines(sink) => Some(sink.pixels),
             Self::RawPlanes(_) => None
         }
     }
 
-    pub(crate) const fn requested_raw_stripe(&self) -> Option<usize> {
+    pub(crate) const fn requested_output_stripe(&self) -> Option<usize> {
         match self {
             Self::RawPlanes(sink) => sink.requested_stripe,
+            Self::Scanlines(sink) => Some(sink.requested_stripe),
             Self::Pixels(_) => None
         }
     }
 
-    pub(crate) fn mark_raw_source_complete(&mut self) {
+    pub(crate) const fn requests_raw_output(&self) -> bool {
+        match self {
+            Self::RawPlanes(_) => true,
+            Self::Pixels(_) | Self::Scanlines(_) => false
+        }
+    }
+
+    pub(crate) fn mark_source_complete(&mut self) {
         if let Self::RawPlanes(sink) = self {
             sink.source_complete = true;
         }
+        if let Self::Scanlines(sink) = self {
+            sink.source_complete = true;
+        }
     }
+}
+
+pub(crate) struct ConvertedScanlineSink<'pixels> {
+    pub(crate) pixels:           &'pixels mut [u8],
+    pub(crate) stride:           usize,
+    pub(crate) requested_stripe: usize,
+    pub(crate) rows_written:     usize,
+    pub(crate) source_complete:  bool
 }
 
 /// Caller-provided raw planar buffers for one decode call.
@@ -529,6 +552,33 @@ pub enum RawImcuRowStatus {
     Complete
 }
 
+/// State returned by scanline session lifecycle operations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ScanlineStatus {
+    /// The session is ready to read converted output rows.
+    Ready,
+    /// More compressed input is required to continue.
+    NeedMoreInput,
+    /// All converted rows have been consumed and the image is finished.
+    Complete
+}
+
+/// Result of reading or skipping converted output rows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ScanlineReadStatus {
+    /// The requested operation committed `rows` output rows.
+    RowsProcessed {
+        /// Number of rows read into caller storage or skipped.
+        rows: usize
+    },
+    /// No row was committed because more compressed input is required.
+    NeedMoreInput,
+    /// No output rows remain.
+    Complete
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RawPullPhase {
     Start,
@@ -555,10 +605,46 @@ struct RawPullState {
 }
 
 struct RawPullTargets {
-    lengths:        [usize; MAX_COMPONENTS],
-    strides:        [usize; MAX_COMPONENTS],
-    widths:         [usize; MAX_COMPONENTS],
-    heights:        [usize; MAX_COMPONENTS]
+    lengths: [usize; MAX_COMPONENTS],
+    strides: [usize; MAX_COMPONENTS],
+    widths:  [usize; MAX_COMPONENTS],
+    heights: [usize; MAX_COMPONENTS]
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScanlinePhase {
+    Start,
+    StreamingBaseline,
+    BufferedRows,
+    Complete
+}
+
+struct ScanlineState {
+    phase:           ScanlinePhase,
+    started:         bool,
+    output_scanline: usize,
+    next_mcu_stripe: usize,
+    staged_row:      usize,
+    staged_rows:     usize,
+    staging:         Vec<u8>,
+    source_complete: bool,
+    entropy_tables:  Option<EntropyTables>
+}
+
+impl Default for ScanlineState {
+    fn default() -> Self {
+        Self {
+            phase:           ScanlinePhase::Start,
+            started:         false,
+            output_scanline: 0,
+            next_mcu_stripe: 0,
+            staged_row:      0,
+            staged_rows:     0,
+            staging:         Vec::new(),
+            source_complete: false,
+            entropy_tables:  None
+        }
+    }
 }
 
 impl Default for RawPullState {
@@ -593,6 +679,403 @@ pub struct RawDecodeSession<'decoder, T> {
 impl<T> Drop for RawDecodeSession<'_, T> {
     fn drop(&mut self) {
         self.decoder.incremental_mode = self.previous_incremental_mode;
+    }
+}
+
+/// Stateful converted scanline output session.
+///
+/// Obtain a session with [`JpegDecoder::scanline_output`], call [`Self::start`],
+/// then read or skip rows sequentially before finishing. The session uses the
+/// decoder's configured output colorspace and the same upsampling and color
+/// conversion pipeline as [`JpegDecoder::decode_into`].
+///
+/// Progressive and multi-SOS images do not expose provisional preview rows
+/// through this API. They return [`ScanlineReadStatus::NeedMoreInput`] until
+/// all coefficients needed for stable final rows are available. Progressive
+/// preview reporting on [`JpegDecoder`] remains a separate full-frame API.
+pub struct ScanlineDecodeSession<'decoder, T> {
+    decoder: &'decoder mut JpegDecoder<T>
+}
+
+impl<T> ScanlineDecodeSession<'_, T>
+where
+    T: ZByteReaderTrait
+{
+    /// Parse enough input to make converted output geometry available.
+    ///
+    /// A suspended start does not advance output and can be retried on the
+    /// same session after exposing more input through the underlying reader.
+    pub fn start(&mut self) -> Result<ScanlineStatus, DecodeErrors> {
+        if self.decoder.scanline_state.phase == ScanlinePhase::Complete {
+            return Ok(ScanlineStatus::Complete);
+        }
+        if self.decoder.scanline_state.started {
+            return Ok(ScanlineStatus::Ready);
+        }
+        match self.decoder.decode_headers() {
+            Ok(()) => {
+                if self.decoder.expects_dnl {
+                    return Err(DecodeErrors::FormatStatic(
+                        "converted scanline output does not support DNL images"
+                    ));
+                }
+                self.decoder.scanline_state.started = true;
+                Ok(ScanlineStatus::Ready)
+            }
+            Err(error) if error.is_recoverable_eof() => Ok(ScanlineStatus::NeedMoreInput),
+            Err(error) => Err(error)
+        }
+    }
+
+    /// Number of converted rows already returned or skipped.
+    #[must_use]
+    pub const fn output_scanline(&self) -> usize {
+        self.decoder.scanline_state.output_scanline
+    }
+
+    /// Logical converted bytes in one output row.
+    #[must_use]
+    pub fn output_row_bytes(&self) -> Option<usize> {
+        if !self.decoder.scanline_state.started {
+            return None;
+        }
+        usize::from(self.decoder.width()).checked_mul(
+            self.decoder
+                .options
+                .jpeg_get_out_colorspace()
+                .num_components()
+        )
+    }
+
+    /// Logical number of converted output rows, when known from the frame header.
+    #[must_use]
+    pub fn output_height(&self) -> Option<usize> {
+        if !self.decoder.scanline_state.started || self.decoder.expects_dnl {
+            return None;
+        }
+        Some(usize::from(self.decoder.height()))
+    }
+
+    /// Read as many converted rows as fit in `output` using `stride` bytes per row.
+    ///
+    /// Stride padding is left untouched. An empty output slice is a successful
+    /// zero-row operation. If input suspends after some staged rows were copied,
+    /// those stable rows are returned first and suspension is reported on a
+    /// later call. `Complete` means no logical rows remain; call [`Self::finish`]
+    /// to complete the compressed stream.
+    pub fn read_scanlines(
+        &mut self, output: &mut [u8], stride: usize
+    ) -> Result<ScanlineReadStatus, DecodeErrors> {
+        if !self.decoder.scanline_state.started {
+            return Err(DecodeErrors::FormatStatic(
+                "scanline output must be started before reading rows"
+            ));
+        }
+        let row_bytes = self.output_row_bytes().ok_or(DecodeErrors::FormatStatic(
+            "converted output row size overflow"
+        ))?;
+        if output.is_empty() {
+            return Ok(ScanlineReadStatus::RowsProcessed { rows: 0 });
+        }
+        if stride < row_bytes {
+            return Err(DecodeErrors::Format(format!(
+                "scanline stride {stride} is smaller than row width {row_bytes}"
+            )));
+        }
+        if output.len() < stride {
+            return Err(DecodeErrors::TooSmallOutput(stride, output.len()));
+        }
+        let capacity = output.len() / stride;
+        let height = usize::from(self.decoder.height());
+        if self.decoder.scanline_state.output_scanline >= height {
+            return Ok(ScanlineReadStatus::Complete);
+        }
+
+        let mut rows = 0;
+        while rows < capacity && self.decoder.scanline_state.output_scanline < height {
+            if self.decoder.scanline_state.staged_row == self.decoder.scanline_state.staged_rows {
+                if rows != 0 {
+                    break;
+                }
+                let remaining_capacity = capacity - rows;
+                let maximum_stripe_rows = self.max_scanline_stripe_rows()?;
+                let remaining_rows = height - self.decoder.scanline_state.output_scanline;
+                if remaining_capacity >= maximum_stripe_rows
+                    && remaining_rows >= maximum_stripe_rows
+                {
+                    let destination_start = rows * stride;
+                    match self.decode_scanline_stripe(
+                        &mut output[destination_start..capacity * stride],
+                        stride
+                    )? {
+                        ScanlineReadStatus::RowsProcessed { rows: direct_rows }
+                            if direct_rows != 0 =>
+                        {
+                            self.decoder.scanline_state.output_scanline += direct_rows;
+                            rows += direct_rows;
+                            break;
+                        }
+                        ScanlineReadStatus::NeedMoreInput => {
+                            return Ok(ScanlineReadStatus::NeedMoreInput)
+                        }
+                        ScanlineReadStatus::RowsProcessed { .. } | ScanlineReadStatus::Complete => {
+                            break
+                        }
+                    }
+                }
+                match self.produce_scanline_stripe()? {
+                    ScanlineReadStatus::RowsProcessed { .. } => {}
+                    ScanlineReadStatus::NeedMoreInput => {
+                        return Ok(ScanlineReadStatus::NeedMoreInput)
+                    }
+                    ScanlineReadStatus::Complete => break
+                }
+            }
+            if self.decoder.scanline_state.staged_row == self.decoder.scanline_state.staged_rows {
+                break;
+            }
+
+            let source_start = self.decoder.scanline_state.staged_row * row_bytes;
+            let destination_start = rows * stride;
+            output[destination_start..destination_start + row_bytes].copy_from_slice(
+                &self.decoder.scanline_state.staging[source_start..source_start + row_bytes]
+            );
+            self.decoder.scanline_state.staged_row += 1;
+            self.decoder.scanline_state.output_scanline += 1;
+            rows += 1;
+        }
+
+        if rows != 0 {
+            Ok(ScanlineReadStatus::RowsProcessed { rows })
+        } else if self.decoder.scanline_state.output_scanline >= height {
+            Ok(ScanlineReadStatus::Complete)
+        } else {
+            Ok(ScanlineReadStatus::NeedMoreInput)
+        }
+    }
+
+    /// Skip up to `rows` converted output rows.
+    ///
+    /// Skipped rows advance [`Self::output_scanline`] exactly like rows returned
+    /// by [`Self::read_scanlines`]. A zero-row skip is a successful no-op.
+    pub fn skip_scanlines(&mut self, rows: usize) -> Result<ScanlineReadStatus, DecodeErrors> {
+        if !self.decoder.scanline_state.started {
+            return Err(DecodeErrors::FormatStatic(
+                "scanline output must be started before skipping rows"
+            ));
+        }
+        if rows == 0 {
+            return Ok(ScanlineReadStatus::RowsProcessed { rows: 0 });
+        }
+        let height = usize::from(self.decoder.height());
+        if self.decoder.scanline_state.output_scanline >= height {
+            return Ok(ScanlineReadStatus::Complete);
+        }
+
+        let target = rows.min(height - self.decoder.scanline_state.output_scanline);
+        let mut skipped = 0;
+        while skipped < target {
+            if self.decoder.scanline_state.staged_row == self.decoder.scanline_state.staged_rows {
+                if skipped != 0 {
+                    break;
+                }
+                match self.produce_scanline_stripe()? {
+                    ScanlineReadStatus::RowsProcessed { .. } => {}
+                    ScanlineReadStatus::NeedMoreInput => {
+                        return Ok(ScanlineReadStatus::NeedMoreInput)
+                    }
+                    ScanlineReadStatus::Complete => break
+                }
+            }
+            let available = self
+                .decoder
+                .scanline_state
+                .staged_rows
+                .saturating_sub(self.decoder.scanline_state.staged_row);
+            if available == 0 {
+                break;
+            }
+            let consume = available.min(target - skipped);
+            self.decoder.scanline_state.staged_row += consume;
+            self.decoder.scanline_state.output_scanline += consume;
+            skipped += consume;
+        }
+
+        if skipped != 0 {
+            Ok(ScanlineReadStatus::RowsProcessed { rows: skipped })
+        } else if self.decoder.scanline_state.output_scanline >= height {
+            Ok(ScanlineReadStatus::Complete)
+        } else {
+            Ok(ScanlineReadStatus::NeedMoreInput)
+        }
+    }
+
+    /// Consume all unread output and finish the compressed image.
+    ///
+    /// Calling this before reading every row discards the unread converted rows
+    /// while continuing entropy decode and marker processing to completion.
+    /// `NeedMoreInput` leaves the session resumable. `Complete` is sticky for
+    /// the current session.
+    pub fn finish(&mut self) -> Result<ScanlineStatus, DecodeErrors> {
+        if !self.decoder.scanline_state.started {
+            return Err(DecodeErrors::FormatStatic(
+                "scanline output must be started before finishing"
+            ));
+        }
+        if self.decoder.scanline_state.phase == ScanlinePhase::Complete {
+            return Ok(ScanlineStatus::Complete);
+        }
+        let height = usize::from(self.decoder.height());
+        while self.decoder.scanline_state.output_scanline < height {
+            match self.skip_scanlines(height - self.decoder.scanline_state.output_scanline)? {
+                ScanlineReadStatus::RowsProcessed { .. } => {}
+                ScanlineReadStatus::NeedMoreInput => return Ok(ScanlineStatus::NeedMoreInput),
+                ScanlineReadStatus::Complete => break
+            }
+        }
+        if !self.decoder.scanline_state.source_complete {
+            match self.produce_scanline_stripe()? {
+                ScanlineReadStatus::NeedMoreInput => return Ok(ScanlineStatus::NeedMoreInput),
+                ScanlineReadStatus::RowsProcessed { .. } | ScanlineReadStatus::Complete => {}
+            }
+        }
+        self.decoder.finish_output_source();
+        self.decoder.scanline_state.phase = ScanlinePhase::Complete;
+        Ok(ScanlineStatus::Complete)
+    }
+
+    fn produce_scanline_stripe(&mut self) -> Result<ScanlineReadStatus, DecodeErrors> {
+        let row_bytes = self.output_row_bytes().ok_or(DecodeErrors::FormatStatic(
+            "converted output row size overflow"
+        ))?;
+        let max_rows = self.max_scanline_stripe_rows()?;
+        let staging_len = row_bytes
+            .checked_mul(max_rows)
+            .ok_or(DecodeErrors::FormatStatic(
+                "converted scanline staging size overflow"
+            ))?;
+        let mut staging = core::mem::take(&mut self.decoder.scanline_state.staging);
+        staging.clear();
+        staging.resize(staging_len, 0);
+        let result = self.decode_scanline_stripe(&mut staging, row_bytes);
+        self.decoder.scanline_state.staging = staging;
+        let status = result?;
+        if let ScanlineReadStatus::RowsProcessed { rows } = status {
+            self.decoder.scanline_state.staged_row = 0;
+            self.decoder.scanline_state.staged_rows = rows;
+        }
+        Ok(status)
+    }
+
+    fn max_scanline_stripe_rows(&self) -> Result<usize, DecodeErrors> {
+        let max_v = self
+            .decoder
+            .components
+            .iter()
+            .map(|component| component.vertical_sample)
+            .max()
+            .unwrap_or(1);
+        // Vertical interpolation can defer one sample group until the next
+        // MCU stripe, which then emits that group plus its regular 8 groups.
+        (DCT_BLOCK_SIZE + 1)
+            .checked_mul(max_v)
+            .ok_or(DecodeErrors::FormatStatic(
+                "converted scanline staging height overflow"
+            ))
+    }
+
+    fn decode_scanline_stripe(
+        &mut self, pixels: &mut [u8], stride: usize
+    ) -> Result<ScanlineReadStatus, DecodeErrors> {
+        let prepared = if self.decoder.scanline_state.phase == ScanlinePhase::Start {
+            self.decoder.prepare_for_scan_decode()?;
+            let buffered = self.decoder.is_progressive
+                || usize::from(self.decoder.num_scans) != self.decoder.components.len();
+            self.decoder.scanline_state.phase = if buffered {
+                ScanlinePhase::BufferedRows
+            } else {
+                ScanlinePhase::StreamingBaseline
+            };
+            true
+        } else {
+            false
+        };
+        let requested_stripe = self.decoder.scanline_state.next_mcu_stripe;
+        let sink = ConvertedScanlineSink {
+            pixels,
+            stride,
+            requested_stripe,
+            rows_written: 0,
+            source_complete: false
+        };
+        let mut output = McuDecodeOutput::Scanlines(sink);
+
+        let decode_result = match self.decoder.scanline_state.phase {
+            ScanlinePhase::StreamingBaseline => {
+                if !prepared {
+                    self.decoder.prepare_for_scan_decode()?;
+                }
+                #[cfg(feature = "arith")]
+                self.restore_arithmetic_context()?;
+                self.decoder.decode_mcu_output(&mut output)
+            }
+            ScanlinePhase::BufferedRows if self.decoder.scanline_state.source_complete => {
+                self.decoder.render_buffered_output_stripe(&mut output)
+            }
+            ScanlinePhase::BufferedRows => {
+                if !prepared {
+                    self.decoder.prepare_for_scan_decode()?;
+                }
+                self.decoder.decode_mcu_output(&mut output)
+            }
+            ScanlinePhase::Start | ScanlinePhase::Complete => unreachable!()
+        };
+
+        let (rows_written, source_complete) = match output {
+            McuDecodeOutput::Scanlines(sink) => (sink.rows_written, sink.source_complete),
+            McuDecodeOutput::Pixels(_) | McuDecodeOutput::RawPlanes(_) => unreachable!()
+        };
+        if let Err(error) = decode_result {
+            if error.is_recoverable_eof() {
+                return Ok(ScanlineReadStatus::NeedMoreInput);
+            }
+            return Err(error);
+        }
+
+        let remaining = usize::from(self.decoder.height())
+            .saturating_sub(self.decoder.scanline_state.output_scanline);
+        let rows_written = rows_written.min(remaining);
+        self.decoder.scanline_state.next_mcu_stripe += 1;
+        self.decoder.scanline_state.source_complete |= source_complete;
+        if self.decoder.scanline_state.phase == ScanlinePhase::StreamingBaseline
+            && self.decoder.is_arithmetic
+        {
+            self.decoder.scanline_state.entropy_tables = Some(self.decoder.entropy_tables.clone());
+        }
+        Ok(ScanlineReadStatus::RowsProcessed { rows: rows_written })
+    }
+
+    #[cfg(feature = "arith")]
+    fn restore_arithmetic_context(&mut self) -> Result<(), DecodeErrors> {
+        if !self.decoder.is_arithmetic {
+            return Ok(());
+        }
+        let resumes_completed_row = match self.decoder.scan_checkpoint() {
+            Some(checkpoint) => match checkpoint.bitstream_state {
+                BitstreamStateSnapshot::Arithmetic(_) => true,
+                BitstreamStateSnapshot::Huffman(_) | BitstreamStateSnapshot::None => false
+            },
+            None => false
+        };
+        if resumes_completed_row {
+            let tables = self.decoder.scanline_state.entropy_tables.as_ref().ok_or(
+                DecodeErrors::FormatStatic(
+                    "missing arithmetic contexts for converted scanline resume"
+                )
+            )?;
+            self.decoder.entropy_tables = tables.clone();
+        }
+        Ok(())
     }
 }
 
@@ -740,7 +1223,7 @@ where
 
         let total_stripes = self.decoder.raw_imcu_row_count(&layout, n);
         if self.decoder.raw_pull_state.next_stripe >= total_stripes {
-            self.decoder.finish_raw_pull_source();
+            self.decoder.finish_output_source();
             self.decoder.raw_pull_state.phase = RawPullPhase::Complete;
             return Ok(RawImcuRowStatus::Complete);
         }
@@ -779,11 +1262,11 @@ where
 
         let sink = match output {
             McuDecodeOutput::RawPlanes(sink) => sink,
-            McuDecodeOutput::Pixels(_) => unreachable!()
+            McuDecodeOutput::Pixels(_) | McuDecodeOutput::Scanlines(_) => unreachable!()
         };
         if sink.source_complete {
             self.decoder.raw_pull_state.buffered_source_complete = true;
-            self.decoder.finish_raw_pull_source();
+            self.decoder.finish_output_source();
         }
         if !sink.stripe_ready {
             self.decoder.raw_pull_state.phase = RawPullPhase::Complete;
@@ -810,21 +1293,24 @@ where
         if let Some(layout) = self.decoder.raw_pull_state.layout {
             return Ok(layout);
         }
-        let layout = self.decoder.raw_planar_layout().ok_or(
-            DecodeErrors::FormatStatic("raw layout unavailable before headers are decoded")
-        )?;
+        let layout = self
+            .decoder
+            .raw_planar_layout()
+            .ok_or(DecodeErrors::FormatStatic(
+                "raw layout unavailable before headers are decoded"
+            ))?;
         self.decoder.raw_pull_state.layout = Some(layout);
         Ok(layout)
     }
 
     fn pull_targets(
-        &self, planes: &[&mut [u8]], strides: &[usize],
-        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+        &self, planes: &[&mut [u8]], strides: &[usize], layout: &[PlaneInfo; MAX_COMPONENTS],
+        n: usize
     ) -> Result<RawPullTargets, DecodeErrors> {
         let mut targets = RawPullTargets {
             lengths: [0; MAX_COMPONENTS],
             strides: [0; MAX_COMPONENTS],
-            widths: [0; MAX_COMPONENTS],
+            widths:  [0; MAX_COMPONENTS],
             heights: [0; MAX_COMPONENTS]
         };
         for i in 0..n {
@@ -864,8 +1350,8 @@ where
     }
 
     fn decode_pull_phase(
-        &mut self, output: &mut McuDecodeOutput<'_, '_>,
-        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+        &mut self, output: &mut McuDecodeOutput<'_, '_>, layout: &[PlaneInfo; MAX_COMPONENTS],
+        n: usize
     ) -> Result<(), DecodeErrors> {
         match self.decoder.raw_pull_state.phase {
             RawPullPhase::Start => self.start_pull(output, layout, n),
@@ -877,7 +1363,7 @@ where
             }
             RawPullPhase::BufferedRows => {
                 if self.decoder.raw_pull_state.buffered_source_complete {
-                    self.decoder.render_buffered_raw_stripe(output)
+                    self.decoder.render_buffered_output_stripe(output)
                 } else {
                     self.prepare_pull_scan()?;
                     self.decode_buffered_source_and_render(output, layout, n)
@@ -888,8 +1374,8 @@ where
     }
 
     fn start_pull(
-        &mut self, output: &mut McuDecodeOutput<'_, '_>,
-        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+        &mut self, output: &mut McuDecodeOutput<'_, '_>, layout: &[PlaneInfo; MAX_COMPONENTS],
+        n: usize
     ) -> Result<(), DecodeErrors> {
         self.prepare_pull_scan()?;
         let buffered = self.decoder.is_progressive
@@ -913,13 +1399,13 @@ where
     }
 
     fn decode_buffered_source_and_render(
-        &mut self, output: &mut McuDecodeOutput<'_, '_>,
-        layout: &[PlaneInfo; MAX_COMPONENTS], n: usize
+        &mut self, output: &mut McuDecodeOutput<'_, '_>, layout: &[PlaneInfo; MAX_COMPONENTS],
+        n: usize
     ) -> Result<(), DecodeErrors> {
         let stripe = self.decoder.raw_pull_state.next_stripe;
         self.decoder.decode_buffered_raw_source(stripe, layout, n)?;
         self.decoder.raw_pull_state.buffered_source_complete = true;
-        self.decoder.render_buffered_raw_stripe(output)
+        self.decoder.render_buffered_output_stripe(output)
     }
 
     #[cfg(feature = "arith")]
@@ -935,14 +1421,9 @@ where
             None => false
         };
         if resumes_completed_row {
-            let tables = self
-                .decoder
-                .raw_pull_state
-                .entropy_tables
-                .as_ref()
-                .ok_or(DecodeErrors::FormatStatic(
-                    "missing arithmetic contexts for raw iMCU-row resume"
-                ))?;
+            let tables = self.decoder.raw_pull_state.entropy_tables.as_ref().ok_or(
+                DecodeErrors::FormatStatic("missing arithmetic contexts for raw iMCU-row resume")
+            )?;
             self.decoder.entropy_tables = tables.clone();
         }
         Ok(())
@@ -1113,7 +1594,7 @@ where
         loop {
             let stripe = self.decoder.raw_pull_state.next_stripe;
             if self.decoder.raw_pull_state.phase == RawPullPhase::Complete {
-                self.decoder.finish_raw_pull_source();
+                self.decoder.finish_output_source();
                 return Ok(());
             }
             let mut stripe_planes: Vec<&mut [u8]> = planes
@@ -1159,9 +1640,8 @@ where
     // instead of restarting from SOI.
     fn stream_position(&mut self) -> Result<usize, DecodeErrors> {
         let position = self.stream.position()?;
-        usize::try_from(position).map_err(|_| {
-            DecodeErrors::FormatStatic("Stream position does not fit in usize")
-        })
+        usize::try_from(position)
+            .map_err(|_| DecodeErrors::FormatStatic("Stream position does not fit in usize"))
     }
 
     fn checkpoint_headers(&mut self) -> Result<(), DecodeErrors> {
@@ -1334,8 +1814,7 @@ where
     /// row-granularity resume.
     pub(crate) fn checkpoint_scan_with_bitstream(
         &mut self, mcu_row: usize, mcu_col: usize, pixels_written: usize,
-        dc_predictions: [(i32, i32); MAX_COMPONENTS],
-        bitstream_state: BitstreamStateSnapshot
+        dc_predictions: [(i32, i32); MAX_COMPONENTS], bitstream_state: BitstreamStateSnapshot
     ) -> Result<(), DecodeErrors> {
         let stream_position = self.stream_position()?;
         let sos_snapshot = self.capture_sos_params();
@@ -1385,8 +1864,7 @@ where
         }
     }
 
-    // Match output colorspace; we only care for ycbcr to rgb/rgba here, in
-    // case one is using another colorspace may god help you.
+    // Refresh the conversion function selected by the configured output colorspace.
     fn set_color_convert_from_options(&mut self) {
         let out_colorspace = self.options.jpeg_get_out_colorspace();
         if matches!(
@@ -1405,27 +1883,27 @@ where
     fn default(options: DecoderOptions, buffer: T) -> Self {
         let color_convert = choose_ycbcr_to_rgb_convert_func(ColorSpace::RGB, &options).unwrap();
         JpegDecoder {
-            info:                  ImageInfo::default(),
-            qt_tables:             [None, None, None, None],
-            entropy_tables:        EntropyTables {
-                dc_huffman: [None, None, None, None],
-                ac_huffman: [None, None, None, None],
+            info:                        ImageInfo::default(),
+            qt_tables:                   [None, None, None, None],
+            entropy_tables:              EntropyTables {
+                dc_huffman:                              [None, None, None, None],
+                ac_huffman:                              [None, None, None, None],
                 #[cfg(feature = "arith")]
-                dc_arithmetic: [
+                dc_arithmetic:                           [
                     ArithDCTables::default(),
                     ArithDCTables::default(),
                     ArithDCTables::default(),
                     ArithDCTables::default()
                 ],
                 #[cfg(feature = "arith")]
-                ac_arithmetic: [
+                ac_arithmetic:                           [
                     ArithACTables::default(),
                     ArithACTables::default(),
                     ArithACTables::default(),
                     ArithACTables::default()
                 ]
             },
-            components:        vec![],
+            components:                  vec![],
             // Interleaved information
             h_max:                       1,
             v_max:                       1,
@@ -1475,7 +1953,8 @@ where
             progressive_render_incomplete: false,
             marker_body_scratch:         Vec::new(),
             expects_dnl:                 false,
-            raw_pull_state:              RawPullState::default()
+            raw_pull_state:              RawPullState::default(),
+            scanline_state:              ScanlineState::default()
         }
     }
     /// Decode a buffer already in memory
@@ -1496,15 +1975,22 @@ where
             // (the configured max height), run decode_into normally — the MCU
             // loop will intercept the DNL marker and set info.height — then
             // truncate to the actual decoded size.
-            let max_size = self.options.max_height()
+            let max_size = self
+                .options
+                .max_height()
                 .checked_mul(usize::from(self.info.width))
-                .and_then(|v| v.checked_mul(self.options.jpeg_get_out_colorspace().num_components()))
-                .ok_or(DecodeErrors::FormatStatic("DNL image dimensions overflow usize"))?;
+                .and_then(|v| {
+                    v.checked_mul(self.options.jpeg_get_out_colorspace().num_components())
+                })
+                .ok_or(DecodeErrors::FormatStatic(
+                    "DNL image dimensions overflow usize"
+                ))?;
             let mut out = vec![0u8; max_size];
             self.decode_into(&mut out)?;
             // After decode_into, info.height has been set by the DNL handler.
-            let actual_size = self.output_buffer_size()
-                .ok_or(DecodeErrors::FormatStatic("DNL image: output size unavailable after decode"))?;
+            let actual_size = self.output_buffer_size().ok_or(DecodeErrors::FormatStatic(
+                "DNL image: output size unavailable after decode"
+            ))?;
             out.truncate(actual_size);
             return Ok(out);
         }
@@ -1700,6 +2186,7 @@ where
     /// output planes. The session borrows this decoder mutably, preventing
     /// pixel output or option changes until the session is dropped.
     pub fn raw_output(&mut self) -> RawDecodeSession<'_, T> {
+        self.abort_scanline_sequence();
         if self.raw_pull_state.phase == RawPullPhase::Complete {
             self.raw_pull_state = RawPullState::default();
         }
@@ -1712,6 +2199,21 @@ where
             decoder: self,
             previous_incremental_mode,
         }
+    }
+
+    /// Begin an exclusive converted scanline output session.
+    ///
+    /// Call [`ScanlineDecodeSession::start`] before reading rows. Recreating a
+    /// session after input suspension preserves decoder-owned scanline state.
+    pub fn scanline_output(&mut self) -> ScanlineDecodeSession<'_, T> {
+        self.abort_raw_pull_sequence();
+        if self.scanline_state.phase == ScanlinePhase::Complete {
+            self.abort_scanline_sequence();
+        }
+        if !self.scanline_state.started {
+            self.clear_scan_checkpoints();
+        }
+        ScanlineDecodeSession { decoder: self }
     }
 
     #[cfg(test)]
@@ -1867,10 +2369,9 @@ where
     }
     /// Set decoder options
     ///
-    /// This can be used to set new options even after initialization
-    /// but before decoding.
-    ///
-    /// This does not bear any significance after decoding an image
+    /// This can be used after initialization or a partial decode. Active raw
+    /// and scanline sequences are aborted, and the next output operation
+    /// replays from scan start with the new options.
     ///
     /// # Arguments
     /// - `options`: New decoder options
@@ -1951,8 +2452,13 @@ where
         Ok(())
     }
 
+    /// Replace decoder options and restart any active raw or scanline sequence.
+    ///
+    /// Changes rebuild cached output and dispatch state, so the next decode
+    /// replays from scan start using the new options.
     pub fn set_options(&mut self, options: DecoderOptions) {
         self.abort_raw_pull_sequence();
+        self.abort_scanline_sequence();
         self.clear_scan_checkpoints();
         self.options = options;
         self.coeff = 1;
@@ -2043,8 +2549,8 @@ where
                 return Err(DecodeErrors::IllegalMagicBytes(magic_bytes));
             }
 
-            // Color convert depends only on options, so pick it once
-            // on a fresh decode rather than on every resume.
+            // Select the initial color converter. `set_options` refreshes it
+            // when output options change after headers have been parsed.
             self.set_color_convert_from_options();
             self.checkpoint_headers()?;
         } else {
@@ -2150,13 +2656,12 @@ where
             Some(_) => unreachable!("APP14 parser rejects unknown transforms"),
             None if self.components.len() == 1 => ColorSpace::Luma,
             None if self.components.len() == 4 => ColorSpace::CMYK,
-            None
-                if self.components.len() == 3
-                    && self
-                        .components
-                        .iter()
-                        .zip(b"RGB")
-                        .all(|(component, id)| component.id == *id) =>
+            None if self.components.len() == 3
+                && self
+                    .components
+                    .iter()
+                    .zip(b"RGB")
+                    .all(|(component, id)| component.id == *id) =>
             {
                 ColorSpace::RGB
             }
@@ -2369,9 +2874,7 @@ where
                 parse_app13(self)?;
             }
             _ => {
-                warn!(
-                    "Capabilities for processing marker \"{m:?}\" not implemented"
-                );
+                warn!("Capabilities for processing marker \"{m:?}\" not implemented");
                 self.skip_marker_payload()?;
             }
         }
@@ -2756,9 +3259,7 @@ where
                 self.todo = view.todo;
                 self.pixels_decoded = view.pixels_written;
                 // Restore DC predictor state from the checkpoint.
-                for (i, comp) in
-                    self.components.iter_mut().enumerate().take(MAX_COMPONENTS)
-                {
+                for (i, comp) in self.components.iter_mut().enumerate().take(MAX_COMPONENTS) {
                     let (dc_pred, dc_diff) = view.dc_predictions[i];
                     comp.dc_pred = dc_pred;
                     comp.dc_diff = dc_diff;
@@ -2841,6 +3342,7 @@ where
 
     pub fn decode_into(&mut self, out: &mut [u8]) -> Result<(), DecodeErrors> {
         self.abort_raw_pull_sequence();
+        self.abort_scanline_sequence();
         self.prepare_for_scan_decode()?;
 
         let expected_size = self.output_buffer_size().unwrap();
@@ -2879,13 +3381,13 @@ where
         }
     }
 
-    fn render_buffered_raw_stripe(
+    fn render_buffered_output_stripe(
         &mut self, output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         if self.is_progressive {
-            self.render_buffered_progressive_raw_stripe(output)
+            self.render_buffered_progressive_stripe(output)
         } else {
-            self.render_buffered_baseline_raw_stripe(output)
+            self.render_buffered_baseline_stripe(output)
         }
     }
 
@@ -2926,10 +3428,17 @@ where
         self.decode_mcu_output(&mut output)
     }
 
-    fn finish_raw_pull_source(&mut self) {
+    fn finish_output_source(&mut self) {
         self.clear_scan_checkpoints();
         if self.is_progressive {
             self.progressive_displayed_scans = self.progressive_completed_scans;
+        }
+    }
+
+    fn clear_scan_checkpoints(&mut self) {
+        if let Some(state) = self.scan_state.as_deref_mut() {
+            state.scan_checkpoint = None;
+            state.progressive_checkpoint = None;
         }
     }
 
@@ -2941,11 +3450,24 @@ where
         self.clear_scan_checkpoints();
     }
 
+    fn abort_scanline_sequence(&mut self) {
+        if !self.scanline_state.started {
+            return;
+        }
+        self.scanline_state = ScanlineState::default();
+        self.clear_scan_checkpoints();
+    }
+
     fn raw_component_ids(&self) -> Option<Vec<u8>> {
         if !self.headers_decoded || self.components.is_empty() {
             return None;
         }
-        Some(self.components.iter().map(|component| component.id).collect())
+        Some(
+            self.components
+                .iter()
+                .map(|component| component.id)
+                .collect()
+        )
     }
 
     /// Copy one MCU stripe (`mcu_stripe_index`) of post-IDCT samples from
@@ -3074,8 +3596,6 @@ where
         Ok(())
     }
 
-
-
     /// Create a new decoder with the specified options to be used for decoding
     /// an image
     ///
@@ -3092,7 +3612,7 @@ where
         // no sampling, return early
         // check if horizontal max ==1
         if self.h_max == self.v_max && self.h_max == 1 {
-            return ;
+            return;
         }
 
         for comp in &mut self.components {
@@ -3124,7 +3644,6 @@ where
             comp.setup_upsample_scanline();
             comp.up_sampler = samp_factor;
         }
-
     }
     #[must_use]
     /// Get the width of the image as a u16
@@ -3165,10 +3684,10 @@ pub struct GainMapInfo {
 
 #[derive(Default, Clone, Eq, PartialEq, Debug)]
 pub(crate) struct ExtendedXmpSegment {
-    pub(crate) offset: u32,
+    pub(crate) offset:     u32,
     pub(crate) total_size: u32,
-    pub(crate) guid: Vec<u8>,
-    pub(crate) data: Vec<u8>,
+    pub(crate) guid:       Vec<u8>,
+    pub(crate) data:       Vec<u8>
 }
 
 /// A struct representing Image Information
@@ -3176,39 +3695,39 @@ pub(crate) struct ExtendedXmpSegment {
 #[allow(clippy::module_name_repetitions)]
 pub struct ImageInfo {
     /// Width of the image
-    pub width: u16,
+    pub width:                            u16,
     /// Height of image
-    pub height: u16,
+    pub height:                           u16,
     /// Sample precision in bits.
-    pub pixel_density: u8,
+    pub pixel_density:                    u8,
     /// Start of frame markers
-    pub sof: SOFMarkers,
+    pub sof:                              SOFMarkers,
     /// Horizontal sample
-    pub x_density: u16,
+    pub x_density:                        u16,
     /// Vertical sample
-    pub y_density: u16,
+    pub y_density:                        u16,
     /// Number of components
-    pub components: u8,
+    pub components:                       u8,
     /// Gain Map information, useful for
     /// UHDR images
-    pub gain_map_info: Vec<GainMapInfo>,
+    pub gain_map_info:                    Vec<GainMapInfo>,
     /// Multi picture information, useful for
     /// UHDR images
-    pub multi_picture_information: Option<Vec<u8>>,
+    pub multi_picture_information:        Option<Vec<u8>>,
     /// Exif Data
-    pub exif_data: Option<Vec<u8>>,
+    pub exif_data:                        Option<Vec<u8>>,
     /// XMP Data
-    pub xmp_data: Option<Vec<u8>>,
+    pub xmp_data:                         Option<Vec<u8>>,
     /// IPTC Data
-    pub iptc_data: Option<Vec<u8>>,
+    pub iptc_data:                        Option<Vec<u8>>,
     /// Extended XMP Data
-    pub extended_xmp: Option<Vec<u8>>,
+    pub extended_xmp:                     Option<Vec<u8>>,
     /// Extended XMP Guid
-    pub extended_xmp_guid: Option<Vec<u8>>,
+    pub extended_xmp_guid:                Option<Vec<u8>>,
     /// Image sub-sampling ratio
-    pub sample_ratio: SampleRatios,
+    pub sample_ratio:                     SampleRatios,
     /// The offset at which Multi picture information was found
-    pub multi_picture_information_offset: Option<u64>,
+    pub multi_picture_information_offset: Option<u64>
 }
 
 impl ImageInfo {
@@ -3264,8 +3783,8 @@ mod planar_layout_helpers {
     use zune_core::options::DecoderOptions;
 
     use crate::color_convert::choose_ycbcr_to_rgb_convert_func;
+    use super::{round_up_pow2, JpegDecoder, RawImcuRowStatus, ScanlineReadStatus, ScanlineStatus};
     use crate::idct::{choose_idct_1x1_func, choose_idct_4x4_func, choose_idct_func};
-    use super::{round_up_pow2, JpegDecoder, RawImcuRowStatus};
 
     #[test]
     fn div_ceil_basic() {
@@ -3301,7 +3820,10 @@ mod planar_layout_helpers {
         ] {
             let mut decoder = JpegDecoder::new_with_options(ZCursor::new(&[]), initial);
             decoder.set_options(replacement);
-            assert_eq!(decoder.idct_func as usize, choose_idct_func(&replacement) as usize);
+            assert_eq!(
+                decoder.idct_func as usize,
+                choose_idct_func(&replacement) as usize
+            );
             assert_eq!(
                 decoder.idct_4x4_func as usize,
                 choose_idct_4x4_func(&replacement) as usize
@@ -3357,6 +3879,37 @@ mod planar_layout_helpers {
                 "component {index} exceeded one-iMCU-row scratch bound"
             );
             assert!(stripe_buffers[index] < layout[index].byte_size);
+        }
+    }
+
+    #[test]
+    fn baseline_scanline_memory_is_stripe_bounded() {
+        let data = include_bytes!("../../../test-images/jpeg/2029.jpg");
+        let mut decoder = JpegDecoder::new(ZCursor::new(data));
+        let (row_bytes, height) = {
+            let mut scanlines = decoder.scanline_output();
+            assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+            let row_bytes = scanlines.output_row_bytes().unwrap();
+            let height = scanlines.output_height().unwrap();
+            let mut row = vec![0; row_bytes];
+            assert_eq!(
+                scanlines.read_scanlines(&mut row, row_bytes).unwrap(),
+                ScanlineReadStatus::RowsProcessed { rows: 1 }
+            );
+            (row_bytes, height)
+        };
+
+        assert!(decoder
+            .progressive_mcus_buffer
+            .iter()
+            .all(|buffer| buffer.capacity() == 0));
+        assert!(decoder.scanline_state.staging.capacity() <= row_bytes * 36);
+        assert!(decoder.scanline_state.staging.capacity() < row_bytes * height);
+        for component in &decoder.components {
+            assert!(
+                component.raw_coeff.capacity()
+                    <= (component.width_stride + 8) * component.vertical_sample * 8
+            );
         }
     }
 }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -653,13 +653,14 @@ where
     /// needed for final samples; their rows are still pulled sequentially, but
     /// compressed input consumption is not row-streaming.
     ///
-    /// Each stride must be at least the corresponding logical plane width.
-    /// Each plane must be large enough for
-    /// `stride * vertical_sampling_factor * 8` bytes. The returned
-    /// `rows_written` count identifies the meaningful prefix; the final iMCU
-    /// row is clipped to the logical component height. Components that exhaust
-    /// their logical height before other components report zero rows on later
-    /// calls.
+    /// Each stride must be at least the corresponding logical plane width. For
+    /// a component that will return `rows` rows, its plane must contain at least
+    /// `(rows - 1) * stride + width` bytes, or zero bytes when `rows == 0`.
+    /// Padding is addressable only between logical rows; no padding is required
+    /// after the final row. The returned `rows_written` count identifies the
+    /// meaningful prefix; the final iMCU row is clipped to the logical component
+    /// height. Components that exhaust their logical height before other
+    /// components report zero rows on later calls.
     ///
     /// A recoverable input suspension returns [`RawImcuRowStatus::NeedMoreInput`]
     /// and leaves caller planes untouched. Expose more input through the same
@@ -841,11 +842,16 @@ where
             };
             let row_start = self.decoder.raw_pull_state.next_stripe * stripe_rows;
             let rows = layout[i].height.saturating_sub(row_start).min(stripe_rows);
-            let need = strides[i]
-                .checked_mul(rows)
-                .ok_or(DecodeErrors::FormatStatic(
-                    "raw iMCU-row plane size overflow"
-                ))?;
+            let need = if rows == 0 {
+                0
+            } else {
+                (rows - 1)
+                    .checked_mul(strides[i])
+                    .and_then(|offset| offset.checked_add(layout[i].width))
+                    .ok_or(DecodeErrors::FormatStatic(
+                        "raw iMCU-row plane size overflow",
+                    ))?
+            };
             if planes[i].len() < need {
                 return Err(DecodeErrors::TooSmallOutput(need, planes[i].len()));
             }

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -15,7 +15,6 @@ use alloc::vec::Vec;
 use alloc::sync::Arc;
 use alloc::{format, vec};
 use core::num::NonZeroU32;
-use core::ptr::NonNull;
 
 use zune_core::bytestream::{ZByteReaderTrait, ZReader};
 use zune_core::colorspace::ColorSpace;
@@ -460,16 +459,19 @@ pub struct JpegDecoder<T> {
 }
 
 /// Internal sink for one raw planar decode call.
+///
+/// Holds owned per-component plane buffers that MCU-stripe copies write into.
+/// After decoding completes, the caller copies from these into its output slices.
 pub(crate) struct RawPlanesSink {
-    /// Per-component plane base pointer (only `0..n_components` are valid).
-    pub(crate) ptrs:           [*mut u8; MAX_COMPONENTS],
-    /// Bytes between successive destination rows.
+    /// Internal plane buffers (one per component, sized to full plane).
+    pub(crate) planes:         Vec<Vec<u8>>,
+    /// Bytes between successive destination rows (used for strided output).
     pub(crate) target_strides: [usize; MAX_COMPONENTS],
     /// Maximum bytes to write per destination row.
     pub(crate) target_widths:  [usize; MAX_COMPONENTS],
-    /// Number of destination rows the caller's buffer can accept.
+    /// Number of destination rows per plane.
     pub(crate) target_heights: [usize; MAX_COMPONENTS],
-    /// Number of valid components in `ptrs`.
+    /// Number of valid components.
     pub(crate) n_components:   usize
 }
 
@@ -2180,33 +2182,30 @@ where
             }
         }
 
-        // Each plane is mutably borrowed for this call; the guard clears the
-        // raw pointers before returning.
-        let mut ptrs: [*mut u8; MAX_COMPONENTS] = [core::ptr::null_mut(); MAX_COMPONENTS];
+        // Each plane is mutably borrowed for this call; internal buffers
+        // collect the MCU stripe outputs, then are copied to the caller at the end.
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        for (i, plane) in planes.iter_mut().enumerate() {
-            ptrs[i] = plane.as_mut_ptr();
+        let mut internal_planes: Vec<Vec<u8>> = Vec::with_capacity(n);
+        for i in 0..n {
             target_strides[i] = layout[i].stride;
             target_widths[i] = layout[i].stride;
             target_heights[i] = layout[i].allocated_height;
+            internal_planes.push(vec![0u8; layout[i].byte_size]);
         }
         self.raw_planes_sink = Some(RawPlanesSink {
-            ptrs,
+            planes: internal_planes,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
         });
-        let _guard = RawPlanesGuard {
-            dec: NonNull::from(&mut *self)
-        };
 
-        // Raw mode writes into the plane sink; downstream pixel bookkeeping
-        // only needs a placeholder slice.
+        // Raw mode writes into the internal plane buffers; downstream pixel
+        // bookkeeping only needs a placeholder slice.
         let mut sink: [u8; 0] = [];
-        if self.is_arithmetic {
+        let result = if self.is_arithmetic {
             #[cfg(feature = "arith")]
             {
                 if self.is_progressive {
@@ -2221,8 +2220,17 @@ where
             self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
         } else {
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
+        };
+
+        // Copy from internal buffers to the caller's output slices.
+        if let Some(raw_sink) = self.raw_planes_sink.take() {
+            for (i, internal) in raw_sink.planes.into_iter().enumerate() {
+                let dst = &mut planes[i][..internal.len()];
+                dst.copy_from_slice(&internal);
+            }
         }
-        // Guard clears `raw_planes_sink` on drop.
+
+        result
     }
 
     /// Decode raw planes using caller-supplied row strides.
@@ -2309,31 +2317,28 @@ where
             }
         }
 
-        // Each plane is mutably borrowed for this call; the guard clears the
-        // raw pointers before returning.
-        let mut ptrs: [*mut u8; MAX_COMPONENTS] = [core::ptr::null_mut(); MAX_COMPONENTS];
+        // Each plane is mutably borrowed for this call; internal buffers
+        // collect the MCU stripe outputs, then are copied to the caller at the end.
         let mut target_strides = [0usize; MAX_COMPONENTS];
         let mut target_widths = [0usize; MAX_COMPONENTS];
         let mut target_heights = [0usize; MAX_COMPONENTS];
-        for (i, plane) in planes.iter_mut().enumerate() {
-            ptrs[i] = plane.as_mut_ptr();
+        let mut internal_planes: Vec<Vec<u8>> = Vec::with_capacity(n);
+        for i in 0..n {
             target_strides[i] = strides[i];
             target_widths[i] = layout[i].width;
             target_heights[i] = layout[i].height;
+            internal_planes.push(vec![0u8; strides[i] * layout[i].height]);
         }
         self.raw_planes_sink = Some(RawPlanesSink {
-            ptrs,
+            planes: internal_planes,
             target_strides,
             target_widths,
             target_heights,
             n_components: n
         });
-        let _guard = RawPlanesGuard {
-            dec: NonNull::from(&mut *self)
-        };
 
         let mut sink: [u8; 0] = [];
-        if self.is_arithmetic {
+        let result = if self.is_arithmetic {
             #[cfg(feature = "arith")]
             {
                 if self.is_progressive {
@@ -2348,7 +2353,24 @@ where
             self.decode_mcu_ycbcr_progressive::<BitStreamHuffman>(&mut sink)
         } else {
             self.decode_mcu_ycbcr_baseline::<BitStreamHuffman>(&mut sink)
+        };
+
+        // Copy from internal buffers to the caller's output slices.
+        // Only copy logical width per row to preserve caller's padding bytes.
+        if let Some(raw_sink) = self.raw_planes_sink.take() {
+            for (i, internal) in raw_sink.planes.into_iter().enumerate() {
+                let stride = raw_sink.target_strides[i];
+                let width = raw_sink.target_widths[i];
+                let height = raw_sink.target_heights[i];
+                for y in 0..height {
+                    let off = y * stride;
+                    planes[i][off..off + width]
+                        .copy_from_slice(&internal[off..off + width]);
+                }
+            }
         }
+
+        result
     }
 
     /// Per-component [`ComponentID`] in declaration order
@@ -2383,16 +2405,12 @@ where
     ) -> Result<(), DecodeErrors> {
         let sink = self
             .raw_planes_sink
-            .as_ref()
+            .as_mut()
             .expect("copy_raw_planes_for_mcu_stripe called without active sink");
 
         for (idx, comp) in self.components.iter().enumerate() {
             if idx >= sink.n_components {
                 break;
-            }
-            let plane_ptr = sink.ptrs[idx];
-            if plane_ptr.is_null() {
-                continue;
             }
             let target_stride = sink.target_strides[idx];
             let target_width = sink.target_widths[idx];
@@ -2400,7 +2418,7 @@ where
 
             let stripe_rows = comp.vertical_sample * DCT_BLOCK_SIZE;
             let row_start = mcu_stripe_index * stripe_rows;
-            // Clip rows to the caller-provided plane height.
+            // Clip rows to the plane height.
             if row_start >= target_height {
                 continue;
             }
@@ -2408,6 +2426,8 @@ where
 
             let src_stride = comp.width_stride;
             let copy_w = core::cmp::min(src_stride, core::cmp::min(target_width, target_stride));
+
+            let plane = &mut sink.planes[idx];
 
             for r in 0..rows_to_copy {
                 let src_row_start = r * src_stride;
@@ -2419,22 +2439,12 @@ where
                 }
                 let src = &comp.raw_coeff[src_row_start..src_row_end];
 
-                // SAFETY: `plane_ptr` came from a `&mut [u8]` of length at
-                // least `target_stride * target_height` (validated in
-                // `decode_raw` / `decode_raw_strided`). `(row_start + r) <
-                // target_height` and `copy_w <= target_stride`, so
-                // `dst_offset + copy_w <= target_stride * target_height`.
-                // No other code path borrows the plane buffer while
-                // `raw_planes_sink` is set.
-                unsafe {
-                    let dst_offset = (row_start + r) * target_stride;
-                    let dst = plane_ptr.add(dst_offset);
-                    for (i, sample) in src.iter().enumerate() {
-                        // Post-IDCT samples are already clamped to [0, 255].
-                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                        {
-                            *dst.add(i) = *sample as u8;
-                        }
+                let dst_offset = (row_start + r) * target_stride;
+                let dst = &mut plane[dst_offset..dst_offset + copy_w];
+                for (i, sample) in src.iter().enumerate() {
+                    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                    {
+                        dst[i] = *sample as u8;
                     }
                 }
             }
@@ -2657,31 +2667,6 @@ impl ImageInfo {
     #[allow(dead_code)]
     pub(crate) fn set_y(&mut self, sample: u16) {
         self.y_density = sample;
-    }
-}
-
-// SAFETY: `RawPlanesSink` only ever holds raw pointers into caller-owned
-// buffers for the duration of a single `decode_raw` call (which takes
-// `&mut self`). No other code path can observe or alias the pointers, so
-// these auto-trait restorations are defensive — they let `JpegDecoder<T>`
-// retain whatever Send/Sync it would have had without this field, when
-// `T: Send + Sync`.
-unsafe impl Send for RawPlanesSink {}
-unsafe impl Sync for RawPlanesSink {}
-
-/// RAII guard that clears [`JpegDecoder::raw_planes_sink`] when dropped,
-/// including on panic / early `?` returns from inside `decode_raw`.
-pub(crate) struct RawPlanesGuard<T: ZByteReaderTrait> {
-    pub(crate) dec: NonNull<JpegDecoder<T>>
-}
-
-impl<T: ZByteReaderTrait> Drop for RawPlanesGuard<T> {
-    fn drop(&mut self) {
-        // SAFETY: `dec` was created from `&mut *self` inside `decode_raw`
-        // and the guard does not outlive that borrow.
-        unsafe {
-            self.dec.as_mut().raw_planes_sink = None;
-        }
     }
 }
 

--- a/crates/zune-jpeg/src/decoder.rs
+++ b/crates/zune-jpeg/src/decoder.rs
@@ -464,11 +464,7 @@ pub(crate) enum McuDecodeOutput<'planes, 'buf> {
 
 impl McuDecodeOutput<'_, '_> {
     pub(crate) const fn is_raw(&self) -> bool {
-        match self {
-            Self::Pixels(_) => false,
-            Self::RawPlanes(_) => true,
-            Self::Scanlines(_) => false
-        }
+        matches!(self, Self::RawPlanes(_))
     }
 
     pub(crate) fn pixels_mut(&mut self) -> Option<&mut [u8]> {
@@ -676,12 +672,6 @@ pub struct RawDecodeSession<'decoder, T> {
     previous_incremental_mode: bool,
 }
 
-impl<T> Drop for RawDecodeSession<'_, T> {
-    fn drop(&mut self) {
-        self.decoder.incremental_mode = self.previous_incremental_mode;
-    }
-}
-
 /// Stateful converted scanline output session.
 ///
 /// Obtain a session with [`JpegDecoder::scanline_output`], call [`Self::start`],
@@ -693,8 +683,24 @@ impl<T> Drop for RawDecodeSession<'_, T> {
 /// through this API. They return [`ScanlineReadStatus::NeedMoreInput`] until
 /// all coefficients needed for stable final rows are available. Progressive
 /// preview reporting on [`JpegDecoder`] remains a separate full-frame API.
+/// Output dimensions always match the JPEG frame dimensions. This API does not
+/// provide libjpeg's scaled-IDCT or horizontal crop operations; callers must
+/// perform scaling or cropping after row conversion.
 pub struct ScanlineDecodeSession<'decoder, T> {
-    decoder: &'decoder mut JpegDecoder<T>
+    decoder: &'decoder mut JpegDecoder<T>,
+    previous_incremental_mode: bool,
+}
+
+impl<T> Drop for RawDecodeSession<'_, T> {
+    fn drop(&mut self) {
+        self.decoder.incremental_mode = self.previous_incremental_mode;
+    }
+}
+
+impl<T> Drop for ScanlineDecodeSession<'_, T> {
+    fn drop(&mut self) {
+        self.decoder.incremental_mode = self.previous_incremental_mode;
+    }
 }
 
 impl<T> ScanlineDecodeSession<'_, T>
@@ -1856,14 +1862,6 @@ where
         }
     }
 
-    fn clear_scan_checkpoints(&mut self) {
-        if let Some(state) = self.scan_state.as_deref_mut() {
-            state.scan_checkpoint = None;
-            state.progressive_checkpoint = None;
-            state.progressive_fine_checkpoint = None;
-        }
-    }
-
     // Refresh the conversion function selected by the configured output colorspace.
     fn set_color_convert_from_options(&mut self) {
         let out_colorspace = self.options.jpeg_get_out_colorspace();
@@ -2213,7 +2211,12 @@ where
         if !self.scanline_state.started {
             self.clear_scan_checkpoints();
         }
-        ScanlineDecodeSession { decoder: self }
+        let previous_incremental_mode = self.incremental_mode;
+        self.incremental_mode = true;
+        ScanlineDecodeSession {
+            decoder: self,
+            previous_incremental_mode,
+        }
     }
 
     #[cfg(test)]
@@ -3439,6 +3442,7 @@ where
         if let Some(state) = self.scan_state.as_deref_mut() {
             state.scan_checkpoint = None;
             state.progressive_checkpoint = None;
+            state.progressive_fine_checkpoint = None;
         }
     }
 

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -206,17 +206,16 @@ pub(crate) fn parse_dac<T: ZByteReaderTrait>(
 where
 {
     with_marker_body(decoder, |decoder, mut cursor| {
+        if cursor.body().len() % 2 != 0 {
+            return Err(DecodeErrors::FormatStatic(
+                "Bogus (odd) Arithmetic-coding conditioning segment length"
+            ));
+        }
         // Validate everything before committing: collect new entries into a
         // local Vec and apply them only when the whole body parses cleanly.
         enum DacEntry {
             Dc { index: usize, l: u8, u: u8 },
             Ac { index: usize, kx: u8 }
-        }
-
-        if cursor.body().len() % 2 != 0 {
-            return Err(DecodeErrors::FormatStatic(
-                "Bogus (odd) Arithmetic-coding conditioning segment length"
-            ));
         }
         let mut entries: Vec<DacEntry> = Vec::with_capacity(cursor.body().len() / 2);
         while cursor.remaining() >= 2 {

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -416,6 +416,12 @@ pub(crate) fn parse_start_of_frame<T: ZByteReaderTrait>(
 
         trace!("Image components : {num_components}");
 
+        if usize::from(num_components) > MAX_COMPONENTS {
+            return Err(DecodeErrors::SofError(format!(
+                "Invalid number of components in start of frame {num_components}, expected in range 1..={MAX_COMPONENTS}"
+            )));
+        }
+
         // Build components list locally; commit only when the whole body parses.
         let mut components = Vec::with_capacity(num_components as usize);
         let mut temp = [0; 3];

--- a/crates/zune-jpeg/src/headers.rs
+++ b/crates/zune-jpeg/src/headers.rs
@@ -206,16 +206,17 @@ pub(crate) fn parse_dac<T: ZByteReaderTrait>(
 where
 {
     with_marker_body(decoder, |decoder, mut cursor| {
-        if cursor.body().len() % 2 != 0 {
-            return Err(DecodeErrors::FormatStatic(
-                "Bogus (odd) Arithmetic-coding conditioning segment length"
-            ));
-        }
         // Validate everything before committing: collect new entries into a
         // local Vec and apply them only when the whole body parses cleanly.
         enum DacEntry {
             Dc { index: usize, l: u8, u: u8 },
             Ac { index: usize, kx: u8 }
+        }
+
+        if cursor.body().len() % 2 != 0 {
+            return Err(DecodeErrors::FormatStatic(
+                "Bogus (odd) Arithmetic-coding conditioning segment length"
+            ));
         }
         let mut entries: Vec<DacEntry> = Vec::with_capacity(cursor.body().len() / 2);
         while cursor.remaining() >= 2 {

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -37,6 +37,37 @@
 //! let mut pixels = decoder.decode().unwrap();
 //! ```
 //!
+//! ## Decode converted scanlines into caller storage
+//!
+//! `scanline_output()` provides sequential converted rows without allocating a
+//! full internal pixel image. It uses the decoder's configured output
+//! colorspace and supports caller-selected row stride.
+//!
+//! ```no_run
+//! use zune_core::bytestream::ZCursor;
+//! use zune_jpeg::{JpegDecoder, ScanlineReadStatus, ScanlineStatus};
+//!
+//! let data = std::fs::read("photo.jpg").unwrap();
+//! let mut decoder = JpegDecoder::new(ZCursor::new(&data));
+//! let mut scanlines = decoder.scanline_output();
+//! assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+//! let row_bytes = scanlines.output_row_bytes().unwrap();
+//! let mut output = vec![0; row_bytes * 16];
+//!
+//! loop {
+//!     match scanlines.read_scanlines(&mut output, row_bytes).unwrap() {
+//!         ScanlineReadStatus::RowsProcessed { rows } => {
+//!             // Consume `rows` converted rows from `output`.
+//!             let _ = rows;
+//!         }
+//!         ScanlineReadStatus::NeedMoreInput => break,
+//!         ScanlineReadStatus::Complete => break,
+//!         _ => unreachable!()
+//!     }
+//! }
+//! assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+//! ```
+//!
 //! ## Incremental input
 //!
 //! `JpegDecoder` can be retried on the same decoder when the underlying reader can
@@ -286,15 +317,17 @@ extern crate core;
 
 pub use zune_core;
 
+pub use crate::cancel::{CancelCheck, NeverCancel};
 pub use crate::components::SampleRatios;
 pub use crate::decoder::{
-    ImageInfo, JpegDecoder, PlaneInfo, RawDecodeSession, RawImcuRowStatus
+    ImageInfo, JpegDecoder, PlaneInfo, RawDecodeSession, RawImcuRowStatus, ScanlineDecodeSession,
+    ScanlineReadStatus, ScanlineStatus
 };
 pub use crate::marker::Marker;
-pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;
 #[cfg(feature = "arith")]
 mod bitstream_arith;
+mod cancel;
 mod color_convert;
 mod components;
 mod decoder;
@@ -309,7 +342,6 @@ mod marker;
 mod mcu;
 mod mcu_prog;
 mod misc;
-mod cancel;
 mod unsafe_utils;
 mod unsafe_utils_avx2;
 mod unsafe_utils_neon;

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -277,7 +277,7 @@
 )]
 // no_std compatibility
 #![deny(clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
-#![cfg_attr(not(any(feature = "x86", feature = "neon")), forbid(unsafe_code))]
+#![cfg_attr(not(any(feature = "x86", feature = "neon")), deny(unsafe_code))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "portable_simd", feature(portable_simd))]
 #![macro_use]

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -277,7 +277,7 @@
 )]
 // no_std compatibility
 #![deny(clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
-#![cfg_attr(not(any(feature = "x86", feature = "neon")), deny(unsafe_code))]
+#![cfg_attr(not(any(feature = "x86", feature = "neon")), forbid(unsafe_code))]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "portable_simd", feature(portable_simd))]
 #![macro_use]
@@ -286,8 +286,8 @@ extern crate core;
 
 pub use zune_core;
 
-pub use crate::components::{ComponentID, SampleRatios};
-pub use crate::decoder::{ImageInfo, JpegDecoder, PlaneInfo};
+pub use crate::components::SampleRatios;
+pub use crate::decoder::{ImageInfo, JpegDecoder, PlaneInfo, RawDecodeSession};
 pub use crate::marker::Marker;
 pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -287,7 +287,9 @@ extern crate core;
 pub use zune_core;
 
 pub use crate::components::SampleRatios;
-pub use crate::decoder::{ImageInfo, JpegDecoder, PlaneInfo, RawDecodeSession};
+pub use crate::decoder::{
+    ImageInfo, JpegDecoder, PlaneInfo, RawDecodeSession, RawImcuRowStatus
+};
 pub use crate::marker::Marker;
 pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;

--- a/crates/zune-jpeg/src/lib.rs
+++ b/crates/zune-jpeg/src/lib.rs
@@ -286,8 +286,8 @@ extern crate core;
 
 pub use zune_core;
 
-pub use crate::components::SampleRatios;
-pub use crate::decoder::{ImageInfo, JpegDecoder};
+pub use crate::components::{ComponentID, SampleRatios};
+pub use crate::decoder::{ImageInfo, JpegDecoder, PlaneInfo};
 pub use crate::marker::Marker;
 pub use crate::cancel::{CancelCheck, NeverCancel};
 mod bitstream;

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -466,7 +466,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 width,
                                 padded_width,
                                 &mut stripe_written,
-                                upsampler_scratch_space
+                                upsampler_scratch_space,
                             )?;
                             scanlines.rows_written = stripe_written / scanlines.stride;
                         }

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -29,19 +29,19 @@ use crate::JpegDecoder;
 pub const DCT_BLOCK: usize = 64;
 
 struct McuWidthContext<'a, B: BitStream> {
-    mcu_width: usize,
+    mcu_width:      usize,
     // Current MCU row, used when indexing progressive scratch buffers and checkpoints.
-    mcu_row: usize,
+    mcu_row:        usize,
     // First MCU column to decode in this row; non-zero when resuming from a restart checkpoint.
-    start_col: usize,
+    start_col:      usize,
     // Number of output bytes already committed before this MCU row.
     pixels_written: usize,
     // Shared coefficient scratch block reused for each decoded data unit.
-    tmp: &'a mut [i32; 64],
+    tmp:            &'a mut [i32; 64],
     // Entropy decoder state for the current scan.
-    stream: &'a mut B,
+    stream:         &'a mut B,
     // Full-image coefficient buffers for multi-SOS baseline scans.
-    progressive: &'a mut [Vec<i16>; MAX_COMPONENTS],
+    progressive:    &'a mut [Vec<i16>; MAX_COMPONENTS]
 }
 
 impl<T: ZByteReaderTrait> JpegDecoder<T> {
@@ -52,7 +52,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             let _ = B::get_dc_ac_tables(
                 &mut self.entropy_tables,
                 component.dc_huff_table,
-                component.ac_huff_table,
+                component.ac_huff_table
             )?;
         }
         Ok(())
@@ -172,7 +172,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             if raw_mode
                 || min(
                     self.options.jpeg_get_out_colorspace().num_components() - 1,
-                    pos,
+                    pos
                 ) == pos
                 || comp_len == 4
             // Special colorspace
@@ -256,8 +256,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             } else {
                 let component_index = self.z_order.first().copied().unwrap_or(0);
                 if let Some(component) = self.components.get(component_index) {
-                    (self.info.height as usize * component.vertical_sample)
-                        .div_ceil(self.v_max * 8)
+                    (self.info.height as usize * component.vertical_sample).div_ceil(self.v_max * 8)
                 } else {
                     mcu_height
                 }
@@ -322,7 +321,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         start_col,
                         pixels_written,
                         dc_predictions,
-                        bs_state,
+                        bs_state
                     )?;
                 }
 
@@ -400,10 +399,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
                 // A pull request must not publish a row assembled after the
                 // entropy reader exhausted visible input.
-                if output.requested_raw_stripe().is_some() && stream.overread_by() > 0 {
+                if output.requested_output_stripe().is_some() && stream.overread_by() > 0 {
                     return Err(DecodeErrors::ExhaustedData);
                 }
-                if output.requested_raw_stripe().is_some()
+                if output.requests_raw_output()
                     && matches!(terminate, McuContinuation::Terminate)
                     && !*stream.seen_eoi()
                 {
@@ -413,7 +412,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // process that width up until it's impossible. This is faster than allocation the
                 // full components, which we skipped earlier.
                 if all_components_in_first_scan {
-                    let pull_row_ready = output.requested_raw_stripe().is_some();
+                    let pull_row_ready = output.requested_output_stripe().is_some();
                     if pull_row_ready {
                         let dc_predictions = core::array::from_fn(|idx| {
                             self.components
@@ -431,8 +430,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
                     match output {
                         McuDecodeOutput::Pixels(pixels) => {
+                            let output_stride =
+                                width * self.options.jpeg_get_out_colorspace().num_components();
                             self.post_process(
                                 pixels,
+                                output_stride,
                                 i,
                                 mcu_height,
                                 width,
@@ -444,6 +446,25 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         }
                         McuDecodeOutput::RawPlanes(raw_planes) => {
                             self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                        }
+                        McuDecodeOutput::Scanlines(scanlines) => {
+                            if scanlines.requested_stripe != i {
+                                return Err(DecodeErrors::FormatStatic(
+                                    "converted scanline output advanced out of sequence"
+                                ));
+                            }
+                            let mut stripe_written = 0;
+                            self.post_process(
+                                scanlines.pixels,
+                                scanlines.stride,
+                                i,
+                                mcu_height,
+                                width,
+                                padded_width,
+                                &mut stripe_written,
+                                upsampler_scratch_space
+                            )?;
+                            scanlines.rows_written = stripe_written / scanlines.stride;
                         }
                     }
                     if pull_row_ready {
@@ -472,7 +493,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     }
                     McuContinuation::Terminate => {
                         warn!("Got terminate signal, will not process further");
-                        if let Some(v) = output.pixels_mut().and_then(|p| p.get_mut(pixels_written..)) {
+                        if let Some(v) = output
+                            .pixels_mut()
+                            .and_then(|p| p.get_mut(pixels_written..))
+                        {
                             v.fill(128);
                         }
                         return Ok(());
@@ -598,7 +622,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         trace!("Finished decoding image");
 
-        output.mark_raw_source_complete();
+        output.mark_source_complete();
 
         Ok(())
     }
@@ -610,7 +634,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::cast_sign_loss)]
     pub(crate) fn finish_baseline_decoding(
         &mut self, block: &[Vec<i16>; MAX_COMPONENTS], _mcu_width: usize,
-        output: &mut McuDecodeOutput<'_, '_>,
+        output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         let mcu_height = self.mcu_y;
 
@@ -637,15 +661,15 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             comp.needed = raw_mode
                 || min(
                     self.options.jpeg_get_out_colorspace().num_components() - 1,
-                    pos,
+                    pos
                 ) == pos
                 || self.input_colorspace == ColorSpace::YCCK
                 || self.input_colorspace == ColorSpace::CMYK;
         }
 
         let mut pixels_written = 0;
-        let stripe_start = output.requested_raw_stripe().unwrap_or(0);
-        let stripe_end = if output.requested_raw_stripe().is_some() {
+        let stripe_start = output.requested_output_stripe().unwrap_or(0);
+        let stripe_end = if output.requested_output_stripe().is_some() {
             core::cmp::min(stripe_start + 1, mcu_height)
         } else {
             mcu_height
@@ -684,25 +708,40 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             match output {
                 McuDecodeOutput::Pixels(pixels) => self.post_process(
                     pixels,
+                    width * self.options.jpeg_get_out_colorspace().num_components(),
                     i,
                     mcu_height,
                     width,
                     padded_width,
                     &mut pixels_written,
-                    &mut upsampler_scratch_space,
+                    &mut upsampler_scratch_space
                 )?,
                 McuDecodeOutput::RawPlanes(raw_planes) => {
                     self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
                 }
+                McuDecodeOutput::Scanlines(scanlines) => {
+                    let mut stripe_written = 0;
+                    self.post_process(
+                        scanlines.pixels,
+                        scanlines.stride,
+                        i,
+                        mcu_height,
+                        width,
+                        padded_width,
+                        &mut stripe_written,
+                        &mut upsampler_scratch_space
+                    )?;
+                    scanlines.rows_written = stripe_written / scanlines.stride;
+                }
             }
         }
 
-        output.mark_raw_source_complete();
+        output.mark_source_complete();
 
         return Ok(());
     }
 
-    pub(crate) fn render_buffered_baseline_raw_stripe(
+    pub(crate) fn render_buffered_baseline_stripe(
         &mut self, output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         let block = core::mem::take(&mut self.progressive_mcus_buffer);
@@ -712,7 +751,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn decode_mcu_width<const PROGRESSIVE: bool, B: BitStream>(
-        &mut self, context: &mut McuWidthContext<'_, B>,
+        &mut self, context: &mut McuWidthContext<'_, B>
     ) -> Result<McuContinuation, DecodeErrors> {
         let is_one_by_one = !self.scan_subsampled;
 
@@ -739,7 +778,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     // the scan. The difference was ~1% or a bit more.
     #[allow(clippy::too_many_lines)]
     fn inner_decode_mcu_width<const PROGRESSIVE: bool, const SAMPLED: bool, B: BitStream>(
-        &mut self, context: &mut McuWidthContext<'_, B>,
+        &mut self, context: &mut McuWidthContext<'_, B>
     ) -> Result<McuContinuation, DecodeErrors> {
         // Destructure the context into local bindings up front. Reading the
         // hot loop through `context.<field>` keeps the optimizer from
@@ -799,7 +838,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 let (dc_table, ac_table) = B::get_dc_ac_tables(
                     &mut self.entropy_tables,
                     component.dc_huff_table % MAX_COMPONENTS,
-                    component.ac_huff_table % MAX_COMPONENTS,
+                    component.ac_huff_table % MAX_COMPONENTS
                 )?;
 
                 let qt_table = &component.quantization_table;
@@ -856,7 +895,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 qt_table,
                                 tmp,
                                 &mut component.dc_pred,
-                                &mut component.dc_diff,
+                                &mut component.dc_diff
                             )
                         } else {
                             // We do not touch tmp so there is no need to reset it.
@@ -864,7 +903,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 &mut self.stream,
                                 dc_table,
                                 ac_table,
-                                &mut component.dc_diff,
+                                &mut component.dc_diff
                             )
                         };
 
@@ -952,7 +991,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn check_stream_marker_after_mcu_width<B: BitStream>(
-        &mut self, stream: &mut B,
+        &mut self, stream: &mut B
     ) -> Result<McuContinuation, DecodeErrors> {
         // After all interleaved components, that's an MCU
         // handle stream markers
@@ -1020,7 +1059,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     // (parsing it would silently corrupt info.height).\n                    // Swallow the segment body so the stream stays consistent.
                     if self.options.strict_mode() {
                         return Err(DecodeErrors::Format(format!(
-                            "Marker {:?} found where not expected", m
+                            "Marker {:?} found where not expected",
+                            m
                         )));
                     }
                     error!("Unexpected DNL marker in Huffman stream, possibly corrupt jpeg");
@@ -1067,7 +1107,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// * `Ok(false)` - Found EOI, decoding complete
     /// * `Err(_)` - Error (too many markers, unexpected marker in strict mode, etc.)
     fn advance_to_next_sos<B: BitStream>(
-        &mut self, first_marker: Marker, stream: &mut B,
+        &mut self, first_marker: Marker, stream: &mut B
     ) -> Result<bool, DecodeErrors> {
         // Limit iterations to prevent DoS from malicious files.
         const MAX_INTER_SCAN_MARKERS: usize = 64;
@@ -1075,7 +1115,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let inter_scan_snapshot = if self.scan_checkpoint().is_some() {
             Some((
                 HeaderAppendStateSnapshot::capture(self),
-                self.capture_scan_header_state(),
+                self.capture_scan_header_state()
             ))
         } else {
             None
@@ -1155,7 +1195,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         Err(DecodeErrors::FormatStatic(
-            "Too many markers between scans (exceeded limit of 64)",
+            "Too many markers between scans (exceeded limit of 64)"
         ))
     }
 
@@ -1205,10 +1245,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
     #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     pub(crate) fn post_process(
-        &mut self, pixels: &mut [u8], i: usize, mcu_height: usize, width: usize,
-        padded_width: usize, pixels_written: &mut usize, upsampler_scratch_space: &mut [i16],
+        &mut self, pixels: &mut [u8], output_stride: usize, i: usize, mcu_height: usize,
+        width: usize, padded_width: usize, pixels_written: &mut usize,
+        upsampler_scratch_space: &mut [i16]
     ) -> Result<(), DecodeErrors> {
         let out_colorspace_components = self.options.jpeg_get_out_colorspace().num_components();
+        let row_bytes = width
+            .checked_mul(out_colorspace_components)
+            .ok_or(DecodeErrors::FormatStatic("output row size overflow"))?;
+        if output_stride < row_bytes {
+            return Err(DecodeErrors::FormatStatic(
+                "output stride is smaller than the converted row width"
+            ));
+        }
 
         let mut px = *pixels_written;
         // indicates whether image is vertically up-sampled
@@ -1229,7 +1278,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut color_conv_function =
             |num_iters: usize, samples: [&[i16]; 4]| -> Result<(), DecodeErrors> {
                 for (pos, output) in pixels[px..]
-                    .chunks_exact_mut(width * out_colorspace_components)
+                    .chunks_exact_mut(output_stride)
                     .take(num_iters)
                     .enumerate()
                 {
@@ -1249,11 +1298,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         self.color_convert_16,
                         self.input_colorspace,
                         self.options.jpeg_get_out_colorspace(),
-                        output,
+                        &mut output[..row_bytes],
                         width,
-                        padded_width,
+                        padded_width
                     )?;
-                    px += width * out_colorspace_components;
+                    px += output_stride;
                 }
                 Ok(())
             };
@@ -1267,7 +1316,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     mcu_height,
                     i,
                     upsampler_scratch_space,
-                    is_vertically_sampled,
+                    is_vertically_sampled
                 )?;
             }
 

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -245,45 +245,47 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
 
         'sos: loop {
+            let scan_mcu_height = if all_components_in_first_scan {
+                mcu_height
+            } else {
+                let z_scans = &self.z_order[..usize::from(self.num_scans)];
+                z_scans
+                    .iter()
+                    .map(|&component_index| {
+                        let component = &self.components[component_index];
+                        (self.info.height as usize * component.vertical_sample)
+                            .div_ceil(self.v_max * 8)
+                    })
+                    .min()
+                    .unwrap_or(mcu_height)
+            };
+
             trace!(
                 "Baseline decoding of components: {:?}",
                 &self.z_order[..usize::from(self.num_scans)]
             );
 
-            trace!("Decoding MCU width: {mcu_width}, height: {mcu_height}");
+            trace!("Decoding MCU width: {mcu_width}, height: {scan_mcu_height}");
 
-            // Consume the resume position once into locals so later SOS scans
-            // start at row 0, and so we don't mutate the loop's range bound
-            // from inside the loop below.
-            let current_resume_row = resume_row;
-            let current_resume_col = resume_col;
+            let scan_start_row = resume_row;
+            let scan_start_col = resume_col;
             resume_row = 0;
             resume_col = 0;
 
-            let scan_du_height = if all_components_in_first_scan {
-                mcu_height
-            } else {
-                let k = self.z_order.first().copied().unwrap_or(0);
-                if let Some(comp) = self.components.get(k) {
-                    (self.info.height as usize * comp.vertical_sample).div_ceil(self.v_max * 8)
-                } else {
-                    mcu_height
-                }
-            };
-
             let mut cancel = self.cancel_debounced(mcu_width);
-            for i in current_resume_row..scan_du_height {
-                let start_col = if i == current_resume_row {
-                    current_resume_col
-                } else {
-                    0
-                };
+            for i in scan_start_row..scan_mcu_height {
+                let start_col = if i == scan_start_row { scan_start_col } else { 0 };
+                if cancel.is_cancelled() {
+                    return Err(DecodeErrors::Cancelled);
+                }
                 if stream.overread_by() > 0 {
                     if self.scan_eof_is_error() {
                         return Err(DecodeErrors::ExhaustedData);
                     }
                     if all_components_in_first_scan {
-                        if let Some(remaining) = pixels.get_mut(pixels_written..) {
+                        if let Some(remaining) =
+                            output.pixels_mut().and_then(|pixels| pixels.get_mut(pixels_written..))
+                        {
                             remaining.fill(128);
                         }
                         return Ok(());
@@ -365,20 +367,27 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     Err(e) if e.is_recoverable_eof() && !self.scan_eof_is_error() => {
                         error!("{e}");
                         if all_components_in_first_scan {
-                            self.post_process(
-                                pixels,
-                                i,
-                                mcu_height,
-                                width,
-                                padded_width,
-                                &mut pixels_written,
-                                &mut upsampler_scratch_space,
-                            )?;
-                            self.pixels_decoded = pixels_written;
-                            if let Some(remaining) = pixels.get_mut(pixels_written..) {
-                                remaining.fill(128);
+                            match output {
+                                McuDecodeOutput::Pixels(pixels) => {
+                                    self.post_process(
+                                        pixels,
+                                        i,
+                                        mcu_height,
+                                        width,
+                                        padded_width,
+                                        &mut pixels_written,
+                                        &mut upsampler_scratch_space,
+                                    )?;
+                                    self.pixels_decoded = pixels_written;
+                                    if let Some(remaining) = pixels.get_mut(pixels_written..) {
+                                        remaining.fill(128);
+                                    }
+                                }
+                                McuDecodeOutput::RawPlanes(raw_planes) => {
+                                    self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                                }
                             }
-                        } else {
+                        } else if let Some(pixels) = output.pixels_mut() {
                             pixels.fill(128);
                         }
                         return Ok(());

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -153,15 +153,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // must not be re-zeroed. On a fresh decode they are (re-)allocated.
         let resuming = self.scan_checkpoint().is_some();
 
+        let raw_mode = self.raw_planes_sink.is_some();
+
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
             //
             // For special colorspaces i.e YCCK and CMYK, just allocate all of the needed
             // components.
-            if min(
-                self.options.jpeg_get_out_colorspace().num_components() - 1,
-                pos,
-            ) == pos
+            //
+            // Raw output needs every component regardless of output colorspace.
+            if raw_mode
+                || min(
+                    self.options.jpeg_get_out_colorspace().num_components() - 1,
+                    pos,
+                ) == pos
                 || comp_len == 4
             // Special colorspace
             {
@@ -382,16 +387,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // process that width up until it's impossible. This is faster than allocation the
                 // full components, which we skipped earlier.
                 if all_components_in_first_scan {
-                    self.post_process(
-                        pixels,
-                        i,
-                        mcu_height,
-                        width,
-                        padded_width,
-                        &mut pixels_written,
-                        &mut upsampler_scratch_space,
-                    )?;
-                    self.pixels_decoded = pixels_written;
+                    if self.raw_planes_sink.is_some() {
+                        self.copy_raw_planes_for_mcu_stripe(i)?;
+                    } else {
+                        self.post_process(
+                            pixels,
+                            i,
+                            mcu_height,
+                            width,
+                            padded_width,
+                            &mut pixels_written,
+                            &mut upsampler_scratch_space,
+                        )?;
+                        self.pixels_decoded = pixels_written;
+                    }
                     // This row's coefficient buffers can be reused next, so
                     // any checkpoint inside the row is no longer valid.
                     self.invalidate_scan_checkpoint();
@@ -569,12 +578,17 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
 
+        let raw_mode = self.raw_planes_sink.is_some();
+
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Mark only needed components for computing output colors.
-            comp.needed = min(
-                self.options.jpeg_get_out_colorspace().num_components() - 1,
-                pos,
-            ) == pos
+            //
+            // Raw output needs every component regardless of output colorspace.
+            comp.needed = raw_mode
+                || min(
+                    self.options.jpeg_get_out_colorspace().num_components() - 1,
+                    pos,
+                ) == pos
                 || self.input_colorspace == ColorSpace::YCCK
                 || self.input_colorspace == ColorSpace::CMYK;
         }
@@ -611,15 +625,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             // process that whole stripe of MCUs
-            self.post_process(
-                pixels,
-                i,
-                mcu_height,
-                width,
-                padded_width,
-                &mut pixels_written,
-                &mut upsampler_scratch_space,
-            )?;
+            if self.raw_planes_sink.is_some() {
+                self.copy_raw_planes_for_mcu_stripe(i)?;
+            } else {
+                self.post_process(
+                    pixels,
+                    i,
+                    mcu_height,
+                    width,
+                    padded_width,
+                    &mut pixels_written,
+                    &mut upsampler_scratch_space,
+                )?;
+            }
         }
 
         return Ok(());

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -371,8 +371,11 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         if all_components_in_first_scan {
                             match output {
                                 McuDecodeOutput::Pixels(pixels) => {
+                                    let output_stride = width
+                                        * self.options.jpeg_get_out_colorspace().num_components();
                                     self.post_process(
                                         pixels,
+                                        output_stride,
                                         i,
                                         mcu_height,
                                         width,
@@ -388,6 +391,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 McuDecodeOutput::RawPlanes(raw_planes) => {
                                     self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
                                 }
+                                McuDecodeOutput::Scanlines(_) => return Err(e),
                             }
                         } else if let Some(pixels) = output.pixels_mut() {
                             pixels.fill(128);

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -248,16 +248,13 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             let scan_mcu_height = if all_components_in_first_scan {
                 mcu_height
             } else {
-                let z_scans = &self.z_order[..usize::from(self.num_scans)];
-                z_scans
-                    .iter()
-                    .map(|&component_index| {
-                        let component = &self.components[component_index];
-                        (self.info.height as usize * component.vertical_sample)
-                            .div_ceil(self.v_max * 8)
-                    })
-                    .min()
-                    .unwrap_or(mcu_height)
+                let component_index = self.z_order.first().copied().unwrap_or(0);
+                if let Some(component) = self.components.get(component_index) {
+                    (self.info.height as usize * component.vertical_sample)
+                        .div_ceil(self.v_max * 8)
+                } else {
+                    mcu_height
+                }
             };
 
             trace!(

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -392,9 +392,37 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     Err(e) => return Err(e)
                 };
 
+                // A pull request must not publish a row assembled after the
+                // entropy reader exhausted visible input.
+                if output.requested_raw_stripe().is_some() && stream.overread_by() > 0 {
+                    return Err(DecodeErrors::ExhaustedData);
+                }
+                if output.requested_raw_stripe().is_some()
+                    && matches!(terminate, McuContinuation::Terminate)
+                    && !*stream.seen_eoi()
+                {
+                    return Err(DecodeErrors::ExhaustedData);
+                }
+
                 // process that width up until it's impossible. This is faster than allocation the
                 // full components, which we skipped earlier.
                 if all_components_in_first_scan {
+                    let pull_row_ready = output.requested_raw_stripe().is_some();
+                    if pull_row_ready {
+                        let dc_predictions = core::array::from_fn(|idx| {
+                            self.components
+                                .get(idx)
+                                .map_or((0, 0), |component| (component.dc_pred, component.dc_diff))
+                        });
+                        self.checkpoint_scan_with_bitstream(
+                            i + 1,
+                            0,
+                            pixels_written,
+                            dc_predictions,
+                            stream.snapshot_state()
+                        )?;
+                    }
+
                     match output {
                         McuDecodeOutput::Pixels(pixels) => {
                             self.post_process(
@@ -411,6 +439,9 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         McuDecodeOutput::RawPlanes(raw_planes) => {
                             self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
                         }
+                    }
+                    if pull_row_ready {
+                        return Ok(());
                     }
                     // This row's coefficient buffers can be reused next, so
                     // any checkpoint inside the row is no longer valid.
@@ -561,6 +592,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         trace!("Finished decoding image");
 
+        output.mark_raw_source_complete();
+
         Ok(())
     }
 
@@ -606,10 +639,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         let mut pixels_written = 0;
-        let mut cancel = self.cancel_debounced(self.mcu_x);
+        let stripe_start = output.requested_raw_stripe().unwrap_or(0);
+        let stripe_end = if output.requested_raw_stripe().is_some() {
+            core::cmp::min(stripe_start + 1, mcu_height)
+        } else {
+            mcu_height
+        };
 
         // dequantize and idct have been performed, only color convert.
-        for i in 0..mcu_height {
+        let mut cancel = self.cancel_debounced(self.mcu_x);
+        for i in stripe_start..stripe_end {
             if cancel.is_cancelled() {
                 return Err(DecodeErrors::Cancelled);
             }
@@ -653,7 +692,18 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
         }
 
+        output.mark_raw_source_complete();
+
         return Ok(());
+    }
+
+    pub(crate) fn render_buffered_baseline_raw_stripe(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        let block = core::mem::take(&mut self.progressive_mcus_buffer);
+        let result = self.finish_baseline_decoding(&block, 0, output);
+        self.progressive_mcus_buffer = block;
+        result
     }
 
     fn decode_mcu_width<const PROGRESSIVE: bool, B: BitStream>(

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -70,9 +70,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // `decode_into` retries, which is what lets scan checkpoints stay
         // allocation-free.
         let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
-        let result =
-            self.decode_mcu_ycbcr_baseline_inner::<B>(output, &mut progressive_mcus);
+        let mut upsampler_scratch = core::mem::take(&mut self.upsampler_scratch);
+        let result = self.decode_mcu_ycbcr_baseline_inner::<B>(
+            output,
+            &mut progressive_mcus,
+            &mut upsampler_scratch,
+        );
         self.progressive_mcus_buffer = progressive_mcus;
+        self.upsampler_scratch = upsampler_scratch;
         result
     }
 
@@ -93,7 +98,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[inline(never)]
     fn decode_mcu_ycbcr_baseline_inner<B: BitStream>(
         &mut self, output: &mut McuDecodeOutput<'_, '_>,
-        progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS]
+        progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS], upsampler_scratch_space: &mut Vec<i16>,
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
 
@@ -233,7 +238,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             stream.restore_snapshot(checkpoint.bitstream_state);
         }
 
-        let is_hv = usize::from(self.is_interleaved);
+        let is_hv = usize::from(self.is_interleaved && !raw_mode);
         let upsampler_scratch_size = is_hv
             * self
                 .components
@@ -242,7 +247,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 .max()
                 .unwrap_or(0)
             * 8;
-        let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
+        upsampler_scratch_space.clear();
+        upsampler_scratch_space.resize(upsampler_scratch_size, 0);
 
         'sos: loop {
             let scan_mcu_height = if all_components_in_first_scan {
@@ -373,7 +379,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                         width,
                                         padded_width,
                                         &mut pixels_written,
-                                        &mut upsampler_scratch_space,
+                                        upsampler_scratch_space,
                                     )?;
                                     self.pixels_decoded = pixels_written;
                                     if let Some(remaining) = pixels.get_mut(pixels_written..) {
@@ -432,7 +438,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 width,
                                 padded_width,
                                 &mut pixels_written,
-                                &mut upsampler_scratch_space,
+                                upsampler_scratch_space,
                             )?;
                             self.pixels_decoded = pixels_written;
                         }
@@ -609,7 +615,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mcu_height = self.mcu_y;
 
         // Size of our output image(width*height)
-        let is_hv = usize::from(self.is_interleaved);
+        let raw_mode = output.is_raw();
+        let is_hv = usize::from(self.is_interleaved && !raw_mode);
         let upsampler_scratch_size = is_hv
             * self
                 .components
@@ -622,8 +629,6 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let padded_width = calculate_padded_width(width, self.info.sample_ratio);
 
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
-
-        let raw_mode = output.is_raw();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Mark only needed components for computing output colors.

--- a/crates/zune-jpeg/src/mcu.rs
+++ b/crates/zune-jpeg/src/mcu.rs
@@ -17,7 +17,7 @@ use zune_core::log::{error, trace, warn};
 
 use crate::bitstream::BitStream;
 use crate::components::SampleRatios;
-use crate::decoder::{HeaderAppendStateSnapshot, MAX_COMPONENTS};
+use crate::decoder::{HeaderAppendStateSnapshot, McuDecodeOutput, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
 use crate::marker::Marker;
 use crate::mcu_prog::get_marker;
@@ -62,7 +62,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     ///
     /// This is the main decoder loop for the library, the hot path.
     pub(crate) fn decode_mcu_ycbcr_baseline<B: BitStream>(
-        &mut self, pixels: &mut [u8],
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         // Move the persistent multi-SOS coefficient buffer out of `self` so
         // the inner decoder can borrow it mutably while still calling methods
@@ -70,7 +70,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // `decode_into` retries, which is what lets scan checkpoints stay
         // allocation-free.
         let mut progressive_mcus = core::mem::take(&mut self.progressive_mcus_buffer);
-        let result = self.decode_mcu_ycbcr_baseline_inner::<B>(pixels, &mut progressive_mcus);
+        let result =
+            self.decode_mcu_ycbcr_baseline_inner::<B>(output, &mut progressive_mcus);
         self.progressive_mcus_buffer = progressive_mcus;
         result
     }
@@ -91,7 +92,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     )]
     #[inline(never)]
     fn decode_mcu_ycbcr_baseline_inner<B: BitStream>(
-        &mut self, pixels: &mut [u8], progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS],
+        &mut self, output: &mut McuDecodeOutput<'_, '_>,
+        progressive_mcus: &mut [Vec<i16>; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
 
@@ -153,7 +155,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         // must not be re-zeroed. On a fresh decode they are (re-)allocated.
         let resuming = self.scan_checkpoint().is_some();
 
-        let raw_mode = self.raw_planes_sink.is_some();
+        let raw_mode = output.is_raw();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
@@ -387,19 +389,22 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 // process that width up until it's impossible. This is faster than allocation the
                 // full components, which we skipped earlier.
                 if all_components_in_first_scan {
-                    if self.raw_planes_sink.is_some() {
-                        self.copy_raw_planes_for_mcu_stripe(i)?;
-                    } else {
-                        self.post_process(
-                            pixels,
-                            i,
-                            mcu_height,
-                            width,
-                            padded_width,
-                            &mut pixels_written,
-                            &mut upsampler_scratch_space,
-                        )?;
-                        self.pixels_decoded = pixels_written;
+                    match output {
+                        McuDecodeOutput::Pixels(pixels) => {
+                            self.post_process(
+                                pixels,
+                                i,
+                                mcu_height,
+                                width,
+                                padded_width,
+                                &mut pixels_written,
+                                &mut upsampler_scratch_space,
+                            )?;
+                            self.pixels_decoded = pixels_written;
+                        }
+                        McuDecodeOutput::RawPlanes(raw_planes) => {
+                            self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                        }
                     }
                     // This row's coefficient buffers can be reused next, so
                     // any checkpoint inside the row is no longer valid.
@@ -424,7 +429,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     }
                     McuContinuation::Terminate => {
                         warn!("Got terminate signal, will not process further");
-                        if let Some(v) = pixels.get_mut(pixels_written..) {
+                        if let Some(v) = output.pixels_mut().and_then(|p| p.get_mut(pixels_written..)) {
                             v.fill(128);
                         }
                         return Ok(());
@@ -516,7 +521,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         if !all_components_in_first_scan {
-            self.finish_baseline_decoding(progressive_mcus, mcu_width, pixels)?;
+            self.finish_baseline_decoding(progressive_mcus, mcu_width, output)?;
         }
 
         // it may happen that some images don't have the whole buffer
@@ -559,7 +564,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::cast_sign_loss)]
     pub(crate) fn finish_baseline_decoding(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], _mcu_width: usize, pixels: &mut [u8],
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], _mcu_width: usize,
+        output: &mut McuDecodeOutput<'_, '_>,
     ) -> Result<(), DecodeErrors> {
         let mcu_height = self.mcu_y;
 
@@ -578,7 +584,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
 
-        let raw_mode = self.raw_planes_sink.is_some();
+        let raw_mode = output.is_raw();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Mark only needed components for computing output colors.
@@ -625,10 +631,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             // process that whole stripe of MCUs
-            if self.raw_planes_sink.is_some() {
-                self.copy_raw_planes_for_mcu_stripe(i)?;
-            } else {
-                self.post_process(
+            match output {
+                McuDecodeOutput::Pixels(pixels) => self.post_process(
                     pixels,
                     i,
                     mcu_height,
@@ -636,7 +640,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     padded_width,
                     &mut pixels_written,
                     &mut upsampler_scratch_space,
-                )?;
+                )?,
+                McuDecodeOutput::RawPlanes(raw_planes) => {
+                    self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                }
             }
         }
 

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -178,7 +178,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         self.succ_high,
                         self.succ_low,
                         self.spec_start,
-                        self.spec_end,
+                        self.spec_end
                     );
                     if !self.decode_progressive_scan(
                         &mut stream,
@@ -244,7 +244,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
         }
 
-    self.finish_progressive_decoding(block, output)
+        self.finish_progressive_decoding(block, output)
     }
 
     fn decode_progressive_scan<B: BitStream>(
@@ -396,8 +396,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 
     fn handle_progressive_inter_scan_error(
         &mut self, error: DecodeErrors, block: &[Vec<i16>; MAX_COMPONENTS],
-        output: &mut McuDecodeOutput<'_, '_>,
-        preserve_completed_scans: bool
+        output: &mut McuDecodeOutput<'_, '_>, preserve_completed_scans: bool
     ) -> Result<(), DecodeErrors> {
         if matches!(error, DecodeErrors::Cancelled) {
             return Err(error);
@@ -517,7 +516,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             // Safety checks
             if self.spec_end != 0 && self.spec_start == 0 {
                 return Err(DecodeErrors::FormatStatic(
-                    "Can't merge DC and AC corrupt jpeg",
+                    "Can't merge DC and AC corrupt jpeg"
                 ));
             }
 
@@ -546,7 +545,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         } else {
             if self.spec_end != 0 {
                 return Err(DecodeErrors::HuffmanDecode(
-                    "Can't merge dc and AC corrupt jpeg".to_string(),
+                    "Can't merge dc and AC corrupt jpeg".to_string()
                 ));
             }
 
@@ -612,7 +611,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         dc_table,
                         dc_pred,
                         &mut component.dc_pred,
-                        &mut component.dc_diff,
+                        &mut component.dc_diff
                     )?;
 
                     self.todo -= 1;
@@ -625,7 +624,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_dc_refine_non_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let width_stride = self.components[k].width_stride / 8;
@@ -651,7 +650,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_ac_first_non_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
@@ -691,7 +690,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_ac_refine_non_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize,
+        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS], k: usize
     ) -> Result<(), DecodeErrors> {
         let (mcu_width, mcu_height) = self.get_non_interleaved_dimensions(k);
         let ac_pos = self.components[k].ac_huff_table;
@@ -754,7 +753,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                                 huff_table,
                                 data,
                                 &mut component.dc_pred,
-                                &mut component.dc_diff,
+                                &mut component.dc_diff
                             )?;
                         }
                     }
@@ -768,7 +767,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn parse_dc_refine_interleaved<B: BitStream>(
-        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS],
+        &mut self, stream: &mut B, buffer: &mut [Vec<i16>; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         let mut cancel = self.cancel_debounced(self.mcu_x);
         for i in 0..self.mcu_y {
@@ -814,7 +813,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// [`Self::handle_rst_main_with_status`] instead.
     #[allow(clippy::used_underscore_binding)]
     pub(crate) fn handle_rst_main<B: BitStream>(
-        &mut self, stream: &mut B,
+        &mut self, stream: &mut B
     ) -> Result<(), DecodeErrors> {
         self.handle_rst_main_inner(stream).map(|_| ())
     }
@@ -895,7 +894,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     /// the two formulations could disagree — `todo == 0`, no marker, no
     /// interval — is unreachable.
     pub(crate) fn handle_rst_main_with_status<B: BitStream>(
-        &mut self, stream: &mut B,
+        &mut self, stream: &mut B
     ) -> Result<bool, DecodeErrors> {
         let was_due = self.todo == 0;
         let handled_restart = self.handle_rst_main_inner(stream)?;
@@ -984,8 +983,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         let mut pixels_written = 0;
-        let stripe_start = output.requested_raw_stripe().unwrap_or(0);
-        let stripe_end = if output.requested_raw_stripe().is_some() {
+        let stripe_start = output.requested_output_stripe().unwrap_or(0);
+        let stripe_end = if output.requested_output_stripe().is_some() {
             core::cmp::min(stripe_start + 1, mcu_height)
         } else {
             mcu_height
@@ -1035,7 +1034,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         // See https://github.com/etemesi254/zune-image/issues/262 sample 3.
                         let Some(qt_slice) = slice.get(start..start + 64) else {
                             return Err(DecodeErrors::FormatStatic(
-                                "Invalid slice , would panic, invalid image",
+                                "Invalid slice , would panic, invalid image"
                             ));
                         };
                         // dequantize
@@ -1066,6 +1065,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             match output {
                 McuDecodeOutput::Pixels(pixels) => self.post_process(
                     pixels,
+                    width * self.options.jpeg_get_out_colorspace().num_components(),
                     i,
                     mcu_height,
                     width,
@@ -1076,10 +1076,24 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 McuDecodeOutput::RawPlanes(raw_planes) => {
                     self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
                 }
+                McuDecodeOutput::Scanlines(scanlines) => {
+                    let mut stripe_written = 0;
+                    self.post_process(
+                        scanlines.pixels,
+                        scanlines.stride,
+                        i,
+                        mcu_height,
+                        width,
+                        padded_width,
+                        &mut stripe_written,
+                        &mut upsampler_scratch_space
+                    )?;
+                    scanlines.rows_written = stripe_written / scanlines.stride;
+                }
             }
         }
 
-        output.mark_raw_source_complete();
+        output.mark_source_complete();
 
         trace!("Finished decoding image");
 
@@ -1088,7 +1102,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         return Ok(());
     }
 
-    pub(crate) fn render_buffered_progressive_raw_stripe(
+    pub(crate) fn render_buffered_progressive_stripe(
         &mut self, output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         let block = core::mem::take(&mut self.progressive_mcus_buffer);
@@ -1120,10 +1134,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
 ///
 /// This reads until it gets a marker or end of file is encountered
 pub fn get_marker<T, B: BitStream>(
-    reader: &mut ZReader<T>, stream: &mut B,
+    reader: &mut ZReader<T>, stream: &mut B
 ) -> Result<Marker, DecodeErrors>
 where
-    T: ZByteReaderTrait,
+    T: ZByteReaderTrait
 {
     if let Some(marker) = stream.marker().take() {
         return Ok(marker);
@@ -1332,7 +1346,7 @@ mod tests {
             0x3f, 0x21, 0xf1, 0x1f, 0xff, 0xda, 0x00, 0x08, 0x01, 0x01, 0x00, 0x03, 0x3f, 0x10,
             0xd2, 0x57, 0xa9, 0xa4, 0xd2, 0x7f, 0xff, 0xda, 0x00, 0x08, 0x01, 0x02, 0x00, 0x03,
             0x3f, 0x10, 0xb3, 0xff, 0xda, 0x00, 0x08, 0x01, 0x03, 0x00, 0x03, 0x3f, 0x10, 0xfa,
-            0x8f, 0xff, 0xd9,
+            0x8f, 0xff, 0xd9
         ];
 
         let mut decoder = JpegDecoder::new(ZCursor::new(JPEG));
@@ -1385,7 +1399,7 @@ mod tests {
             248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248, 248,
             248, 248, 248, 248, 248, 248, 248, 255, 192, 0, 17, 8, 0, 32, 0, 32, 3, 1, 34, 0, 2,
             17, 1, 3, 17, 1, 255, 196, 0, 24, 0, 1, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            2, 0, 126, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 198,
+            2, 0, 126, 0, 0, 0, 0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 198
         ]);
         let mut decoder = JpegDecoder::new(data);
         decoder.decode().unwrap();

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -950,15 +950,20 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
         let mut tmp = [0_i32; DCT_BLOCK];
 
+        let raw_mode = self.raw_planes_sink.is_some();
+
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
             //
             // For special colorspaces i.e YCCK and CMYK, just allocate all of the needed
             // components.
-            if min(
-                self.options.jpeg_get_out_colorspace().num_components() - 1,
-                pos,
-            ) == pos
+            //
+            // Raw output needs every component regardless of output colorspace.
+            if raw_mode
+                || min(
+                    self.options.jpeg_get_out_colorspace().num_components() - 1,
+                    pos
+                ) == pos
                 || self.input_colorspace == ColorSpace::YCCK
                 || self.input_colorspace == ColorSpace::CMYK
             {
@@ -1048,15 +1053,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             // process that width up until it's impossible
-            self.post_process(
-                pixels,
-                i,
-                mcu_height,
-                width,
-                padded_width,
-                &mut pixels_written,
-                &mut upsampler_scratch_space,
-            )?;
+            if self.raw_planes_sink.is_some() {
+                self.copy_raw_planes_for_mcu_stripe(i)?;
+            } else {
+                self.post_process(
+                    pixels,
+                    i,
+                    mcu_height,
+                    width,
+                    padded_width,
+                    &mut pixels_written,
+                    &mut upsampler_scratch_space
+                )?;
+            }
         }
 
         trace!("Finished decoding image");

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -19,7 +19,7 @@ use zune_core::log::{error, trace, warn};
 
 use crate::bitstream::BitStream;
 use crate::components::SampleRatios;
-use crate::decoder::{JpegDecoder, ProgressiveFineCheckpoint, MAX_COMPONENTS};
+use crate::decoder::{JpegDecoder, McuDecodeOutput, ProgressiveFineCheckpoint, MAX_COMPONENTS};
 use crate::errors::DecodeErrors;
 use crate::headers::parse_sos;
 use crate::marker::Marker;
@@ -46,14 +46,17 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     )]
     #[inline(never)]
     pub(crate) fn decode_mcu_ycbcr_progressive<B: BitStream>(
-        &mut self, pixels: &mut [u8],
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         // Move the coefficient buffers out so scan helpers can borrow `self`
         // while receiving the buffers separately.
         let mut block = core::mem::take(&mut self.progressive_mcus_buffer);
         let mut scan_block = core::mem::take(&mut self.progressive_scan_buffer);
-        let result =
-            self.decode_mcu_ycbcr_progressive_inner::<B>(pixels, &mut block, &mut scan_block);
+        let result = self.decode_mcu_ycbcr_progressive_inner::<B>(
+            output,
+            &mut block,
+            &mut scan_block,
+        );
         if matches!(&result, Err(error) if error.is_recoverable_eof() || matches!(error, DecodeErrors::Cancelled)) {
             self.progressive_scan_buffer = scan_block;
         }
@@ -68,8 +71,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         clippy::too_many_lines
     )]
     fn decode_mcu_ycbcr_progressive_inner<B: BitStream>(
-        &mut self, pixels: &mut [u8], block: &mut [Vec<i16>; MAX_COMPONENTS],
-        scan_block: &mut [Vec<i16>; MAX_COMPONENTS]
+        &mut self, output: &mut McuDecodeOutput<'_, '_>, block: &mut [Vec<i16>; MAX_COMPONENTS]
+        , scan_block: &mut [Vec<i16>; MAX_COMPONENTS]
     ) -> Result<(), DecodeErrors> {
         setup_component_params(self)?;
         let mut mcu_height;
@@ -133,10 +136,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             &mut stream,
             block,
             scan_block,
-            pixels,
+            output,
             preserve_progressive_scans,
         )? {
-            return self.finish_progressive_decoding(block, pixels);
+            return self.finish_progressive_decoding(block, output);
         }
         if self.progressive_completed_scans > self.options.jpeg_get_max_scans() {
             return Err(DecodeErrors::Format(format!(
@@ -151,7 +154,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 return self.handle_progressive_inter_scan_error(
                     e,
                     block,
-                    pixels,
+                    output,
                     preserve_progressive_scans
                 )
             }
@@ -166,7 +169,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         return self.handle_progressive_inter_scan_error(
                             e,
                             block,
-                            pixels,
+                            output,
                             preserve_progressive_scans
                         );
                     }
@@ -181,7 +184,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         &mut stream,
                         block,
                         scan_block,
-                        pixels,
+                        output,
                         preserve_progressive_scans
                     )? {
                         break 'eoi;
@@ -205,7 +208,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                             return self.handle_progressive_inter_scan_error(
                                 e,
                                 block,
-                                pixels,
+                                output,
                                 preserve_progressive_scans
                             )
                         }
@@ -219,7 +222,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                         return self.handle_progressive_inter_scan_error(
                             e,
                             block,
-                            pixels,
+                            output,
                             preserve_progressive_scans
                         );
                     }
@@ -234,19 +237,19 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     return self.handle_progressive_inter_scan_error(
                         e,
                         block,
-                        pixels,
+                        output,
                         preserve_progressive_scans
                     )
                 }
             }
         }
 
-        self.finish_progressive_decoding(block, pixels)
+    self.finish_progressive_decoding(block, output)
     }
 
     fn decode_progressive_scan<B: BitStream>(
         &mut self, stream: &mut B, block: &mut [Vec<i16>; MAX_COMPONENTS],
-        scan_block: &mut [Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        scan_block: &mut [Vec<i16>; MAX_COMPONENTS], output: &mut McuDecodeOutput<'_, '_>,
         use_scratch_coefficients: bool
     ) -> Result<bool, DecodeErrors> {
         if !use_scratch_coefficients {
@@ -296,14 +299,14 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 if fine_resume.is_some() {
                     self.invalidate_progressive_fine_checkpoint();
                 }
-                self.finish_progressive_partial(block, pixels)?;
+                self.finish_progressive_partial(block, output)?;
                 return Err(e);
             }
             if self.stream.eof()? && self.scan_eof_is_error() {
                 if fine_resume.is_some() {
                     self.invalidate_progressive_fine_checkpoint();
                 }
-                self.finish_progressive_partial(block, pixels)?;
+                self.finish_progressive_partial(block, output)?;
                 return Err(DecodeErrors::ExhaustedData);
             }
             if self.options.strict_mode() {
@@ -328,7 +331,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                 if fine_resume.is_some() {
                     self.invalidate_progressive_fine_checkpoint();
                 }
-                self.finish_progressive_partial(block, pixels)?;
+                self.finish_progressive_partial(block, output)?;
                 return Err(DecodeErrors::ExhaustedData);
             }
             error!("{}", DecodeErrors::ExhaustedData);
@@ -392,7 +395,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn handle_progressive_inter_scan_error(
-        &mut self, error: DecodeErrors, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        &mut self, error: DecodeErrors, block: &[Vec<i16>; MAX_COMPONENTS],
+        output: &mut McuDecodeOutput<'_, '_>,
         preserve_completed_scans: bool
     ) -> Result<(), DecodeErrors> {
         if matches!(error, DecodeErrors::Cancelled) {
@@ -400,7 +404,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
         if error.is_recoverable_eof() && self.scan_eof_is_error() {
             if preserve_completed_scans {
-                self.finish_progressive_partial(block, pixels)?;
+                self.finish_progressive_partial(block, output)?;
             } else {
                 self.discard_progressive_partial();
             }
@@ -410,7 +414,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             return Err(error);
         }
         error!("{error}");
-        self.finish_progressive_decoding(block, pixels)
+        self.finish_progressive_decoding(block, output)
     }
 
     fn discard_progressive_partial(&mut self) {
@@ -422,7 +426,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     }
 
     fn finish_progressive_partial(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8]
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         if self.progressive_completed_scans == 0 {
             self.pixels_decoded = 0;
@@ -431,7 +435,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         if self.progressive_displayed_scans != self.progressive_completed_scans {
-            self.finish_progressive_decoding(block, pixels)?;
+            self.finish_progressive_decoding(block, output)?;
             self.progressive_displayed_scans = self.progressive_completed_scans;
         }
         self.pixels_decoded = 0;
@@ -900,7 +904,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::needless_range_loop, clippy::cast_sign_loss)]
     fn finish_progressive_decoding(
-        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], pixels: &mut [u8],
+        &mut self, block: &[Vec<i16>; MAX_COMPONENTS], output: &mut McuDecodeOutput<'_, '_>
     ) -> Result<(), DecodeErrors> {
         // Rendering replaces the caller's output row by row. Until every row
         // succeeds, the buffer may contain a mix of preview generations and
@@ -950,7 +954,7 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         let mut upsampler_scratch_space = vec![0; upsampler_scratch_size];
         let mut tmp = [0_i32; DCT_BLOCK];
 
-        let raw_mode = self.raw_planes_sink.is_some();
+        let raw_mode = output.is_raw();
 
         for (pos, comp) in self.components.iter_mut().enumerate() {
             // Allocate only needed components.
@@ -1053,10 +1057,8 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
 
             // process that width up until it's impossible
-            if self.raw_planes_sink.is_some() {
-                self.copy_raw_planes_for_mcu_stripe(i)?;
-            } else {
-                self.post_process(
+            match output {
+                McuDecodeOutput::Pixels(pixels) => self.post_process(
                     pixels,
                     i,
                     mcu_height,
@@ -1064,7 +1066,10 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
                     padded_width,
                     &mut pixels_written,
                     &mut upsampler_scratch_space
-                )?;
+                )?,
+                McuDecodeOutput::RawPlanes(raw_planes) => {
+                    self.copy_raw_planes_for_mcu_stripe(i, raw_planes)?;
+                }
             }
         }
 

--- a/crates/zune-jpeg/src/mcu_prog.rs
+++ b/crates/zune-jpeg/src/mcu_prog.rs
@@ -984,10 +984,16 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
         }
 
         let mut pixels_written = 0;
+        let stripe_start = output.requested_raw_stripe().unwrap_or(0);
+        let stripe_end = if output.requested_raw_stripe().is_some() {
+            core::cmp::min(stripe_start + 1, mcu_height)
+        } else {
+            mcu_height
+        };
 
         // dequantize, idct and color convert.
         let mut cancel = self.cancel_debounced(self.mcu_x);
-        for i in 0..mcu_height {
+        for i in stripe_start..stripe_end {
             if cancel.is_cancelled() {
                 return Err(DecodeErrors::Cancelled);
             }
@@ -1073,12 +1079,24 @@ impl<T: ZByteReaderTrait> JpegDecoder<T> {
             }
         }
 
+        output.mark_raw_source_complete();
+
         trace!("Finished decoding image");
 
         self.progressive_render_incomplete = false;
 
         return Ok(());
     }
+
+    pub(crate) fn render_buffered_progressive_raw_stripe(
+        &mut self, output: &mut McuDecodeOutput<'_, '_>
+    ) -> Result<(), DecodeErrors> {
+        let block = core::mem::take(&mut self.progressive_mcus_buffer);
+        let result = self.finish_progressive_decoding(&block, output);
+        self.progressive_mcus_buffer = block;
+        result
+    }
+
     pub(crate) fn reset_params(&mut self) {
         /*
         Apparently, grayscale images which can be down sampled exists, which is weird in the sense

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -64,6 +64,50 @@ fn decode_raw_into_owned(bytes: &[u8]) -> Vec<Vec<u8>> {
 }
 
 #[test]
+fn decode_raw_matches_libjpeg_turbo_with_idct_tolerance() {
+    // Logical samples produced by libjpeg-turbo 2.1.5 through
+    // jpeg_read_raw_data. Rows in this 16x16 fixture are constant, keeping
+    // the independent oracle compact while still checking every sample.
+    let expected_rows = [
+        [
+            76, 74, 70, 66, 64, 60, 56, 54, 51, 49, 45, 41, 39, 35, 31, 29,
+        ],
+        [
+            85, 95, 108, 120, 129, 141, 154, 164, 176, 186, 200, 211, 221, 232, 245, 255,
+        ],
+        [
+            255, 247, 235, 225, 218, 208, 196, 187, 176, 167, 155, 145, 138, 128, 116, 107,
+        ],
+    ];
+    let bytes = include_bytes!("../../../test-images/jpeg/tiny_non_interleaved_444.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..3)
+        .map(|index| vec![0; layout[index].byte_size])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    raw.decode_into(&mut refs).unwrap();
+
+    for (plane_index, expected) in expected_rows.iter().enumerate() {
+        assert_eq!(
+            (layout[plane_index].width, layout[plane_index].height),
+            (16, 16)
+        );
+        for (row, expected_sample) in expected.iter().enumerate() {
+            for column in 0..16 {
+                let actual = planes[plane_index][row * layout[plane_index].stride + column];
+                assert!(
+                    actual.abs_diff(*expected_sample) <= 2,
+                    "plane {plane_index} sample ({column},{row}) differs from libjpeg-turbo: {actual} vs {expected_sample}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
 fn decode_raw_rejects_wrong_plane_count() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -656,3 +656,25 @@ fn component_ids_returns_none_before_headers() {
     let raw = decoder.raw_output();
     assert!(raw.component_ids().is_none());
 }
+
+#[test]
+fn dnl_whole_raw_apis_are_rejected_before_false_completion() {
+    let bytes = include_bytes!("images/dnl_image.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let mut planes = [];
+
+    assert!(matches!(
+        raw.decode_into(&mut planes),
+        Err(DecodeErrors::FormatStatic(
+            "raw output does not support DNL images"
+        ))
+    ));
+    assert!(matches!(
+        raw.decode_into_strided(&mut planes, &[]),
+        Err(DecodeErrors::FormatStatic(
+            "raw output does not support DNL images"
+        ))
+    ));
+}

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -11,14 +11,6 @@
 //! Mirrors libjpeg-turbo's `jpeg_read_raw_data` semantics: each component's
 //! post-IDCT samples are written directly into a caller-provided plane,
 //! skipping upsampling and color conversion.
-//!
-//! Note: the existing baseline decoder has a long-standing layout quirk for
-//! `non_interleaved_*` fixtures (each component in its own SOS) where the
-//! per-stripe data is not laid out contiguously in `progressive_mcus`. The
-//! existing `post_process` path papers over this; the raw bypass faithfully
-//! reflects what the decoder actually writes, so non-interleaved fixtures
-//! are exercised only for API surface (validation, plane sizing) and not
-//! for sample-content sanity.
 
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::errors::DecodeErrors;
@@ -310,36 +302,26 @@ fn ycbcr_to_rgb(y: u8, cb: u8, cr: u8) -> [u8; 3] {
     ]
 }
 
-#[test]
-fn decode_raw_content_matches_decode_within_upsample_tolerance() {
-    // Decode the same image two ways and assert the planes, after
-    // nearest-neighbour upsampling and JFIF YCbCr -> RGB, are statistically
-    // close to the regular RGB output. This guards against plane-ordering,
-    // stride, and clamp-cast regressions.
-    //
-    // Tolerance is loose because zune-jpeg uses a fancier upsampler than the
-    // nearest-neighbour we apply in test code; we only assert that the mean
-    // absolute difference per channel is small.
-    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
-
+fn assert_raw_content_matches_decode_within_upsample_tolerance(
+    name: &str, bytes: &[u8], max_mean_delta: u64
+) {
     let rgb = {
-        let mut d = JpegDecoder::new(ZCursor::new(bytes));
-        d.decode().unwrap()
+        let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+        decoder.decode().unwrap()
     };
 
-    let mut d2 = JpegDecoder::new(ZCursor::new(bytes));
-    d2.decode_headers().unwrap();
-    let (w, h) = d2.dimensions().unwrap();
-    let layout = d2.planar_layout().unwrap();
-    let n = d2.num_components().unwrap();
-    assert_eq!(n, 3);
+    let mut raw_decoder = JpegDecoder::new(ZCursor::new(bytes));
+    raw_decoder.decode_headers().unwrap();
+    let (w, h) = raw_decoder.dimensions().unwrap();
+    let layout = raw_decoder.planar_layout().unwrap();
+    let n = raw_decoder.num_components().unwrap();
+    assert_eq!(n, 3, "{name}: expected YCbCr fixture");
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        d2.decode_raw(&mut refs).unwrap();
+        raw_decoder.decode_raw(&mut refs).unwrap();
     }
 
-    // Upsample Cb / Cr to Y dimensions.
     let y_up = nearest_upsample(
         &planes[0],
         layout[0].width,
@@ -381,13 +363,54 @@ fn decode_raw_content_matches_decode_within_upsample_tolerance() {
     let avg_dr = sum_dr / total;
     let avg_dg = sum_dg / total;
     let avg_db = sum_db / total;
+    assert!(
+        avg_dr < max_mean_delta && avg_dg < max_mean_delta && avg_db < max_mean_delta,
+        "{name}: mean abs RGB delta too large: dr={avg_dr} dg={avg_dg} db={avg_db}"
+    );
+}
+
+#[test]
+fn decode_raw_content_matches_decode_within_upsample_tolerance() {
+    // Decode the same image two ways and assert the planes, after
+    // nearest-neighbour upsampling and JFIF YCbCr -> RGB, are statistically
+    // close to the regular RGB output. This guards against plane-ordering,
+    // stride, and clamp-cast regressions.
+    //
+    // Tolerance is loose because zune-jpeg uses a fancier upsampler than the
+    // nearest-neighbour we apply in test code; we only assert that the mean
+    // absolute difference per channel is small.
     // A plane swap, stride bug, or wrong YCbCr->RGB matrix would produce
     // mean absolute deltas in the dozens; nearest-vs-fancy-upsample alone
     // typically produces single-digit deltas on photographic content.
-    assert!(
-        avg_dr < 12 && avg_dg < 12 && avg_db < 12,
-        "mean abs RGB delta too large: dr={avg_dr} dg={avg_dg} db={avg_db}"
+    assert_raw_content_matches_decode_within_upsample_tolerance(
+        "interleaved_420",
+        include_bytes!("../../../test-images/jpeg/2029.jpg"),
+        12
     );
+}
+
+#[test]
+fn decode_raw_non_interleaved_content_matches_decode() {
+    for (name, bytes) in [
+        (
+            "non_interleaved_444",
+            &include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg")[..]
+        ),
+        (
+            "non_interleaved_420",
+            &include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg")[..]
+        ),
+        (
+            "non_interleaved_422",
+            &include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg")[..]
+        ),
+        (
+            "non_interleaved_440",
+            &include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg")[..]
+        )
+    ] {
+        assert_raw_content_matches_decode_within_upsample_tolerance(name, bytes, 24);
+    }
 }
 
 // decode_raw_strided: Skia-style logically-sized planes.

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -1,0 +1,590 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+//! Tests for `JpegDecoder::decode_raw()`.
+//!
+//! Mirrors libjpeg-turbo's `jpeg_read_raw_data` semantics: each component's
+//! post-IDCT samples are written directly into a caller-provided plane,
+//! skipping upsampling and color conversion.
+//!
+//! Note: the existing baseline decoder has a long-standing layout quirk for
+//! `non_interleaved_*` fixtures (each component in its own SOS) where the
+//! per-stripe data is not laid out contiguously in `progressive_mcus`. The
+//! existing `post_process` path papers over this; the raw bypass faithfully
+//! reflects what the decoder actually writes, so non-interleaved fixtures
+//! are exercised only for API surface (validation, plane sizing) and not
+//! for sample-content sanity.
+
+use zune_core::bytestream::ZCursor;
+use zune_jpeg::errors::DecodeErrors;
+use zune_jpeg::JpegDecoder;
+
+/// Allocate per-plane buffers sized to the layout reported by
+/// `planar_layout()`, then run `decode_raw` and return the populated planes.
+fn decode_raw_into_owned(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().expect("decode_headers");
+    let n = decoder.num_components().expect("num_components");
+    let layout = decoder.planar_layout().expect("planar_layout");
+
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw(&mut refs).expect("decode_raw");
+    }
+    planes
+}
+
+#[test]
+fn decode_raw_rejects_wrong_plane_count() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    // 3-component image, pass 2 planes.
+    let mut p0 = vec![0u8; layout[0].byte_size];
+    let mut p1 = vec![0u8; layout[1].byte_size];
+    let mut refs: [&mut [u8]; 2] = [&mut p0, &mut p1];
+    let err = decoder.decode_raw(&mut refs).unwrap_err();
+    match err {
+        DecodeErrors::Format(_) => {}
+        other => panic!("expected Format error, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_rejects_too_small_plane() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let mut p0 = vec![0u8; layout[0].byte_size - 1]; // one byte short
+    let mut p1 = vec![0u8; layout[1].byte_size];
+    let mut p2 = vec![0u8; layout[2].byte_size];
+    let mut refs: [&mut [u8]; 3] = [&mut p0, &mut p1, &mut p2];
+    let err = decoder.decode_raw(&mut refs).unwrap_err();
+    match err {
+        DecodeErrors::TooSmallOutput(need, got) => {
+            assert_eq!(need, layout[0].byte_size);
+            assert_eq!(got, layout[0].byte_size - 1);
+        }
+        other => panic!("expected TooSmallOutput, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_rejects_more_than_four_sof_components() {
+    const FIVE_COMPONENTS: &[u8] = &[
+        0xff, 0xd8, // SOI
+        0xff, 0xc0, // SOF0
+        0x00, 0x17, // length = 8 + 3 * 5
+        0x08, // precision
+        0x00, 0x01, // height
+        0x00, 0x01, // width
+        0x05, // components
+        1, 0x11, 0,
+        2, 0x11, 0,
+        3, 0x11, 0,
+        4, 0x11, 0,
+        5, 0x11, 0
+    ];
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(FIVE_COMPONENTS));
+    let err = decoder.decode_headers().unwrap_err();
+    match err {
+        DecodeErrors::SofError(_) => {}
+        other => panic!("expected SofError, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_interleaved_420_full_range() {
+    // 388x477 4:2:0 photographic JPEG, all 3 components in a single SOS.
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let planes = decode_raw_into_owned(bytes);
+    assert_eq!(planes.len(), 3);
+
+    // Photographic content: each plane should span a wide range and the
+    // chroma planes should be centred near 128 (neutral).
+    let y_min = *planes[0].iter().min().unwrap();
+    let y_max = *planes[0].iter().max().unwrap();
+    assert!(
+        y_max - y_min > 100,
+        "Y plane range too narrow: {y_min}..{y_max}"
+    );
+    for (idx, plane) in planes[1..].iter().enumerate() {
+        let pmin = *plane.iter().min().unwrap();
+        let pmax = *plane.iter().max().unwrap();
+        assert!(pmax > pmin, "chroma plane {} appears constant", idx + 1);
+        let avg: u64 = plane.iter().map(|&v| v as u64).sum::<u64>() / plane.len() as u64;
+        assert!(
+            (96..=160).contains(&avg),
+            "chroma plane {} avg {} not in expected near-neutral band",
+            idx + 1,
+            avg
+        );
+    }
+}
+
+#[test]
+fn decode_raw_interleaved_420_deterministic() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let a = decode_raw_into_owned(bytes);
+    let b = decode_raw_into_owned(bytes);
+    assert_eq!(a, b);
+}
+
+#[test]
+fn decode_raw_interleaved_no_subsampling() {
+    // 4:4:4 image where every plane has the same dimensions.
+    let bytes = include_bytes!("../../../test-images/jpeg/medium_no_samp_2500x1786.jpg");
+    let planes = decode_raw_into_owned(bytes);
+    assert_eq!(planes.len(), 3);
+    assert_eq!(planes[0].len(), planes[1].len());
+    assert_eq!(planes[1].len(), planes[2].len());
+    for (i, plane) in planes.iter().enumerate() {
+        let pmin = *plane.iter().min().unwrap();
+        let pmax = *plane.iter().max().unwrap();
+        assert!(pmax > pmin, "plane {i} appears constant");
+    }
+}
+
+#[test]
+fn decode_raw_grayscale_progressive_single_plane() {
+    let bytes = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let n = decoder.num_components().unwrap();
+    assert_eq!(n, 1, "expected grayscale (1 component)");
+    let layout = decoder.planar_layout().unwrap();
+    let mut p = vec![0u8; layout[0].byte_size];
+    {
+        let mut refs: [&mut [u8]; 1] = [&mut p];
+        decoder
+            .decode_raw(&mut refs)
+            .expect("decode_raw progressive");
+    }
+    let min = *p.iter().min().unwrap();
+    let max = *p.iter().max().unwrap();
+    assert!(max > min, "decoded grayscale plane is a single constant");
+}
+
+#[test]
+fn decode_raw_progressive_four_component() {
+    let bytes =
+        include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let n = decoder.num_components().unwrap();
+    assert_eq!(n, 4, "expected 4-component CMYK/YCCK image");
+    let layout = decoder.planar_layout().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw(&mut refs).expect("decode_raw");
+    }
+    for (i, plane) in planes.iter().enumerate() {
+        assert_eq!(plane.len(), layout[i].byte_size);
+        let pmin = *plane.iter().min().unwrap();
+        let pmax = *plane.iter().max().unwrap();
+        assert!(pmax > pmin, "plane {i} appears constant");
+    }
+}
+
+#[test]
+fn decode_raw_works_after_explicit_decode_headers() {
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    decoder.decode_raw(&mut refs).unwrap();
+}
+
+#[test]
+fn decode_raw_ignores_out_colorspace_setting() {
+    // Regression test: previously, configuring `out_colorspace = Luma` on a
+    // 3-component YCbCr image caused the baseline decoder to skip allocating
+    // raw_coeff for Cb / Cr (their `comp.needed` was set to false), so
+    // `decode_raw` would either panic or return garbage planes.
+    //
+    // In raw mode we want every component regardless of the configured
+    // output colorspace.
+    use zune_core::colorspace::ColorSpace;
+    use zune_core::options::DecoderOptions;
+
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let opts = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::Luma);
+    let mut decoder = JpegDecoder::new_with_options(ZCursor::new(bytes), opts);
+    decoder.decode_headers().unwrap();
+    let n = decoder.num_components().unwrap();
+    assert_eq!(n, 3, "fixture is 3-component");
+    let layout = decoder.planar_layout().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder
+            .decode_raw(&mut refs)
+            .expect("decode_raw should succeed regardless of out_colorspace");
+    }
+    // All three planes must contain real decoded data, not zeros.
+    for (i, plane) in planes.iter().enumerate() {
+        let pmin = *plane.iter().min().unwrap();
+        let pmax = *plane.iter().max().unwrap();
+        assert!(
+            pmax > pmin,
+            "plane {i} appears constant ({pmin}); raw mode must decode all components"
+        );
+    }
+}
+
+#[test]
+fn decode_raw_unaligned_dimensions_decode_succeeds() {
+    // 605x806 image with unaligned dimensions: width padded 605 -> 608,
+    // height padded 806 -> 808. Exercises the per-row padding-truncation
+    // path in `copy_raw_planes_for_mcu_stripe` and the trailing-padding-row
+    // bookkeeping.
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    assert_eq!(layout[0].width, 605);
+    assert_eq!(layout[0].height, 806);
+    assert_eq!(layout[0].stride, 608);
+    assert_eq!(layout[0].allocated_height, 808);
+
+    let n = decoder.num_components().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw(&mut refs).unwrap();
+    }
+    // Spot-check: meaningful Y region (rows 0..806, cols 0..605) has data.
+    let y = &planes[0];
+    let mut has_non_zero = false;
+    for row in 0..layout[0].height {
+        let v = y[row * layout[0].stride];
+        if v != 0 {
+            has_non_zero = true;
+            break;
+        }
+    }
+    assert!(has_non_zero, "first column of Y plane is all zero");
+}
+
+/// Manual nearest-neighbour upsampling of `src` (size `sw x sh`, row stride
+/// `s_stride`) into a `tw x th` plane.
+fn nearest_upsample(
+    src: &[u8], sw: usize, sh: usize, s_stride: usize, tw: usize, th: usize
+) -> Vec<u8> {
+    let mut out = vec![0u8; tw * th];
+    for y in 0..th {
+        let sy = (y * sh) / th;
+        for x in 0..tw {
+            let sx = (x * sw) / tw;
+            out[y * tw + x] = src[sy * s_stride + sx];
+        }
+    }
+    out
+}
+
+/// JFIF YCbCr -> RGB conversion (8-bit).
+fn ycbcr_to_rgb(y: u8, cb: u8, cr: u8) -> [u8; 3] {
+    let yf = y as f32;
+    let cbf = cb as f32 - 128.0;
+    let crf = cr as f32 - 128.0;
+    let r = yf + 1.402 * crf;
+    let g = yf - 0.344136 * cbf - 0.714136 * crf;
+    let b = yf + 1.772 * cbf;
+    [
+        r.round().clamp(0.0, 255.0) as u8,
+        g.round().clamp(0.0, 255.0) as u8,
+        b.round().clamp(0.0, 255.0) as u8
+    ]
+}
+
+#[test]
+fn decode_raw_content_matches_decode_within_upsample_tolerance() {
+    // Decode the same image two ways and assert the planes, after
+    // nearest-neighbour upsampling and JFIF YCbCr -> RGB, are statistically
+    // close to the regular RGB output. This guards against plane-ordering,
+    // stride, and clamp-cast regressions.
+    //
+    // Tolerance is loose because zune-jpeg uses a fancier upsampler than the
+    // nearest-neighbour we apply in test code; we only assert that the mean
+    // absolute difference per channel is small.
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+
+    let rgb = {
+        let mut d = JpegDecoder::new(ZCursor::new(bytes));
+        d.decode().unwrap()
+    };
+
+    let mut d2 = JpegDecoder::new(ZCursor::new(bytes));
+    d2.decode_headers().unwrap();
+    let (w, h) = d2.dimensions().unwrap();
+    let layout = d2.planar_layout().unwrap();
+    let n = d2.num_components().unwrap();
+    assert_eq!(n, 3);
+    let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        d2.decode_raw(&mut refs).unwrap();
+    }
+
+    // Upsample Cb / Cr to Y dimensions.
+    let y_up = nearest_upsample(
+        &planes[0],
+        layout[0].width,
+        layout[0].height,
+        layout[0].stride,
+        w,
+        h
+    );
+    let cb_up = nearest_upsample(
+        &planes[1],
+        layout[1].width,
+        layout[1].height,
+        layout[1].stride,
+        w,
+        h
+    );
+    let cr_up = nearest_upsample(
+        &planes[2],
+        layout[2].width,
+        layout[2].height,
+        layout[2].stride,
+        w,
+        h
+    );
+
+    let mut sum_dr = 0u64;
+    let mut sum_dg = 0u64;
+    let mut sum_db = 0u64;
+    let total = (w * h) as u64;
+    for i in 0..(w * h) {
+        let [r, g, b] = ycbcr_to_rgb(y_up[i], cb_up[i], cr_up[i]);
+        let rr = rgb[i * 3];
+        let gg = rgb[i * 3 + 1];
+        let bb = rgb[i * 3 + 2];
+        sum_dr += (r as i32 - rr as i32).unsigned_abs() as u64;
+        sum_dg += (g as i32 - gg as i32).unsigned_abs() as u64;
+        sum_db += (b as i32 - bb as i32).unsigned_abs() as u64;
+    }
+    let avg_dr = sum_dr / total;
+    let avg_dg = sum_dg / total;
+    let avg_db = sum_db / total;
+    // A plane swap, stride bug, or wrong YCbCr->RGB matrix would produce
+    // mean absolute deltas in the dozens; nearest-vs-fancy-upsample alone
+    // typically produces single-digit deltas on photographic content.
+    assert!(
+        avg_dr < 12 && avg_dg < 12 && avg_db < 12,
+        "mean abs RGB delta too large: dr={avg_dr} dg={avg_dg} db={avg_db}"
+    );
+}
+
+// decode_raw_strided: Skia-style logically-sized planes.
+
+#[test]
+fn decode_raw_strided_logical_size_matches_padded_decode() {
+    // 605x806 4:2:0 image: padded layout is 608x808 / 304x404; logical layout
+    // is 605x806 / 303x403. Verify that decode_raw_strided into a logical
+    // (width-stride) buffer returns identical samples within
+    // [0,width) x [0,height) versus decode_raw into the padded buffer.
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+
+    // Padded reference.
+    let padded = decode_raw_into_owned(bytes);
+
+    // Logical-sized via decode_raw_strided.
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
+    let mut logical: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0u8; strides[i] * layout[i].height])
+        .collect();
+    {
+        let mut refs: Vec<&mut [u8]> = logical.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+    }
+
+    for i in 0..n {
+        let pi = layout[i];
+        for y in 0..pi.height {
+            for x in 0..pi.width {
+                let logical_byte = logical[i][y * strides[i] + x];
+                let padded_byte = padded[i][y * pi.stride + x];
+                assert_eq!(
+                    logical_byte, padded_byte,
+                    "mismatch at component {i} ({},{})",
+                    x, y
+                );
+            }
+        }
+        assert_eq!(logical[i].len(), strides[i] * pi.height);
+    }
+}
+
+#[test]
+fn decode_raw_strided_accepts_oversized_stride() {
+    // Caller supplies a larger-than-width stride (e.g. row alignment of 64).
+    // Verify the per-row padding bytes stay zero and the meaningful samples
+    // match the logical decode.
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let padded = decode_raw_into_owned(bytes);
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    // Round each width up to the next multiple of 64.
+    let strides: Vec<usize> = (0..n).map(|i| (layout[i].width + 63) & !63).collect();
+    let mut planes: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0xAAu8; strides[i] * layout[i].height])
+        .collect();
+    {
+        let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+    }
+
+    for i in 0..n {
+        let pi = layout[i];
+        for y in 0..pi.height {
+            for x in 0..pi.width {
+                assert_eq!(
+                    planes[i][y * strides[i] + x],
+                    padded[i][y * pi.stride + x],
+                    "mismatch at component {i} ({},{})",
+                    x,
+                    y
+                );
+            }
+            // Trailing pad bytes from logical width up to caller stride
+            // must remain at the sentinel value (we did not write them).
+            for x in pi.width..strides[i] {
+                assert_eq!(
+                    planes[i][y * strides[i] + x],
+                    0xAA,
+                    "stride padding modified at component {i} ({},{})",
+                    x,
+                    y
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn decode_raw_strided_rejects_too_small_stride() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    // Stride for component 0 is one less than the logical width.
+    let strides: Vec<usize> = (0..n)
+        .map(|i| if i == 0 { layout[i].width - 1 } else { layout[i].width })
+        .collect();
+    let mut planes: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0u8; strides[i].max(1) * layout[i].height])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    let err = decoder.decode_raw_strided(&mut refs, &strides).unwrap_err();
+    match err {
+        DecodeErrors::Format(_) => {}
+        other => panic!("expected Format error, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_strided_rejects_too_small_buffer() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
+    let mut planes: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0u8; strides[i] * layout[i].height])
+        .collect();
+    // Truncate component 0 by one byte.
+    planes[0].pop();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    let err = decoder.decode_raw_strided(&mut refs, &strides).unwrap_err();
+    match err {
+        DecodeErrors::TooSmallOutput(_, _) => {}
+        other => panic!("expected TooSmallOutput, got {other:?}")
+    }
+}
+
+#[test]
+fn decode_raw_strided_unaligned_dimensions_no_pad_writes() {
+    // Logical-sized buffer on a non-DCT-aligned image. Verify the trailing
+    // row past `height` is never touched by the decoder (no scratch leak).
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n = decoder.num_components().unwrap();
+
+    // Allocate exactly one extra sentinel row past `height` in the same
+    // backing Vec, but tell the decoder the buffer is `stride * height`.
+    let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
+    let buf_lens: Vec<usize> = (0..n).map(|i| strides[i] * layout[i].height).collect();
+    let mut backing: Vec<Vec<u8>> = (0..n)
+        .map(|i| vec![0xCDu8; buf_lens[i] + strides[i]]) // one extra row of sentinel
+        .collect();
+
+    {
+        // Slice each plane to exactly buf_lens[i] so the decoder cannot
+        // address past it.
+        let mut refs: Vec<&mut [u8]> = backing
+            .iter_mut()
+            .enumerate()
+            .map(|(i, v)| &mut v[..buf_lens[i]])
+            .collect();
+        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+    }
+
+    for i in 0..n {
+        let extra = &backing[i][buf_lens[i]..];
+        assert!(
+            extra.iter().all(|&b| b == 0xCD),
+            "trailing sentinel row clobbered for component {i}"
+        );
+    }
+}
+
+// component_ids() accessor.
+
+#[test]
+fn component_ids_returns_ycbcr_for_3_component_jpeg() {
+    use zune_jpeg::ComponentID;
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let ids = decoder
+        .component_ids()
+        .expect("component_ids after headers");
+    assert_eq!(ids, vec![ComponentID::Y, ComponentID::Cb, ComponentID::Cr]);
+}
+
+#[test]
+fn component_ids_returns_none_before_headers() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let decoder = JpegDecoder::new(ZCursor::new(bytes));
+    assert!(decoder.component_ids().is_none());
+}

--- a/crates/zune-jpeg/tests/decode_raw.rs
+++ b/crates/zune-jpeg/tests/decode_raw.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-//! Tests for `JpegDecoder::decode_raw()`.
+//! Tests for `JpegDecoder::raw_output()`.
 //!
 //! Mirrors libjpeg-turbo's `jpeg_read_raw_data` semantics: each component's
 //! post-IDCT samples are written directly into a caller-provided plane,
@@ -16,18 +16,49 @@ use zune_core::bytestream::ZCursor;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::JpegDecoder;
 
+fn with_component_ids(data: &[u8], ids: &[u8]) -> Vec<u8> {
+    let mut result = data.to_vec();
+    let sof = result
+        .windows(2)
+        .position(|bytes| bytes[0] == 0xff && (0xc0..=0xc2).contains(&bytes[1]))
+        .expect("fixture must contain a supported SOF marker");
+    assert_eq!(usize::from(result[sof + 9]), ids.len());
+    let old_ids: Vec<_> = (0..ids.len())
+        .map(|index| result[sof + 10 + 3 * index])
+        .collect();
+
+    for (index, id) in ids.iter().enumerate() {
+        result[sof + 10 + 3 * index] = *id;
+    }
+    for sos in result
+        .windows(2)
+        .enumerate()
+        .filter_map(|(offset, bytes)| (bytes == [0xff, 0xda]).then_some(offset))
+        .collect::<Vec<_>>()
+    {
+        for index in 0..usize::from(result[sos + 4]) {
+            let selector = &mut result[sos + 5 + 2 * index];
+            if let Some(id_index) = old_ids.iter().position(|id| id == selector) {
+                *selector = ids[id_index];
+            }
+        }
+    }
+    result
+}
+
 /// Allocate per-plane buffers sized to the layout reported by
-/// `planar_layout()`, then run `decode_raw` and return the populated planes.
+/// `RawDecodeSession::layout()`, then decode and return the populated planes.
 fn decode_raw_into_owned(bytes: &[u8]) -> Vec<Vec<u8>> {
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().expect("decode_headers");
-    let n = decoder.num_components().expect("num_components");
-    let layout = decoder.planar_layout().expect("planar_layout");
+    let mut raw = decoder.raw_output();
+    let n = raw.num_components().expect("num_components");
+    let layout = raw.layout().expect("raw layout");
 
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw(&mut refs).expect("decode_raw");
+        raw.decode_into(&mut refs).expect("raw decode");
     }
     planes
 }
@@ -37,12 +68,13 @@ fn decode_raw_rejects_wrong_plane_count() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
     // 3-component image, pass 2 planes.
     let mut p0 = vec![0u8; layout[0].byte_size];
     let mut p1 = vec![0u8; layout[1].byte_size];
     let mut refs: [&mut [u8]; 2] = [&mut p0, &mut p1];
-    let err = decoder.decode_raw(&mut refs).unwrap_err();
+    let err = raw.decode_into(&mut refs).unwrap_err();
     match err {
         DecodeErrors::Format(_) => {}
         other => panic!("expected Format error, got {other:?}")
@@ -54,12 +86,13 @@ fn decode_raw_rejects_too_small_plane() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
     let mut p0 = vec![0u8; layout[0].byte_size - 1]; // one byte short
     let mut p1 = vec![0u8; layout[1].byte_size];
     let mut p2 = vec![0u8; layout[2].byte_size];
     let mut refs: [&mut [u8]; 3] = [&mut p0, &mut p1, &mut p2];
-    let err = decoder.decode_raw(&mut refs).unwrap_err();
+    let err = raw.decode_into(&mut refs).unwrap_err();
     match err {
         DecodeErrors::TooSmallOutput(need, got) => {
             assert_eq!(need, layout[0].byte_size);
@@ -79,11 +112,7 @@ fn decode_raw_rejects_more_than_four_sof_components() {
         0x00, 0x01, // height
         0x00, 0x01, // width
         0x05, // components
-        1, 0x11, 0,
-        2, 0x11, 0,
-        3, 0x11, 0,
-        4, 0x11, 0,
-        5, 0x11, 0
+        1, 0x11, 0, 2, 0x11, 0, 3, 0x11, 0, 4, 0x11, 0, 5, 0x11, 0
     ];
 
     let mut decoder = JpegDecoder::new(ZCursor::new(FIVE_COMPONENTS));
@@ -151,15 +180,14 @@ fn decode_raw_grayscale_progressive_single_plane() {
     let bytes = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let n = raw.num_components().unwrap();
     assert_eq!(n, 1, "expected grayscale (1 component)");
-    let layout = decoder.planar_layout().unwrap();
+    let layout = raw.layout().unwrap();
     let mut p = vec![0u8; layout[0].byte_size];
     {
         let mut refs: [&mut [u8]; 1] = [&mut p];
-        decoder
-            .decode_raw(&mut refs)
-            .expect("decode_raw progressive");
+        raw.decode_into(&mut refs).expect("raw progressive decode");
     }
     let min = *p.iter().min().unwrap();
     let max = *p.iter().max().unwrap();
@@ -172,13 +200,14 @@ fn decode_raw_progressive_four_component() {
         include_bytes!("../../../test-images/jpeg/Kiara_limited_progressive_four_components.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let n = raw.num_components().unwrap();
     assert_eq!(n, 4, "expected 4-component CMYK/YCCK image");
-    let layout = decoder.planar_layout().unwrap();
+    let layout = raw.layout().unwrap();
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw(&mut refs).expect("decode_raw");
+        raw.decode_into(&mut refs).expect("raw decode");
     }
     for (i, plane) in planes.iter().enumerate() {
         assert_eq!(plane.len(), layout[i].byte_size);
@@ -193,11 +222,12 @@ fn decode_raw_works_after_explicit_decode_headers() {
     let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    decoder.decode_raw(&mut refs).unwrap();
+    raw.decode_into(&mut refs).unwrap();
 }
 
 #[test]
@@ -216,14 +246,14 @@ fn decode_raw_ignores_out_colorspace_setting() {
     let opts = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::Luma);
     let mut decoder = JpegDecoder::new_with_options(ZCursor::new(bytes), opts);
     decoder.decode_headers().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let n = raw.num_components().unwrap();
     assert_eq!(n, 3, "fixture is 3-component");
-    let layout = decoder.planar_layout().unwrap();
+    let layout = raw.layout().unwrap();
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder
-            .decode_raw(&mut refs)
+        raw.decode_into(&mut refs)
             .expect("decode_raw should succeed regardless of out_colorspace");
     }
     // All three planes must contain real decoded data, not zeros.
@@ -246,17 +276,18 @@ fn decode_raw_unaligned_dimensions_decode_succeeds() {
     let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
     assert_eq!(layout[0].width, 605);
     assert_eq!(layout[0].height, 806);
     assert_eq!(layout[0].stride, 608);
     assert_eq!(layout[0].allocated_height, 808);
 
-    let n = decoder.num_components().unwrap();
+    let n = raw.num_components().unwrap();
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw(&mut refs).unwrap();
+        raw.decode_into(&mut refs).unwrap();
     }
     // Spot-check: meaningful Y region (rows 0..806, cols 0..605) has data.
     let y = &planes[0];
@@ -313,13 +344,14 @@ fn assert_raw_content_matches_decode_within_upsample_tolerance(
     let mut raw_decoder = JpegDecoder::new(ZCursor::new(bytes));
     raw_decoder.decode_headers().unwrap();
     let (w, h) = raw_decoder.dimensions().unwrap();
-    let layout = raw_decoder.planar_layout().unwrap();
-    let n = raw_decoder.num_components().unwrap();
+    let mut raw = raw_decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
     assert_eq!(n, 3, "{name}: expected YCbCr fixture");
     let mut planes: Vec<Vec<u8>> = (0..n).map(|i| vec![0u8; layout[i].byte_size]).collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        raw_decoder.decode_raw(&mut refs).unwrap();
+        raw.decode_into(&mut refs).unwrap();
     }
 
     let y_up = nearest_upsample(
@@ -429,8 +461,9 @@ fn decode_raw_strided_logical_size_matches_padded_decode() {
     // Logical-sized via decode_raw_strided.
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
     let mut logical: Vec<Vec<u8>> = (0..n)
@@ -438,7 +471,7 @@ fn decode_raw_strided_logical_size_matches_padded_decode() {
         .collect();
     {
         let mut refs: Vec<&mut [u8]> = logical.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+        raw.decode_into_strided(&mut refs, &strides).unwrap();
     }
 
     for i in 0..n {
@@ -468,8 +501,9 @@ fn decode_raw_strided_accepts_oversized_stride() {
 
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     // Round each width up to the next multiple of 64.
     let strides: Vec<usize> = (0..n).map(|i| (layout[i].width + 63) & !63).collect();
@@ -478,7 +512,7 @@ fn decode_raw_strided_accepts_oversized_stride() {
         .collect();
     {
         let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+        raw.decode_into_strided(&mut refs, &strides).unwrap();
     }
 
     for i in 0..n {
@@ -513,8 +547,9 @@ fn decode_raw_strided_rejects_too_small_stride() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     // Stride for component 0 is one less than the logical width.
     let strides: Vec<usize> = (0..n)
@@ -524,7 +559,7 @@ fn decode_raw_strided_rejects_too_small_stride() {
         .map(|i| vec![0u8; strides[i].max(1) * layout[i].height])
         .collect();
     let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    let err = decoder.decode_raw_strided(&mut refs, &strides).unwrap_err();
+    let err = raw.decode_into_strided(&mut refs, &strides).unwrap_err();
     match err {
         DecodeErrors::Format(_) => {}
         other => panic!("expected Format error, got {other:?}")
@@ -536,8 +571,9 @@ fn decode_raw_strided_rejects_too_small_buffer() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     let strides: Vec<usize> = (0..n).map(|i| layout[i].width).collect();
     let mut planes: Vec<Vec<u8>> = (0..n)
@@ -546,7 +582,7 @@ fn decode_raw_strided_rejects_too_small_buffer() {
     // Truncate component 0 by one byte.
     planes[0].pop();
     let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    let err = decoder.decode_raw_strided(&mut refs, &strides).unwrap_err();
+    let err = raw.decode_into_strided(&mut refs, &strides).unwrap_err();
     match err {
         DecodeErrors::TooSmallOutput(_, _) => {}
         other => panic!("expected TooSmallOutput, got {other:?}")
@@ -560,8 +596,9 @@ fn decode_raw_strided_unaligned_dimensions_no_pad_writes() {
     let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n = decoder.num_components().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n = raw.num_components().unwrap();
 
     // Allocate exactly one extra sentinel row past `height` in the same
     // backing Vec, but tell the decoder the buffer is `stride * height`.
@@ -579,7 +616,7 @@ fn decode_raw_strided_unaligned_dimensions_no_pad_writes() {
             .enumerate()
             .map(|(i, v)| &mut v[..buf_lens[i]])
             .collect();
-        decoder.decode_raw_strided(&mut refs, &strides).unwrap();
+        raw.decode_into_strided(&mut refs, &strides).unwrap();
     }
 
     for i in 0..n {
@@ -591,23 +628,31 @@ fn decode_raw_strided_unaligned_dimensions_no_pad_writes() {
     }
 }
 
-// component_ids() accessor.
+// component_ids() metadata.
 
 #[test]
-fn component_ids_returns_ycbcr_for_3_component_jpeg() {
-    use zune_jpeg::ComponentID;
+fn component_ids_return_canonical_sof_selectors() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().unwrap();
-    let ids = decoder
-        .component_ids()
-        .expect("component_ids after headers");
-    assert_eq!(ids, vec![ComponentID::Y, ComponentID::Cb, ComponentID::Cr]);
+    let raw = decoder.raw_output();
+    let ids = raw.component_ids().expect("component_ids after headers");
+    assert_eq!(ids, vec![1, 2, 3]);
+}
+
+#[test]
+fn component_ids_preserve_noncanonical_sof_selectors() {
+    let bytes = with_component_ids(include_bytes!("../../../test-images/jpeg/2029.jpg"), b"RGB");
+    let mut decoder = JpegDecoder::new(ZCursor::new(&bytes));
+    decoder.decode_headers().unwrap();
+    let raw = decoder.raw_output();
+    assert_eq!(raw.component_ids().as_deref(), Some(b"RGB".as_slice()));
 }
 
 #[test]
 fn component_ids_returns_none_before_headers() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
-    let decoder = JpegDecoder::new(ZCursor::new(bytes));
-    assert!(decoder.component_ids().is_none());
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let raw = decoder.raw_output();
+    assert!(raw.component_ids().is_none());
 }

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -12,6 +12,7 @@
 //! and that retrying with more data produces correct output.
 
 use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
+use zune_core::colorspace::ColorSpace;
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::{JpegDecoder, RawDecodeSession};
@@ -2727,6 +2728,86 @@ fn per_row_checkpoint_avoids_full_scan_replay() {
         "per-row checkpoint should resume past entropy_start ({entropy_start}), \
          but sought to {resume_pos} — indicates full scan replay instead of row resume"
     );
+}
+
+fn checkpointed_pixel_decoder<'a>(
+    data: &'a [u8], cutoff: usize, options: DecoderOptions
+) -> (JpegDecoder<GrowableCursor<'a>>, Rc<Cell<usize>>) {
+    let limit = Rc::new(Cell::new(cutoff));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new_with_options(cursor, options);
+    decoder.decode_headers().unwrap();
+    let mut output = vec![0; decoder.output_buffer_size().unwrap()];
+    for _ in 0..2 {
+        let error = decoder.decode_into(&mut output).unwrap_err();
+        assert!(error.is_recoverable_eof());
+    }
+    assert!(decoder.decoded_scanlines().unwrap_or(0) > 0);
+    (decoder, limit)
+}
+
+#[test]
+fn switching_checkpointed_pixel_decode_to_whole_raw_replays_from_start() {
+    let data = include_bytes!("../../../test-images/jpeg/sampling_factors.jpg");
+    let entropy_start = entropy_start(data);
+    let cutoff = entropy_start + (data.len() - entropy_start) * 60 / 100;
+    let expected = decode_raw_oneshot(data);
+    let (mut decoder, limit) =
+        checkpointed_pixel_decoder(data, cutoff, DecoderOptions::default());
+    limit.set(data.len());
+
+    let mut raw = decoder.raw_output();
+    let mut actual = allocate_raw_planes(&raw);
+    decode_raw_into_existing(&mut raw, &mut actual).unwrap();
+    assert_raw_planes_match(&actual, &expected, "pixel_to_whole_raw", data.len());
+}
+
+#[test]
+fn changing_options_replays_pixel_output_and_invalidates_progress() {
+    let baseline = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let luma = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::Luma);
+    let expected = decode_oneshot(baseline);
+    let entropy_start = entropy_start(baseline);
+    let cutoff = entropy_start + (baseline.len() - entropy_start) * 60 / 100;
+    let (mut decoder, limit) = checkpointed_pixel_decoder(baseline, cutoff, luma);
+    limit.set(baseline.len());
+    decoder.set_options(DecoderOptions::default());
+    assert_eq!(decoder.decoded_output_bytes(), Some(0));
+    assert_eq!(decoder.decoded_scanlines(), Some(0));
+    let mut output = vec![0; expected.len()];
+    decoder.decode_into(&mut output).unwrap();
+    assert_eq!(output, expected);
+
+    let progressive =
+        include_bytes!("../../../test-images/jpeg/rebuilt_relax_fill_bytes_before_marker.jpg");
+    let scans = progressive_sos_scans(progressive);
+    let cutoff = scans[1].data_start + 1;
+    let limit = Rc::new(Cell::new(cutoff));
+    let cursor = GrowableCursor::new(progressive, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new_with_options(cursor, luma);
+    decoder.set_incremental_mode(true);
+    decoder.decode_headers().unwrap();
+    let mut preview = vec![0; decoder.output_buffer_size().unwrap()];
+    let error = decoder.decode_into(&mut preview).unwrap_err();
+    assert!(error.is_recoverable_eof());
+    let committed_scans = decoder.decoded_scans().unwrap();
+    assert!(committed_scans > 0);
+    assert!(decoder.decoded_preview_output_bytes().unwrap_or(0) > 0);
+
+    let rgba = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::RGBA);
+    decoder.set_options(rgba);
+    assert_eq!(decoder.decoded_output_bytes(), Some(0));
+    assert_eq!(decoder.decoded_scanlines(), Some(0));
+    assert_eq!(decoder.decoded_scans(), Some(committed_scans));
+    assert_eq!(decoder.decoded_preview_output_bytes(), Some(0));
+    assert_eq!(decoder.decoded_preview_scanlines(), Some(0));
+    limit.set(progressive.len());
+    let expected = JpegDecoder::new_with_options(ZCursor::new(progressive), rgba)
+        .decode()
+        .unwrap();
+    let mut output = vec![0; expected.len()];
+    decoder.decode_into(&mut output).unwrap();
+    assert_eq!(output, expected);
 }
 
 #[test]

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -14,7 +14,7 @@
 use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
-use zune_jpeg::JpegDecoder;
+use zune_jpeg::{JpegDecoder, RawDecodeSession};
 
 use std::cell::{Cell, RefCell};
 use std::io::{BufRead, Read, Seek, SeekFrom};
@@ -220,33 +220,33 @@ fn assert_decode_into_replay_matches_oneshot(name: &str, data: &[u8]) {
     assert_pixels_match(&replay, &expected, name, data.len());
 }
 
-fn allocate_raw_planes<T>(decoder: &JpegDecoder<T>) -> Vec<Vec<u8>>
+fn allocate_raw_planes<T>(raw: &RawDecodeSession<'_, T>) -> Vec<Vec<u8>>
 where
     T: ZByteReaderTrait
 {
-    let layout = decoder.planar_layout().unwrap();
-    let n_components = decoder.num_components().unwrap();
+    let layout = raw.layout().unwrap();
+    let n_components = raw.num_components().unwrap();
     (0..n_components)
         .map(|index| vec![0u8; layout[index].byte_size])
         .collect()
 }
 
 fn decode_raw_into_existing<T>(
-    decoder: &mut JpegDecoder<T>, planes: &mut [Vec<u8>]
+    raw: &mut RawDecodeSession<'_, T>, planes: &mut [Vec<u8>]
 ) -> Result<(), zune_jpeg::errors::DecodeErrors>
 where
     T: ZByteReaderTrait
 {
     let mut plane_refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    decoder.decode_raw(&mut plane_refs)
+    raw.decode_into(&mut plane_refs)
 }
 
-fn allocate_raw_strided_planes<T>(decoder: &JpegDecoder<T>) -> (Vec<Vec<u8>>, Vec<usize>)
+fn allocate_raw_strided_planes<T>(raw: &RawDecodeSession<'_, T>) -> (Vec<Vec<u8>>, Vec<usize>)
 where
     T: ZByteReaderTrait
 {
-    let layout = decoder.planar_layout().unwrap();
-    let n_components = decoder.num_components().unwrap();
+    let layout = raw.layout().unwrap();
+    let n_components = raw.num_components().unwrap();
     let strides: Vec<usize> = (0..n_components)
         .map(|index| layout[index].width + 5)
         .collect();
@@ -257,35 +257,34 @@ where
 }
 
 fn decode_raw_strided_into_existing<T>(
-    decoder: &mut JpegDecoder<T>, planes: &mut [Vec<u8>], strides: &[usize]
+    raw: &mut RawDecodeSession<'_, T>, planes: &mut [Vec<u8>], strides: &[usize]
 ) -> Result<(), zune_jpeg::errors::DecodeErrors>
 where
     T: ZByteReaderTrait
 {
     let mut plane_refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
-    decoder.decode_raw_strided(&mut plane_refs, strides)
+    raw.decode_into_strided(&mut plane_refs, strides)
 }
 
 fn decode_raw_oneshot(data: &[u8]) -> Vec<Vec<u8>> {
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
-    decoder.decode_headers().expect("one-shot raw headers failed");
-    let mut planes = allocate_raw_planes(&decoder);
-    decode_raw_into_existing(&mut decoder, &mut planes).expect("one-shot raw decode failed");
+    decoder
+        .decode_headers()
+        .expect("one-shot raw headers failed");
+    let mut raw = decoder.raw_output();
+    let mut planes = allocate_raw_planes(&raw);
+    decode_raw_into_existing(&mut raw, &mut planes).expect("one-shot raw decode failed");
     planes
 }
 
-fn assert_raw_planes_match(
-    actual: &[Vec<u8>], expected: &[Vec<u8>], name: &str, available: usize
-) {
+fn assert_raw_planes_match(actual: &[Vec<u8>], expected: &[Vec<u8>], name: &str, available: usize) {
     assert_eq!(
         actual.len(),
         expected.len(),
         "{name}: incremental and one-shot raw plane counts differ"
     );
 
-    for (plane_index, (actual_plane, expected_plane)) in
-        actual.iter().zip(expected).enumerate()
-    {
+    for (plane_index, (actual_plane, expected_plane)) in actual.iter().zip(expected).enumerate() {
         assert_eq!(
             actual_plane.len(),
             expected_plane.len(),
@@ -310,17 +309,26 @@ fn assert_raw_planes_match(
 }
 
 fn assert_raw_strided_planes_match_padded(
-    actual: &[Vec<u8>], strides: &[usize], expected: &[Vec<u8>], name: &str,
-    data: &[u8], available: usize
+    actual: &[Vec<u8>], strides: &[usize], expected: &[Vec<u8>], name: &str, data: &[u8],
+    available: usize
 ) {
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode_headers().unwrap();
-    let layout = decoder.planar_layout().unwrap();
-    let n_components = decoder.num_components().unwrap();
+    let raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let n_components = raw.num_components().unwrap();
 
-    assert_eq!(actual.len(), n_components, "{name}: strided plane count differs");
+    assert_eq!(
+        actual.len(),
+        n_components,
+        "{name}: strided plane count differs"
+    );
     assert_eq!(strides.len(), n_components, "{name}: stride count differs");
-    assert_eq!(expected.len(), n_components, "{name}: padded plane count differs");
+    assert_eq!(
+        expected.len(),
+        n_components,
+        "{name}: padded plane count differs"
+    );
 
     for index in 0..n_components {
         let plane = layout[index];
@@ -357,32 +365,29 @@ fn assert_incremental_raw_decode_matches_oneshot(name: &str, data: &[u8], step: 
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
 
-    let mut header_done = false;
-    let mut planes: Vec<Vec<u8>> = Vec::new();
     let mut available = 0_usize;
 
     loop {
         available = (available + step).min(data.len());
         limit.set(available);
 
-        if !header_done {
-            match decoder.decode_headers() {
-                Ok(()) => {
-                    header_done = true;
-                    planes = allocate_raw_planes(&decoder);
-                }
-                Err(ref err) if err.is_recoverable_eof() => {
-                    assert!(
-                        available < data.len(),
-                        "raw headers still need more data with the full input visible"
-                    );
-                    continue;
-                }
-                Err(err) => panic!("unexpected raw header error at byte {available}: {err:?}")
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(ref err) if err.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "raw headers still need more data with the full input visible"
+                );
             }
+            Err(err) => panic!("unexpected raw header error at byte {available}: {err:?}")
         }
+    }
 
-        match decode_raw_into_existing(&mut decoder, &mut planes) {
+    let mut raw = decoder.raw_output();
+    let mut planes = allocate_raw_planes(&raw);
+
+    loop {
+        match decode_raw_into_existing(&mut raw, &mut planes) {
             Ok(()) => {
                 assert_raw_planes_match(&planes, &expected, name, available);
                 return;
@@ -392,15 +397,15 @@ fn assert_incremental_raw_decode_matches_oneshot(name: &str, data: &[u8], step: 
                     available < data.len(),
                     "raw scan still needs more data with the full input visible"
                 );
+                available = (available + step).min(data.len());
+                limit.set(available);
             }
             Err(err) => panic!("unexpected raw scan error at byte {available}: {err:?}")
         }
     }
 }
 
-fn assert_incremental_raw_strided_decode_matches_oneshot(
-    name: &str, data: &[u8], step: usize
-) {
+fn assert_incremental_raw_strided_decode_matches_oneshot(name: &str, data: &[u8], step: usize) {
     assert!(step > 0, "incremental step must be non-zero");
 
     let expected = decode_raw_oneshot(data);
@@ -408,35 +413,31 @@ fn assert_incremental_raw_strided_decode_matches_oneshot(
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new(cursor);
 
-    let mut header_done = false;
-    let mut planes: Vec<Vec<u8>> = Vec::new();
-    let mut strides: Vec<usize> = Vec::new();
     let mut available = 0_usize;
 
     loop {
         available = (available + step).min(data.len());
         limit.set(available);
 
-        if !header_done {
-            match decoder.decode_headers() {
-                Ok(()) => {
-                    header_done = true;
-                    (planes, strides) = allocate_raw_strided_planes(&decoder);
-                }
-                Err(ref err) if err.is_recoverable_eof() => {
-                    assert!(
-                        available < data.len(),
-                        "raw strided headers still need more data with the full input visible"
-                    );
-                    continue;
-                }
-                Err(err) => {
-                    panic!("unexpected raw strided header error at byte {available}: {err:?}")
-                }
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(ref err) if err.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "raw strided headers still need more data with the full input visible"
+                );
+            }
+            Err(err) => {
+                panic!("unexpected raw strided header error at byte {available}: {err:?}")
             }
         }
+    }
 
-        match decode_raw_strided_into_existing(&mut decoder, &mut planes, &strides) {
+    let mut raw = decoder.raw_output();
+    let (mut planes, strides) = allocate_raw_strided_planes(&raw);
+
+    loop {
+        match decode_raw_strided_into_existing(&mut raw, &mut planes, &strides) {
             Ok(()) => {
                 assert_raw_strided_planes_match_padded(
                     &planes, &strides, &expected, name, data, available
@@ -448,6 +449,8 @@ fn assert_incremental_raw_strided_decode_matches_oneshot(
                     available < data.len(),
                     "raw strided scan still needs more data with the full input visible"
                 );
+                available = (available + step).min(data.len());
+                limit.set(available);
             }
             Err(err) => panic!("unexpected raw strided scan error at byte {available}: {err:?}")
         }
@@ -459,12 +462,13 @@ fn assert_decode_raw_replay_matches_oneshot(name: &str, data: &[u8]) {
 
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode_headers().unwrap();
-    let mut first = allocate_raw_planes(&decoder);
-    decode_raw_into_existing(&mut decoder, &mut first).unwrap();
+    let mut raw = decoder.raw_output();
+    let mut first = allocate_raw_planes(&raw);
+    decode_raw_into_existing(&mut raw, &mut first).unwrap();
     assert_raw_planes_match(&first, &expected, name, data.len());
 
-    let mut replay = allocate_raw_planes(&decoder);
-    decode_raw_into_existing(&mut decoder, &mut replay).unwrap();
+    let mut replay = allocate_raw_planes(&raw);
+    decode_raw_into_existing(&mut raw, &mut replay).unwrap();
     assert_raw_planes_match(&replay, &expected, name, data.len());
 }
 
@@ -473,13 +477,14 @@ fn assert_decode_raw_strided_replay_matches_oneshot(name: &str, data: &[u8]) {
 
     let mut decoder = JpegDecoder::new(ZCursor::new(data));
     decoder.decode_headers().unwrap();
-    let (mut first, strides) = allocate_raw_strided_planes(&decoder);
-    decode_raw_strided_into_existing(&mut decoder, &mut first, &strides).unwrap();
+    let mut raw = decoder.raw_output();
+    let (mut first, strides) = allocate_raw_strided_planes(&raw);
+    decode_raw_strided_into_existing(&mut raw, &mut first, &strides).unwrap();
     assert_raw_strided_planes_match_padded(&first, &strides, &expected, name, data, data.len());
 
-    let (mut replay, replay_strides) = allocate_raw_strided_planes(&decoder);
+    let (mut replay, replay_strides) = allocate_raw_strided_planes(&raw);
     assert_eq!(replay_strides, strides);
-    decode_raw_strided_into_existing(&mut decoder, &mut replay, &replay_strides).unwrap();
+    decode_raw_strided_into_existing(&mut raw, &mut replay, &replay_strides).unwrap();
     assert_raw_strided_planes_match_padded(
         &replay,
         &replay_strides,
@@ -1973,8 +1978,9 @@ fn arithmetic_restart_raw_resume_uses_rst_checkpoint() {
     decoder
         .decode_headers()
         .expect("headers should be visible before first raw RST retry");
-    let mut planes = allocate_raw_planes(&decoder);
-    let err = decode_raw_into_existing(&mut decoder, &mut planes)
+    let mut raw = decoder.raw_output();
+    let mut planes = allocate_raw_planes(&raw);
+    let err = decode_raw_into_existing(&mut raw, &mut planes)
         .expect_err("truncated raw scan after first RST should be recoverable");
     assert!(
         err.is_recoverable_eof(),
@@ -1983,7 +1989,7 @@ fn arithmetic_restart_raw_resume_uses_rst_checkpoint() {
 
     seek_log.borrow_mut().clear();
     limit.set(data.len());
-    decode_raw_into_existing(&mut decoder, &mut planes)
+    decode_raw_into_existing(&mut raw, &mut planes)
         .expect("full input should resume raw decode from RST checkpoint");
 
     let seeks = seek_log.borrow();

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -2736,6 +2736,7 @@ fn checkpointed_pixel_decoder<'a>(
     let limit = Rc::new(Cell::new(cutoff));
     let cursor = GrowableCursor::new(data, Rc::clone(&limit));
     let mut decoder = JpegDecoder::new_with_options(cursor, options);
+    decoder.set_incremental_mode(true);
     decoder.decode_headers().unwrap();
     let mut output = vec![0; decoder.output_buffer_size().unwrap()];
     for _ in 0..2 {

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -15,10 +15,10 @@ use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
 use zune_core::colorspace::ColorSpace;
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
-use zune_jpeg::{JpegDecoder, RawDecodeSession};
+use zune_jpeg::{JpegDecoder, RawDecodeSession, RawImcuRowStatus};
 
 use std::cell::{Cell, RefCell};
-use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::io::{BufRead, Cursor, Read, Seek, SeekFrom};
 use std::rc::Rc;
 
 /// A cursor over a byte slice with an adjustable visibility limit.
@@ -105,6 +105,44 @@ impl Seek for GrowableCursor<'_> {
             seek_log.borrow_mut().push(self.position);
         }
         Ok(self.position as u64)
+    }
+}
+
+struct PositionFailCursor<'a> {
+    inner:       Cursor<&'a [u8]>,
+    calls:       Rc<Cell<usize>>,
+    fail_on_call: Rc<Cell<usize>>
+}
+
+impl Read for PositionFailCursor<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl BufRead for PositionFailCursor<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        self.inner.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.inner.consume(amt);
+    }
+}
+
+impl Seek for PositionFailCursor<'_> {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        if position == SeekFrom::Current(0) {
+            let call = self.calls.get() + 1;
+            self.calls.set(call);
+            if self.fail_on_call.get() == call {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "injected position failure"
+                ));
+            }
+        }
+        self.inner.seek(position)
     }
 }
 
@@ -454,6 +492,78 @@ fn assert_incremental_raw_strided_decode_matches_oneshot(name: &str, data: &[u8]
                 limit.set(available);
             }
             Err(err) => panic!("unexpected raw strided scan error at byte {available}: {err:?}")
+        }
+    }
+}
+
+fn assert_incremental_raw_pull_matches_oneshot(name: &str, data: &[u8], step: usize) {
+    let expected = decode_raw_oneshot(data);
+    let limit = Rc::new(Cell::new(0usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+    let mut available = 0usize;
+
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(error) if error.is_recoverable_eof() => continue,
+            Err(error) => panic!("{name}: unexpected header error: {error:?}")
+        }
+    }
+
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut actual: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.height])
+        .collect();
+    let mut rows_emitted = [0usize; 4];
+    let mut suspended_before_first_row = false;
+
+    loop {
+        let mut stripe_storage: Vec<Vec<u8>> = layout[..count]
+            .iter()
+            .map(|plane| vec![0xCD; plane.width * plane.vertical_sampling_factor * 8])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = stripe_storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    let bytes = rows_written[index] * strides[index];
+                    let dst = rows_emitted[index] * strides[index];
+                    actual[index][dst..dst + bytes]
+                        .copy_from_slice(&stripe_storage[index][..bytes]);
+                    rows_emitted[index] += rows_written[index];
+                }
+            }
+            RawImcuRowStatus::NeedMoreInput => {
+                assert!(
+                    stripe_storage.iter().flatten().all(|byte| *byte == 0xCD),
+                    "{name}: suspended pull modified caller storage"
+                );
+                if rows_emitted[..count].iter().all(|rows| *rows == 0) {
+                    suspended_before_first_row = true;
+                }
+                assert!(available < data.len(), "{name}: suspended with full input");
+                available = (available + step).min(data.len());
+                limit.set(available);
+            }
+            RawImcuRowStatus::Complete => {
+                assert!(
+                    suspended_before_first_row,
+                    "{name}: test did not suspend before publishing its first row"
+                );
+                assert_raw_strided_planes_match_padded(
+                    &actual, &strides, &expected, name, data, available
+                );
+                return;
+            }
+            _ => unreachable!("unknown raw iMCU-row status")
         }
     }
 }
@@ -1896,6 +2006,88 @@ fn raw_strided_incremental_parity() {
 }
 
 #[test]
+fn raw_pull_incremental_parity() {
+    assert_incremental_raw_pull_matches_oneshot(
+        "baseline_pull",
+        include_bytes!("../../../test-images/jpeg/synthetic_image.jpg"),
+        37
+    );
+    assert_incremental_raw_pull_matches_oneshot(
+        "progressive_pull",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+        31
+    );
+    assert_incremental_raw_pull_matches_oneshot(
+        "restart_pull",
+        include_bytes!("../../../test-images/jpeg/four_components.jpg"),
+        97
+    );
+    assert_incremental_raw_pull_matches_oneshot(
+        "multi_sos_pull",
+        include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg"),
+        31
+    );
+}
+
+#[test]
+fn raw_pull_checkpoint_failure_is_atomic() {
+    let data = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let calls = Rc::new(Cell::new(0usize));
+    let fail_on_call = Rc::new(Cell::new(0usize));
+    let cursor = PositionFailCursor {
+        inner: Cursor::new(data.as_slice()),
+        calls: Rc::clone(&calls),
+        fail_on_call: Rc::clone(&fail_on_call)
+    };
+    let mut decoder = JpegDecoder::new(cursor);
+    decoder.decode_headers().unwrap();
+    calls.set(0);
+    fail_on_call.set(2);
+
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0xCD; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    assert_eq!(
+        raw.decode_next_imcu_row(&mut refs, &strides).unwrap(),
+        RawImcuRowStatus::NeedMoreInput
+    );
+    assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+
+    fail_on_call.set(0);
+    let mut retry_storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut retry_refs: Vec<&mut [u8]> =
+        retry_storage.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut retry_refs, &strides).unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_raw_pull_incremental_parity() {
+    assert_incremental_raw_pull_matches_oneshot(
+        "arithmetic_restart_pull",
+        include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg"),
+        23
+    );
+    assert_incremental_raw_pull_matches_oneshot(
+        "arithmetic_progressive_pull",
+        include_bytes!("../../../test-images/jpeg/arith/prog.jpg"),
+        23
+    );
+}
+
+#[test]
 #[cfg(feature = "arith")]
 fn arithmetic_incremental_parity() {
     assert_incremental_decode_matrix(&[
@@ -2761,6 +2953,43 @@ fn switching_checkpointed_pixel_decode_to_whole_raw_replays_from_start() {
     let mut actual = allocate_raw_planes(&raw);
     decode_raw_into_existing(&mut raw, &mut actual).unwrap();
     assert_raw_planes_match(&actual, &expected, "pixel_to_whole_raw", data.len());
+}
+
+#[test]
+fn switching_checkpointed_pixel_decode_to_raw_pull_replays_from_start() {
+    let data = include_bytes!("../../../test-images/jpeg/sampling_factors.jpg");
+    let entropy_start = entropy_start(data);
+    let cutoff = entropy_start + (data.len() - entropy_start) * 60 / 100;
+    let expected = decode_raw_oneshot(data);
+    let (mut decoder, limit) =
+        checkpointed_pixel_decoder(data, cutoff, DecoderOptions::default());
+    limit.set(data.len());
+
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<_> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut planes: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    let rows_written = match raw
+        .decode_next_imcu_row(&mut planes, &strides)
+        .unwrap()
+    {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("raw pull did not replay its first stripe")
+    };
+    for index in 0..count {
+        for row in 0..rows_written[index] {
+            assert_eq!(
+                &storage[index][row * strides[index]..(row + 1) * strides[index]],
+                &expected[index]
+                    [row * layout[index].stride..row * layout[index].stride + strides[index]]
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/zune-jpeg/tests/incremental.rs
+++ b/crates/zune-jpeg/tests/incremental.rs
@@ -11,7 +11,7 @@
 //! Verifies that `is_recoverable_eof()` is reported on truncated input
 //! and that retrying with more data produces correct output.
 
-use zune_core::bytestream::ZCursor;
+use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::JpegDecoder;
@@ -220,6 +220,276 @@ fn assert_decode_into_replay_matches_oneshot(name: &str, data: &[u8]) {
     assert_pixels_match(&replay, &expected, name, data.len());
 }
 
+fn allocate_raw_planes<T>(decoder: &JpegDecoder<T>) -> Vec<Vec<u8>>
+where
+    T: ZByteReaderTrait
+{
+    let layout = decoder.planar_layout().unwrap();
+    let n_components = decoder.num_components().unwrap();
+    (0..n_components)
+        .map(|index| vec![0u8; layout[index].byte_size])
+        .collect()
+}
+
+fn decode_raw_into_existing<T>(
+    decoder: &mut JpegDecoder<T>, planes: &mut [Vec<u8>]
+) -> Result<(), zune_jpeg::errors::DecodeErrors>
+where
+    T: ZByteReaderTrait
+{
+    let mut plane_refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    decoder.decode_raw(&mut plane_refs)
+}
+
+fn allocate_raw_strided_planes<T>(decoder: &JpegDecoder<T>) -> (Vec<Vec<u8>>, Vec<usize>)
+where
+    T: ZByteReaderTrait
+{
+    let layout = decoder.planar_layout().unwrap();
+    let n_components = decoder.num_components().unwrap();
+    let strides: Vec<usize> = (0..n_components)
+        .map(|index| layout[index].width + 5)
+        .collect();
+    let planes = (0..n_components)
+        .map(|index| vec![0xAAu8; strides[index] * layout[index].height])
+        .collect();
+    (planes, strides)
+}
+
+fn decode_raw_strided_into_existing<T>(
+    decoder: &mut JpegDecoder<T>, planes: &mut [Vec<u8>], strides: &[usize]
+) -> Result<(), zune_jpeg::errors::DecodeErrors>
+where
+    T: ZByteReaderTrait
+{
+    let mut plane_refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    decoder.decode_raw_strided(&mut plane_refs, strides)
+}
+
+fn decode_raw_oneshot(data: &[u8]) -> Vec<Vec<u8>> {
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().expect("one-shot raw headers failed");
+    let mut planes = allocate_raw_planes(&decoder);
+    decode_raw_into_existing(&mut decoder, &mut planes).expect("one-shot raw decode failed");
+    planes
+}
+
+fn assert_raw_planes_match(
+    actual: &[Vec<u8>], expected: &[Vec<u8>], name: &str, available: usize
+) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{name}: incremental and one-shot raw plane counts differ"
+    );
+
+    for (plane_index, (actual_plane, expected_plane)) in
+        actual.iter().zip(expected).enumerate()
+    {
+        assert_eq!(
+            actual_plane.len(),
+            expected_plane.len(),
+            "{name}: raw plane {plane_index} lengths differ"
+        );
+        if let Some(index) = actual_plane
+            .iter()
+            .zip(expected_plane)
+            .position(|(left, right)| left != right)
+        {
+            let start = index.saturating_sub(8);
+            let end = (index + 9).min(actual_plane.len());
+            panic!(
+                "{name}: first raw plane {plane_index} mismatch at {index} with {available} bytes visible: incremental={}, one-shot={}, incremental window={:?}, one-shot window={:?}",
+                actual_plane[index],
+                expected_plane[index],
+                &actual_plane[start..end],
+                &expected_plane[start..end]
+            );
+        }
+    }
+}
+
+fn assert_raw_strided_planes_match_padded(
+    actual: &[Vec<u8>], strides: &[usize], expected: &[Vec<u8>], name: &str,
+    data: &[u8], available: usize
+) {
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    let layout = decoder.planar_layout().unwrap();
+    let n_components = decoder.num_components().unwrap();
+
+    assert_eq!(actual.len(), n_components, "{name}: strided plane count differs");
+    assert_eq!(strides.len(), n_components, "{name}: stride count differs");
+    assert_eq!(expected.len(), n_components, "{name}: padded plane count differs");
+
+    for index in 0..n_components {
+        let plane = layout[index];
+        assert_eq!(
+            actual[index].len(),
+            strides[index] * plane.height,
+            "{name}: strided plane {index} length differs"
+        );
+        for y in 0..plane.height {
+            for x in 0..plane.width {
+                let actual_value = actual[index][y * strides[index] + x];
+                let expected_value = expected[index][y * plane.stride + x];
+                assert_eq!(
+                    actual_value, expected_value,
+                    "{name}: strided raw plane {index} mismatch at ({x},{y}) with {available} bytes visible"
+                );
+            }
+            for x in plane.width..strides[index] {
+                assert_eq!(
+                    actual[index][y * strides[index] + x],
+                    0xAA,
+                    "{name}: strided padding modified in plane {index} at ({x},{y})"
+                );
+            }
+        }
+    }
+}
+
+fn assert_incremental_raw_decode_matches_oneshot(name: &str, data: &[u8], step: usize) {
+    assert!(step > 0, "incremental step must be non-zero");
+
+    let expected = decode_raw_oneshot(data);
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    let mut header_done = false;
+    let mut planes: Vec<Vec<u8>> = Vec::new();
+    let mut available = 0_usize;
+
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+
+        if !header_done {
+            match decoder.decode_headers() {
+                Ok(()) => {
+                    header_done = true;
+                    planes = allocate_raw_planes(&decoder);
+                }
+                Err(ref err) if err.is_recoverable_eof() => {
+                    assert!(
+                        available < data.len(),
+                        "raw headers still need more data with the full input visible"
+                    );
+                    continue;
+                }
+                Err(err) => panic!("unexpected raw header error at byte {available}: {err:?}")
+            }
+        }
+
+        match decode_raw_into_existing(&mut decoder, &mut planes) {
+            Ok(()) => {
+                assert_raw_planes_match(&planes, &expected, name, available);
+                return;
+            }
+            Err(ref err) if err.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "raw scan still needs more data with the full input visible"
+                );
+            }
+            Err(err) => panic!("unexpected raw scan error at byte {available}: {err:?}")
+        }
+    }
+}
+
+fn assert_incremental_raw_strided_decode_matches_oneshot(
+    name: &str, data: &[u8], step: usize
+) {
+    assert!(step > 0, "incremental step must be non-zero");
+
+    let expected = decode_raw_oneshot(data);
+    let limit = Rc::new(Cell::new(0_usize));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    let mut header_done = false;
+    let mut planes: Vec<Vec<u8>> = Vec::new();
+    let mut strides: Vec<usize> = Vec::new();
+    let mut available = 0_usize;
+
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+
+        if !header_done {
+            match decoder.decode_headers() {
+                Ok(()) => {
+                    header_done = true;
+                    (planes, strides) = allocate_raw_strided_planes(&decoder);
+                }
+                Err(ref err) if err.is_recoverable_eof() => {
+                    assert!(
+                        available < data.len(),
+                        "raw strided headers still need more data with the full input visible"
+                    );
+                    continue;
+                }
+                Err(err) => {
+                    panic!("unexpected raw strided header error at byte {available}: {err:?}")
+                }
+            }
+        }
+
+        match decode_raw_strided_into_existing(&mut decoder, &mut planes, &strides) {
+            Ok(()) => {
+                assert_raw_strided_planes_match_padded(
+                    &planes, &strides, &expected, name, data, available
+                );
+                return;
+            }
+            Err(ref err) if err.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "raw strided scan still needs more data with the full input visible"
+                );
+            }
+            Err(err) => panic!("unexpected raw strided scan error at byte {available}: {err:?}")
+        }
+    }
+}
+
+fn assert_decode_raw_replay_matches_oneshot(name: &str, data: &[u8]) {
+    let expected = decode_raw_oneshot(data);
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    let mut first = allocate_raw_planes(&decoder);
+    decode_raw_into_existing(&mut decoder, &mut first).unwrap();
+    assert_raw_planes_match(&first, &expected, name, data.len());
+
+    let mut replay = allocate_raw_planes(&decoder);
+    decode_raw_into_existing(&mut decoder, &mut replay).unwrap();
+    assert_raw_planes_match(&replay, &expected, name, data.len());
+}
+
+fn assert_decode_raw_strided_replay_matches_oneshot(name: &str, data: &[u8]) {
+    let expected = decode_raw_oneshot(data);
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    let (mut first, strides) = allocate_raw_strided_planes(&decoder);
+    decode_raw_strided_into_existing(&mut decoder, &mut first, &strides).unwrap();
+    assert_raw_strided_planes_match_padded(&first, &strides, &expected, name, data, data.len());
+
+    let (mut replay, replay_strides) = allocate_raw_strided_planes(&decoder);
+    assert_eq!(replay_strides, strides);
+    decode_raw_strided_into_existing(&mut decoder, &mut replay, &replay_strides).unwrap();
+    assert_raw_strided_planes_match_padded(
+        &replay,
+        &replay_strides,
+        &expected,
+        name,
+        data,
+        data.len()
+    );
+}
+
 /// Feeding the entire file at once via decode_headers + decode_into must
 /// produce byte-identical output to decode() — no regressions.
 #[test]
@@ -242,6 +512,30 @@ fn decode_into_replay_after_success_matches_oneshot() {
     );
     assert_decode_into_replay_matches_oneshot(
         "progressive_replay",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg")
+    );
+}
+
+#[test]
+fn decode_raw_replay_after_success_matches_oneshot() {
+    assert_decode_raw_replay_matches_oneshot(
+        "baseline_raw_replay",
+        include_bytes!("../../../test-images/jpeg/synthetic_image.jpg")
+    );
+    assert_decode_raw_replay_matches_oneshot(
+        "progressive_raw_replay",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg")
+    );
+}
+
+#[test]
+fn decode_raw_strided_replay_after_success_matches_oneshot() {
+    assert_decode_raw_strided_replay_matches_oneshot(
+        "baseline_raw_strided_replay",
+        include_bytes!("../../../test-images/jpeg/fox410.jpg")
+    );
+    assert_decode_raw_strided_replay_matches_oneshot(
+        "progressive_raw_strided_replay",
         include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg")
     );
 }
@@ -1451,6 +1745,20 @@ fn progressive_repeated_dc_eof_falls_back_to_scan_boundary() {
 }
 
 #[test]
+fn raw_incremental_parity() {
+    assert_incremental_raw_decode_matches_oneshot(
+        "synthetic_image_raw",
+        include_bytes!("../../../test-images/jpeg/synthetic_image.jpg"),
+        37
+    );
+    assert_incremental_raw_decode_matches_oneshot(
+        "down_sampled_grayscale_prog_raw",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+        31
+    );
+}
+
+#[test]
 fn progressive_unsafe_scans_replay_from_scan_boundary() {
     let data = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
     let expected = decode_oneshot(data);
@@ -1568,6 +1876,20 @@ fn progressive_arithmetic_restart_replays_dc_scan_boundary() {
 }
 
 #[test]
+fn raw_strided_incremental_parity() {
+    assert_incremental_raw_strided_decode_matches_oneshot(
+        "fox410_raw_strided",
+        include_bytes!("../../../test-images/jpeg/fox410.jpg"),
+        4096
+    );
+    assert_incremental_raw_strided_decode_matches_oneshot(
+        "down_sampled_grayscale_prog_raw_strided",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+        31
+    );
+}
+
+#[test]
 #[cfg(feature = "arith")]
 fn arithmetic_incremental_parity() {
     assert_incremental_decode_matrix(&[
@@ -1636,6 +1958,40 @@ fn arithmetic_restart_resume_uses_rst_checkpoint() {
         "retry should seek to first RST checkpoint at 857, got {seeks:?}"
     );
     assert_pixels_match(&out, &expected, "arith_seq_restart_checkpoint", data.len());
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_restart_raw_resume_uses_rst_checkpoint() {
+    let data = include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg");
+    let expected = decode_raw_oneshot(data);
+    let limit = Rc::new(Cell::new(874_usize));
+    let seek_log = Rc::new(RefCell::new(Vec::new()));
+    let cursor = GrowableCursor::with_seek_log(data, Rc::clone(&limit), Rc::clone(&seek_log));
+    let mut decoder = JpegDecoder::new(cursor);
+
+    decoder
+        .decode_headers()
+        .expect("headers should be visible before first raw RST retry");
+    let mut planes = allocate_raw_planes(&decoder);
+    let err = decode_raw_into_existing(&mut decoder, &mut planes)
+        .expect_err("truncated raw scan after first RST should be recoverable");
+    assert!(
+        err.is_recoverable_eof(),
+        "expected recoverable EOF, got {err:?}"
+    );
+
+    seek_log.borrow_mut().clear();
+    limit.set(data.len());
+    decode_raw_into_existing(&mut decoder, &mut planes)
+        .expect("full input should resume raw decode from RST checkpoint");
+
+    let seeks = seek_log.borrow();
+    assert!(
+        seeks.contains(&857),
+        "raw retry should seek to first RST checkpoint at 857, got {seeks:?}"
+    );
+    assert_raw_planes_match(&planes, &expected, "arith_seq_restart_raw_checkpoint", data.len());
 }
 
 /// Sanity check: byte-by-byte incremental decode of a normal image (no

--- a/crates/zune-jpeg/tests/non_interleaved.rs
+++ b/crates/zune-jpeg/tests/non_interleaved.rs
@@ -17,6 +17,12 @@
 use zune_core::bytestream::ZCursor;
 use zune_jpeg::JpegDecoder;
 
+fn pixel_digest(pixels: &[u8]) -> u64 {
+    pixels.iter().fold(0xcbf29ce484222325, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x100000001b3)
+    })
+}
+
 /// Test decoding a non-interleaved 4:4:4 baseline JPEG (64x64).
 ///
 /// This test image has 3 separate SOS markers (one per Y, Cb, Cr component).
@@ -85,6 +91,7 @@ fn decode_non_interleaved_420_64x64() {
     assert_eq!(info.width, 64);
     assert_eq!(info.height, 64);
     assert_eq!(pixels.len(), 64 * 64 * 3);
+    assert_eq!(pixel_digest(&pixels), 0xcb8faa9b4c94a0e5);
 
     // All pixels should have color (no large black regions from failed upsampling)
     let non_black = pixels.chunks(3).filter(|c| c[0] > 5 || c[1] > 5 || c[2] > 5).count();
@@ -123,6 +130,7 @@ fn decode_non_interleaved_440_64x64() {
     assert_eq!(info.width, 64);
     assert_eq!(info.height, 64);
     assert_eq!(pixels.len(), 64 * 64 * 3);
+    assert_eq!(pixel_digest(&pixels), 0xcb8faa9b4c94a0e5);
 }
 
 /// Test that the existing sos_news.jpeg (non-interleaved) still works.

--- a/crates/zune-jpeg/tests/planar_layout.rs
+++ b/crates/zune-jpeg/tests/planar_layout.rs
@@ -6,7 +6,7 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-//! Tests for `JpegDecoder::planar_layout()` and `num_components()`.
+//! Tests for raw output session layout and component metadata.
 //!
 //! These verify the per-component plane geometry exposed for raw planar
 //! output, against fixture images with known dimensions and sampling
@@ -20,16 +20,31 @@ use zune_jpeg::JpegDecoder;
 fn layout_for(bytes: &[u8]) -> ([zune_jpeg::PlaneInfo; 4], usize) {
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.decode_headers().expect("decode_headers failed");
-    let n = decoder.num_components().expect("num_components");
-    let layout = decoder.planar_layout().expect("planar_layout");
+    let raw = decoder.raw_output();
+    let n = raw.num_components().expect("num_components");
+    let layout = raw.layout().expect("raw layout");
     (layout, n)
+}
+
+fn assert_sampling_factors(layout: &[zune_jpeg::PlaneInfo], expected: &[(usize, usize)]) {
+    let actual: Vec<(usize, usize)> = layout
+        .iter()
+        .map(|plane| {
+            (
+                plane.horizontal_sampling_factor,
+                plane.vertical_sampling_factor
+            )
+        })
+        .collect();
+    assert_eq!(actual, expected);
 }
 
 #[test]
 fn planar_layout_unavailable_before_headers() {
-    let decoder = JpegDecoder::new(ZCursor::new(&[][..]));
-    assert!(decoder.num_components().is_none());
-    assert!(decoder.planar_layout().is_none());
+    let mut decoder = JpegDecoder::new(ZCursor::new(&[][..]));
+    let raw = decoder.raw_output();
+    assert!(raw.num_components().is_none());
+    assert!(raw.layout().is_none());
 }
 
 #[test]
@@ -37,6 +52,7 @@ fn planar_layout_444_64x64_aligned() {
     let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
     let (layout, n) = layout_for(bytes);
     assert_eq!(n, 3, "expected 3 components for YCbCr 4:4:4");
+    assert_sampling_factors(&layout[..n], &[(1, 1), (1, 1), (1, 1)]);
     for plane in &layout[..3] {
         assert_eq!(plane.width, 64);
         assert_eq!(plane.height, 64);
@@ -53,6 +69,7 @@ fn planar_layout_422_64x64_aligned() {
     let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg");
     let (layout, n) = layout_for(bytes);
     assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(2, 1), (1, 1), (1, 1)]);
     // Y: full resolution.
     assert_eq!(layout[0].width, 64);
     assert_eq!(layout[0].height, 64);
@@ -73,6 +90,7 @@ fn planar_layout_420_64x64_aligned() {
     let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
     let (layout, n) = layout_for(bytes);
     assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(2, 2), (1, 1), (1, 1)]);
     assert_eq!(layout[0].width, 64);
     assert_eq!(layout[0].height, 64);
     assert_eq!(layout[0].stride, 64);
@@ -91,6 +109,7 @@ fn planar_layout_440_64x64_aligned() {
     let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg");
     let (layout, n) = layout_for(bytes);
     assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(1, 2), (1, 1), (1, 1)]);
     // Y: full resolution.
     assert_eq!(layout[0].width, 64);
     assert_eq!(layout[0].height, 64);
@@ -122,4 +141,27 @@ fn planar_layout_422_65x65_unaligned_pads_to_dct_block() {
         assert_eq!(plane.allocated_height, 72);
         assert_eq!(plane.byte_size, 40 * 72);
     }
+}
+
+#[test]
+fn planar_layout_exposes_411_sampling_factors() {
+    let mut bytes =
+        include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg").to_vec();
+    let sof = bytes
+        .windows(2)
+        .position(|marker| marker == [0xff, 0xc0])
+        .expect("SOF0 marker");
+    bytes[sof + 11] = 0x41;
+
+    let (layout, n) = layout_for(&bytes);
+    assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(4, 1), (1, 1), (1, 1)]);
+}
+
+#[test]
+fn planar_layout_exposes_410_sampling_factors() {
+    let bytes = include_bytes!("../../../test-images/jpeg/fox410.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    assert_sampling_factors(&layout[..n], &[(4, 2), (1, 1), (1, 1)]);
 }

--- a/crates/zune-jpeg/tests/planar_layout.rs
+++ b/crates/zune-jpeg/tests/planar_layout.rs
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+//! Tests for `JpegDecoder::planar_layout()` and `num_components()`.
+//!
+//! These verify the per-component plane geometry exposed for raw planar
+//! output, against fixture images with known dimensions and sampling
+//! factors. The math mirrors libjpeg-turbo's `jpeg_read_raw_data`:
+//! component dimensions are derived from sampling factors, then both
+//! axes are rounded up to DCT-block (8 sample) boundaries.
+
+use zune_core::bytestream::ZCursor;
+use zune_jpeg::JpegDecoder;
+
+fn layout_for(bytes: &[u8]) -> ([zune_jpeg::PlaneInfo; 4], usize) {
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().expect("decode_headers failed");
+    let n = decoder.num_components().expect("num_components");
+    let layout = decoder.planar_layout().expect("planar_layout");
+    (layout, n)
+}
+
+#[test]
+fn planar_layout_unavailable_before_headers() {
+    let decoder = JpegDecoder::new(ZCursor::new(&[][..]));
+    assert!(decoder.num_components().is_none());
+    assert!(decoder.planar_layout().is_none());
+}
+
+#[test]
+fn planar_layout_444_64x64_aligned() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3, "expected 3 components for YCbCr 4:4:4");
+    for plane in &layout[..3] {
+        assert_eq!(plane.width, 64);
+        assert_eq!(plane.height, 64);
+        assert_eq!(plane.stride, 64);
+        assert_eq!(plane.allocated_height, 64);
+        assert_eq!(plane.byte_size, 64 * 64);
+    }
+    // Trailing slot is unused/zero.
+    assert_eq!(layout[3], zune_jpeg::PlaneInfo::default());
+}
+
+#[test]
+fn planar_layout_422_64x64_aligned() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_64x64.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    // Y: full resolution.
+    assert_eq!(layout[0].width, 64);
+    assert_eq!(layout[0].height, 64);
+    assert_eq!(layout[0].stride, 64);
+    assert_eq!(layout[0].allocated_height, 64);
+    // Cb, Cr: half horizontal, full vertical.
+    for plane in &layout[1..3] {
+        assert_eq!(plane.width, 32);
+        assert_eq!(plane.height, 64);
+        assert_eq!(plane.stride, 32);
+        assert_eq!(plane.allocated_height, 64);
+        assert_eq!(plane.byte_size, 32 * 64);
+    }
+}
+
+#[test]
+fn planar_layout_420_64x64_aligned() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    assert_eq!(layout[0].width, 64);
+    assert_eq!(layout[0].height, 64);
+    assert_eq!(layout[0].stride, 64);
+    assert_eq!(layout[0].allocated_height, 64);
+    for plane in &layout[1..3] {
+        assert_eq!(plane.width, 32);
+        assert_eq!(plane.height, 32);
+        assert_eq!(plane.stride, 32);
+        assert_eq!(plane.allocated_height, 32);
+        assert_eq!(plane.byte_size, 32 * 32);
+    }
+}
+
+#[test]
+fn planar_layout_440_64x64_aligned() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    // Y: full resolution.
+    assert_eq!(layout[0].width, 64);
+    assert_eq!(layout[0].height, 64);
+    // Cb, Cr: full horizontal, half vertical.
+    for plane in &layout[1..3] {
+        assert_eq!(plane.width, 64);
+        assert_eq!(plane.height, 32);
+        assert_eq!(plane.stride, 64);
+        assert_eq!(plane.allocated_height, 32);
+    }
+}
+
+#[test]
+fn planar_layout_422_65x65_unaligned_pads_to_dct_block() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg");
+    let (layout, n) = layout_for(bytes);
+    assert_eq!(n, 3);
+    // Y: 65x65 → padded to 72x72.
+    assert_eq!(layout[0].width, 65);
+    assert_eq!(layout[0].height, 65);
+    assert_eq!(layout[0].stride, 72);
+    assert_eq!(layout[0].allocated_height, 72);
+    assert_eq!(layout[0].byte_size, 72 * 72);
+    // Cb, Cr: ceil(65/2) = 33 wide, 65 tall → padded to 40x72.
+    for plane in &layout[1..3] {
+        assert_eq!(plane.width, 33);
+        assert_eq!(plane.height, 65);
+        assert_eq!(plane.stride, 40);
+        assert_eq!(plane.allocated_height, 72);
+        assert_eq!(plane.byte_size, 40 * 72);
+    }
+}

--- a/crates/zune-jpeg/tests/raw_imcu_rows.rs
+++ b/crates/zune-jpeg/tests/raw_imcu_rows.rs
@@ -172,6 +172,55 @@ fn pull_rows_support_custom_strides_and_report_component_rows() {
 }
 
 #[test]
+fn recreated_session_continues_from_the_next_imcu_row() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+
+    let mut expected_decoder = JpegDecoder::new(ZCursor::new(bytes));
+    expected_decoder.decode_headers().unwrap();
+    let mut expected_session = expected_decoder.raw_output();
+    let layout = expected_session.layout().unwrap();
+    let count = expected_session.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let make_storage = || {
+        layout[..count]
+            .iter()
+            .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+            .collect::<Vec<Vec<u8>>>()
+    };
+    let mut expected_first = make_storage();
+    let mut expected_first_refs: Vec<&mut [u8]> =
+        expected_first.iter_mut().map(Vec::as_mut_slice).collect();
+    expected_session
+        .decode_next_imcu_row(&mut expected_first_refs, &strides)
+        .unwrap();
+    let mut expected_second = make_storage();
+    let mut expected_second_refs: Vec<&mut [u8]> =
+        expected_second.iter_mut().map(Vec::as_mut_slice).collect();
+    let expected_status = expected_session
+        .decode_next_imcu_row(&mut expected_second_refs, &strides)
+        .unwrap();
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut first = make_storage();
+    {
+        let mut session = decoder.raw_output();
+        let mut refs: Vec<&mut [u8]> = first.iter_mut().map(Vec::as_mut_slice).collect();
+        session.decode_next_imcu_row(&mut refs, &strides).unwrap();
+    }
+    let mut second = make_storage();
+    let actual_status = {
+        let mut session = decoder.raw_output();
+        let mut refs: Vec<&mut [u8]> = second.iter_mut().map(Vec::as_mut_slice).collect();
+        session.decode_next_imcu_row(&mut refs, &strides).unwrap()
+    };
+
+    assert_eq!(first, expected_first);
+    assert_eq!(actual_status, expected_status);
+    assert_eq!(second, expected_second);
+}
+
+#[test]
 fn completion_is_sticky_and_new_session_replays() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));

--- a/crates/zune-jpeg/tests/raw_imcu_rows.rs
+++ b/crates/zune-jpeg/tests/raw_imcu_rows.rs
@@ -1,0 +1,482 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This software is free software;
+ *
+ * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
+ */
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use zune_core::bytestream::ZCursor;
+use zune_core::options::DecoderOptions;
+use zune_jpeg::errors::DecodeErrors;
+use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
+
+fn decode_whole(bytes: &[u8]) -> (Vec<Vec<u8>>, [zune_jpeg::PlaneInfo; 4], usize) {
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let mut planes: Vec<Vec<u8>> = (0..count)
+        .map(|index| vec![0; layout[index].byte_size])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = planes.iter_mut().map(Vec::as_mut_slice).collect();
+    raw.decode_into(&mut refs).unwrap();
+    (planes, layout, count)
+}
+
+fn assert_pull_matches_whole(bytes: &[u8]) {
+    let (whole, layout, count) = decode_whole(bytes);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let mut actual: Vec<Vec<u8>> = (0..count)
+        .map(|index| vec![0; layout[index].width * layout[index].height])
+        .collect();
+    let mut component_rows = [0usize; 4];
+
+    loop {
+        let strides: Vec<usize> = (0..count).map(|index| layout[index].width).collect();
+        let mut stripe_storage: Vec<Vec<u8>> = (0..count)
+            .map(|index| {
+                let max_rows = layout[index].vertical_sampling_factor * 8;
+                vec![0xCD; strides[index] * max_rows]
+            })
+            .collect();
+        let mut refs: Vec<&mut [u8]> = stripe_storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    let row_start = component_rows[index];
+                    let row_end = row_start + rows_written[index];
+                    let dst_start = row_start * strides[index];
+                    let dst_end = row_end * strides[index];
+                    actual[index][dst_start..dst_end].copy_from_slice(
+                        &stripe_storage[index][..rows_written[index] * strides[index]]
+                    );
+                    assert!(
+                        stripe_storage[index][rows_written[index] * strides[index]..]
+                            .iter()
+                            .all(|byte| *byte == 0xCD)
+                    );
+                    component_rows[index] = row_end;
+                }
+            }
+            RawImcuRowStatus::NeedMoreInput => panic!("one-shot input unexpectedly suspended"),
+            RawImcuRowStatus::Complete => break,
+            _ => unreachable!("unknown raw iMCU-row status")
+        }
+    }
+
+    for index in 0..count {
+        assert_eq!(component_rows[index], layout[index].height);
+        for row in 0..layout[index].height {
+            let actual_row =
+                &actual[index][row * layout[index].width..(row + 1) * layout[index].width];
+            let whole_row = &whole[index]
+                [row * layout[index].stride..row * layout[index].stride + layout[index].width];
+            assert_eq!(actual_row, whole_row, "component {index}, row {row}");
+        }
+    }
+}
+
+#[test]
+fn pull_rows_match_whole_image_420() {
+    assert_pull_matches_whole(include_bytes!("../../../test-images/jpeg/2029.jpg"));
+}
+
+#[test]
+fn pull_rows_match_whole_image_444() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_444_64x64.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_422() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_422_64x64.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_odd_dimensions() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_422_65x65.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_progressive() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_non_interleaved_420() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_420_64x64.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_440() {
+    assert_pull_matches_whole(include_bytes!(
+        "../../../test-images/jpeg/non_interleaved_440_64x64.jpg"
+    ));
+}
+
+#[test]
+fn pull_rows_match_whole_image_410() {
+    assert_pull_matches_whole(include_bytes!("../../../test-images/jpeg/fox410.jpg"));
+}
+
+#[test]
+fn pull_rows_support_custom_strides_and_report_component_rows() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| vec![0xCD; strides[index] * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+    let rows_written = match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("first iMCU row was not ready")
+    };
+    assert_eq!(rows_written[0], 16);
+    assert_eq!(rows_written[1], 8);
+    assert_eq!(rows_written[2], 8);
+    for index in 0..count {
+        for row in 0..rows_written[index] {
+            let padding = &storage[index]
+                [row * strides[index] + layout[index].width..(row + 1) * strides[index]];
+            assert!(padding.iter().all(|byte| *byte == 0xCD));
+        }
+    }
+}
+
+#[test]
+fn completion_is_sticky_and_new_session_replays() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+
+    let mut first_rows = None;
+    loop {
+        let mut storage: Vec<Vec<u8>> = layout[..count]
+            .iter()
+            .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                first_rows.get_or_insert((rows_written, storage));
+            }
+            RawImcuRowStatus::Complete => break,
+            RawImcuRowStatus::NeedMoreInput => panic!("one-shot input suspended"),
+            _ => unreachable!("unknown raw iMCU-row status")
+        }
+    }
+
+    let mut empty: Vec<&mut [u8]> = Vec::new();
+    assert_eq!(
+        raw.decode_next_imcu_row(&mut empty, &[]).unwrap(),
+        RawImcuRowStatus::Complete
+    );
+    drop(raw);
+
+    let mut replay = decoder.raw_output();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    let rows_written = match replay.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("replay did not yield its first row")
+    };
+    let (expected_rows, expected_storage) = first_rows.unwrap();
+    assert_eq!(rows_written, expected_rows);
+    assert_eq!(storage, expected_storage);
+}
+
+#[test]
+fn cancellation_does_not_publish_a_row() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    decoder.set_cancel(|| true);
+    decoder.set_cancel_interval(1);
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0xCD; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+    let error = raw.decode_next_imcu_row(&mut refs, &strides).unwrap_err();
+    assert!(matches!(error, DecodeErrors::Cancelled));
+    assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+}
+
+#[test]
+fn buffered_baseline_cancellation_between_rows_is_atomic() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg");
+    let (whole, _, _) = decode_whole(bytes);
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let check = Arc::clone(&cancelled);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.set_cancel(move || check.load(Ordering::SeqCst));
+    decoder.set_cancel_interval(1);
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+
+    let mut first: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut first_refs: Vec<&mut [u8]> = first.iter_mut().map(Vec::as_mut_slice).collect();
+    let first_rows = match raw.decode_next_imcu_row(&mut first_refs, &strides).unwrap() {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("first pull did not yield a row")
+    };
+
+    cancelled.store(true, Ordering::SeqCst);
+    let mut cancelled_storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0xCD; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut cancelled_refs: Vec<&mut [u8]> = cancelled_storage
+        .iter_mut()
+        .map(Vec::as_mut_slice)
+        .collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut cancelled_refs, &strides),
+        Err(DecodeErrors::Cancelled)
+    ));
+    assert!(cancelled_storage.iter().flatten().all(|byte| *byte == 0xCD));
+
+    cancelled.store(false, Ordering::SeqCst);
+    let mut retry: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut retry_refs: Vec<&mut [u8]> = retry.iter_mut().map(Vec::as_mut_slice).collect();
+    let retry_rows = match raw.decode_next_imcu_row(&mut retry_refs, &strides).unwrap() {
+        RawImcuRowStatus::RowReady { rows_written } => rows_written,
+        _ => panic!("retry did not yield the next row")
+    };
+    for index in 0..count {
+        for row in 0..retry_rows[index] {
+            let retry_start = row * strides[index];
+            let whole_start = (first_rows[index] + row) * layout[index].stride;
+            assert_eq!(
+                &retry[index][retry_start..retry_start + layout[index].width],
+                &whole[index][whole_start..whole_start + layout[index].width],
+                "component {index}, retried row {row}"
+            );
+        }
+    }
+}
+
+#[test]
+fn switching_to_pixel_decode_replays_from_scan_start() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut refs, &strides).unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+    drop(raw);
+
+    let mut actual = vec![0; decoder.output_buffer_size().unwrap()];
+    decoder.decode_into(&mut actual).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn switching_pull_to_whole_raw_is_rejected() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut stripe: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut stripe_refs: Vec<&mut [u8]> = stripe.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut stripe_refs, &strides)
+            .unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+
+    let mut whole: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.byte_size])
+        .collect();
+    let mut whole_refs: Vec<&mut [u8]> = whole.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_into(&mut whole_refs),
+        Err(DecodeErrors::FormatStatic(_))
+    ));
+}
+
+#[test]
+fn invalid_pull_does_not_claim_raw_output_ownership() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut [], &[]),
+        Err(DecodeErrors::Format(_))
+    ));
+
+    let mut whole: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.byte_size])
+        .collect();
+    let mut whole_refs: Vec<&mut [u8]> = whole.iter_mut().map(Vec::as_mut_slice).collect();
+    raw.decode_into(&mut whole_refs).unwrap();
+    assert!(whole
+        .iter()
+        .all(|plane| plane.iter().any(|byte| *byte != 0)));
+}
+
+#[test]
+fn invalid_pull_stride_does_not_claim_raw_output_ownership() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let mut strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    strides[0] -= 1;
+    let mut stripe: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut stripe_refs: Vec<&mut [u8]> = stripe.iter_mut().map(Vec::as_mut_slice).collect();
+
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut stripe_refs, &strides),
+        Err(DecodeErrors::Format(_))
+    ));
+
+    let mut whole: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.byte_size])
+        .collect();
+    let mut whole_refs: Vec<&mut [u8]> = whole.iter_mut().map(Vec::as_mut_slice).collect();
+    raw.decode_into(&mut whole_refs).unwrap();
+    assert!(whole
+        .iter()
+        .all(|plane| plane.iter().any(|byte| *byte != 0)));
+}
+
+#[test]
+fn changing_options_aborts_pull_and_replays_from_scan_start() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    let mut first: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut first_refs: Vec<&mut [u8]> = first.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut first_refs, &strides).unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+    drop(raw);
+
+    decoder.set_options(DecoderOptions::default());
+    let mut replay = decoder.raw_output();
+    let mut replay_first: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut replay_refs: Vec<&mut [u8]> = replay_first.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        replay
+            .decode_next_imcu_row(&mut replay_refs, &strides)
+            .unwrap(),
+        RawImcuRowStatus::RowReady { .. }
+    ));
+    assert_eq!(replay_first, first);
+}
+
+#[test]
+fn dnl_pull_is_rejected_before_false_completion() {
+    let bytes = include_bytes!("images/dnl_image.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let initial_layout = raw.layout().unwrap();
+    assert_eq!(initial_layout[0].height, 0);
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = initial_layout[..count]
+        .iter()
+        .map(|plane| plane.width)
+        .collect();
+    let mut storage: Vec<Vec<u8>> = initial_layout[..count]
+        .iter()
+        .map(|plane| vec![0; plane.width * plane.vertical_sampling_factor * 8])
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut refs, &strides),
+        Err(DecodeErrors::FormatStatic(
+            "raw output does not support DNL images"
+        ))
+    ));
+}

--- a/crates/zune-jpeg/tests/raw_imcu_rows.rs
+++ b/crates/zune-jpeg/tests/raw_imcu_rows.rs
@@ -6,13 +6,78 @@
  * You can redistribute it or modify it under terms of the MIT, Apache License or Zlib license
  */
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::cell::Cell;
+use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use zune_core::bytestream::ZCursor;
 use zune_core::options::DecoderOptions;
 use zune_jpeg::errors::DecodeErrors;
 use zune_jpeg::{JpegDecoder, RawImcuRowStatus};
+
+struct GrowableCursor<'a> {
+    data: &'a [u8],
+    position: usize,
+    limit: Rc<Cell<usize>>,
+}
+
+impl<'a> GrowableCursor<'a> {
+    fn new(data: &'a [u8], limit: Rc<Cell<usize>>) -> Self {
+        Self {
+            data,
+            position: 0,
+            limit,
+        }
+    }
+
+    fn visible(&self) -> usize {
+        self.limit.get().min(self.data.len())
+    }
+}
+
+impl Read for GrowableCursor<'_> {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        let visible = self.visible();
+        if self.position >= visible {
+            return Ok(0);
+        }
+        let count = output.len().min(visible - self.position);
+        output[..count].copy_from_slice(&self.data[self.position..self.position + count]);
+        self.position += count;
+        Ok(count)
+    }
+}
+
+impl BufRead for GrowableCursor<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        let visible = self.visible();
+        Ok(&self.data[self.position.min(visible)..visible])
+    }
+
+    fn consume(&mut self, amount: usize) {
+        self.position += amount;
+    }
+}
+
+impl Seek for GrowableCursor<'_> {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        let next = match position {
+            SeekFrom::Start(value) => value as i64,
+            SeekFrom::Current(value) => self.position as i64 + value,
+            SeekFrom::End(value) => self.visible() as i64 + value,
+        };
+        if next < 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "seek before start",
+            ));
+        }
+        self.position = next as usize;
+        Ok(self.position as u64)
+    }
+}
 
 fn decode_whole(bytes: &[u8]) -> (Vec<Vec<u8>>, [zune_jpeg::PlaneInfo; 4], usize) {
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
@@ -171,6 +236,398 @@ fn pull_rows_support_custom_strides_and_report_component_rows() {
     }
 }
 
+fn pull_required_len(rows: usize, stride: usize, width: usize) -> usize {
+    if rows == 0 {
+        0
+    } else {
+        (rows - 1) * stride + width
+    }
+}
+
+fn with_luma_sampling(data: &[u8], sampling: u8) -> Vec<u8> {
+    let mut bytes = data.to_vec();
+    let sof = bytes
+        .windows(2)
+        .position(|marker| marker == [0xff, 0xc0])
+        .expect("baseline SOF marker");
+    bytes[sof + 11] = sampling;
+    bytes
+}
+
+fn assert_exact_sized_pull_matches_whole(bytes: &[u8]) {
+    const GUARD: usize = 17;
+    const SENTINEL: u8 = 0xCD;
+
+    let (whole, layout, count) = decode_whole(bytes);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let mut component_rows = [0usize; 4];
+
+    loop {
+        let rows: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| {
+                (plane.height - component_rows[index]).min(plane.vertical_sampling_factor * 8)
+            })
+            .collect();
+        let required: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+            .collect();
+        let mut storage: Vec<Vec<u8>> = required
+            .iter()
+            .map(|length| vec![SENTINEL; length + GUARD])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    assert_eq!(rows_written[index], rows[index]);
+                    for row in 0..rows[index] {
+                        let actual_start = row * strides[index];
+                        let expected_start = (component_rows[index] + row) * layout[index].stride;
+                        assert_eq!(
+                            &storage[index][actual_start..actual_start + layout[index].width],
+                            &whole[index][expected_start..expected_start + layout[index].width]
+                        );
+                        if row + 1 < rows[index] {
+                            assert!(storage[index]
+                                [actual_start + layout[index].width..(row + 1) * strides[index]]
+                                .iter()
+                                .all(|byte| *byte == SENTINEL));
+                        }
+                    }
+                    assert!(storage[index][required[index]..]
+                        .iter()
+                        .all(|byte| *byte == SENTINEL));
+                    component_rows[index] += rows_written[index];
+                }
+            }
+            RawImcuRowStatus::Complete => break,
+            RawImcuRowStatus::NeedMoreInput => panic!("one-shot input suspended"),
+            _ => unreachable!("unknown raw iMCU-row status"),
+        }
+    }
+
+    for index in 0..count {
+        assert_eq!(component_rows[index], layout[index].height);
+    }
+}
+
+fn assert_incremental_pull_is_atomic(
+    name: &str, data: &[u8], step: usize, minimum_suspensions: usize,
+) {
+    const GUARD: usize = 17;
+    const SENTINEL: u8 = 0xCD;
+
+    let (whole, _, _) = decode_whole(data);
+    let limit = Rc::new(Cell::new(0));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+    let mut available = 0;
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+        match decoder.decode_headers() {
+            Ok(()) => break,
+            Err(ref error) if error.is_recoverable_eof() => {
+                assert!(
+                    available < data.len(),
+                    "{name}: headers suspended with full input"
+                );
+            }
+            Err(error) => panic!("{name}: header error at {available}: {error:?}"),
+        }
+    }
+
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 7)
+        .collect();
+    let mut component_rows = [0usize; 4];
+    let mut suspensions = 0;
+
+    loop {
+        let rows: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| {
+                (plane.height - component_rows[index]).min(plane.vertical_sampling_factor * 8)
+            })
+            .collect();
+        let required: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+            .collect();
+        let mut storage: Vec<Vec<u8>> = required
+            .iter()
+            .map(|length| vec![SENTINEL; length + GUARD])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        match raw.decode_next_imcu_row(&mut refs, &strides).unwrap() {
+            RawImcuRowStatus::NeedMoreInput => {
+                suspensions += 1;
+                assert!(storage.iter().flatten().all(|byte| *byte == SENTINEL));
+                assert!(available < data.len(), "{name}: suspended with full input");
+                available = (available + step).min(data.len());
+                limit.set(available);
+            }
+            RawImcuRowStatus::RowReady { rows_written } => {
+                for index in 0..count {
+                    assert_eq!(rows_written[index], rows[index]);
+                    for row in 0..rows_written[index] {
+                        let actual_start = row * strides[index];
+                        let expected_start = (component_rows[index] + row) * layout[index].stride;
+                        assert_eq!(
+                            &storage[index][actual_start..actual_start + layout[index].width],
+                            &whole[index][expected_start..expected_start + layout[index].width],
+                            "{name}: component {index}, row {}",
+                            component_rows[index] + row
+                        );
+                    }
+                    assert!(storage[index][required[index]..]
+                        .iter()
+                        .all(|byte| *byte == SENTINEL));
+                    component_rows[index] += rows_written[index];
+                }
+            }
+            RawImcuRowStatus::Complete => break,
+            _ => unreachable!("unknown raw iMCU-row status"),
+        }
+    }
+
+    assert!(
+        suspensions >= minimum_suspensions,
+        "{name}: expected at least {minimum_suspensions} suspensions, got {suspensions}"
+    );
+    for index in 0..count {
+        assert_eq!(component_rows[index], layout[index].height);
+    }
+}
+
+#[test]
+fn exact_minimum_lengths_cover_sampling_modes_and_final_stripes() {
+    for bytes in [
+        &include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg")[..],
+        &include_bytes!("../../../test-images/jpeg/non_interleaved_440_64x64.jpg")[..],
+        &include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg")[..],
+        &include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg")[..],
+        &include_bytes!("../../../test-images/jpeg/fox410.jpg")[..],
+    ] {
+        assert_exact_sized_pull_matches_whole(bytes);
+    }
+
+    let sampling_411 = with_luma_sampling(
+        include_bytes!("../../../test-images/jpeg/non_interleaved_444_64x64.jpg"),
+        0x41,
+    );
+    assert_exact_sized_pull_matches_whole(&sampling_411);
+}
+
+#[test]
+fn suspension_cut_points_are_atomic_and_retry_exactly() {
+    assert_incremental_pull_is_atomic(
+        "baseline_bytewise",
+        include_bytes!("../../../test-images/jpeg/app14/baseline_rgb_interleaved.jpg"),
+        1,
+        100,
+    );
+    assert_incremental_pull_is_atomic(
+        "progressive_restart",
+        include_bytes!("../../../test-images/jpeg/progressive_restart_420.jpg"),
+        1,
+        100,
+    );
+    assert_incremental_pull_is_atomic(
+        "multi_sos",
+        include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg"),
+        1,
+        10,
+    );
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_suspension_cut_points_are_atomic_and_retry_exactly() {
+    assert_incremental_pull_is_atomic(
+        "arithmetic_restart",
+        include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg"),
+        1,
+        10,
+    );
+    assert_incremental_pull_is_atomic(
+        "arithmetic_progressive",
+        include_bytes!("../../../test-images/jpeg/arith/prog.jpg"),
+        1,
+        10,
+    );
+}
+
+#[test]
+fn exact_minimum_plane_lengths_succeed() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let expected_rows: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.vertical_sampling_factor * 8)
+        .collect();
+    let mut storage: Vec<Vec<u8>> = layout[..count]
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| {
+            vec![0xCD; pull_required_len(expected_rows[index], strides[index], plane.width)]
+        })
+        .collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+    let RawImcuRowStatus::RowReady { rows_written } =
+        raw.decode_next_imcu_row(&mut refs, &strides).unwrap()
+    else {
+        panic!("first iMCU row was not ready")
+    };
+    assert_eq!(&rows_written[..count], expected_rows);
+}
+
+#[test]
+fn one_byte_short_of_minimum_is_rejected() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+
+    for short_index in 0..3 {
+        let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+        decoder.decode_headers().unwrap();
+        let mut raw = decoder.raw_output();
+        let layout = raw.layout().unwrap();
+        let count = raw.num_components().unwrap();
+        let strides: Vec<usize> = layout[..count]
+            .iter()
+            .map(|plane| plane.width + 13)
+            .collect();
+        let rows: Vec<usize> = layout[..count]
+            .iter()
+            .map(|plane| plane.vertical_sampling_factor * 8)
+            .collect();
+        let required: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+            .collect();
+        let mut storage: Vec<Vec<u8>> = required
+            .iter()
+            .enumerate()
+            .map(|(index, length)| vec![0xCD; length - usize::from(index == short_index)])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        assert!(matches!(
+            raw.decode_next_imcu_row(&mut refs, &strides),
+            Err(DecodeErrors::TooSmallOutput(needed, actual))
+                if needed == required[short_index] && actual + 1 == needed
+        ));
+        assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+    }
+}
+
+#[test]
+fn overflowing_minimum_length_is_rejected() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let mut strides: Vec<usize> = layout[..count].iter().map(|plane| plane.width).collect();
+    strides[0] = usize::MAX;
+    let mut storage: Vec<Vec<u8>> = (0..count).map(|_| Vec::new()).collect();
+    let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut refs, &strides),
+        Err(DecodeErrors::FormatStatic(
+            "raw iMCU-row plane size overflow"
+        ))
+    ));
+}
+
+#[test]
+fn one_byte_short_of_final_clipped_stripe_is_rejected() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    let mut raw = decoder.raw_output();
+    let layout = raw.layout().unwrap();
+    let count = raw.num_components().unwrap();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 13)
+        .collect();
+    let mut component_rows = [0usize; 4];
+
+    loop {
+        let rows: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| {
+                (plane.height - component_rows[index]).min(plane.vertical_sampling_factor * 8)
+            })
+            .collect();
+        let required: Vec<usize> = layout[..count]
+            .iter()
+            .enumerate()
+            .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+            .collect();
+        let final_stripe = rows
+            .iter()
+            .enumerate()
+            .all(|(index, rows)| component_rows[index] + rows == layout[index].height);
+        let mut storage: Vec<Vec<u8>> = required
+            .iter()
+            .enumerate()
+            .map(|(index, length)| vec![0xCD; length - usize::from(final_stripe && index == 0)])
+            .collect();
+        let mut refs: Vec<&mut [u8]> = storage.iter_mut().map(Vec::as_mut_slice).collect();
+
+        if final_stripe {
+            assert!(matches!(
+                raw.decode_next_imcu_row(&mut refs, &strides),
+                Err(DecodeErrors::TooSmallOutput(needed, actual))
+                    if needed == required[0] && actual + 1 == needed
+            ));
+            assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+            break;
+        }
+
+        let RawImcuRowStatus::RowReady { rows_written } =
+            raw.decode_next_imcu_row(&mut refs, &strides).unwrap()
+        else {
+            panic!("non-final stripe was not ready")
+        };
+        for index in 0..count {
+            component_rows[index] += rows_written[index];
+        }
+    }
+}
+
 #[test]
 fn recreated_session_continues_from_the_next_imcu_row() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
@@ -252,6 +709,16 @@ fn completion_is_sticky_and_new_session_replays() {
         raw.decode_next_imcu_row(&mut empty, &[]).unwrap(),
         RawImcuRowStatus::Complete
     );
+    let mut exhausted_storage: Vec<Vec<u8>> = (0..count).map(|_| Vec::new()).collect();
+    let mut exhausted_planes: Vec<&mut [u8]> = exhausted_storage
+        .iter_mut()
+        .map(Vec::as_mut_slice)
+        .collect();
+    assert_eq!(
+        raw.decode_next_imcu_row(&mut exhausted_planes, &strides)
+            .unwrap(),
+        RawImcuRowStatus::Complete
+    );
     drop(raw);
 
     let mut replay = decoder.raw_output();
@@ -289,6 +756,64 @@ fn cancellation_does_not_publish_a_row() {
     let error = raw.decode_next_imcu_row(&mut refs, &strides).unwrap_err();
     assert!(matches!(error, DecodeErrors::Cancelled));
     assert!(storage.iter().flatten().all(|byte| *byte == 0xCD));
+}
+
+#[test]
+fn cancellation_during_a_stripe_is_atomic_and_retryable() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let (whole, layout, count) = decode_whole(bytes);
+    let polls = Arc::new(AtomicUsize::new(0));
+    let cancel_after = Arc::new(AtomicUsize::new(1));
+    let check_polls = Arc::clone(&polls);
+    let check_cancel_after = Arc::clone(&cancel_after);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.decode_headers().unwrap();
+    decoder.set_cancel(move || {
+        check_polls.fetch_add(1, Ordering::SeqCst) >= check_cancel_after.load(Ordering::SeqCst)
+    });
+    decoder.set_cancel_interval(1);
+    let mut raw = decoder.raw_output();
+    let strides: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.width + 9)
+        .collect();
+    let rows: Vec<usize> = layout[..count]
+        .iter()
+        .map(|plane| plane.vertical_sampling_factor * 8)
+        .collect();
+    let required: Vec<usize> = layout[..count]
+        .iter()
+        .enumerate()
+        .map(|(index, plane)| pull_required_len(rows[index], strides[index], plane.width))
+        .collect();
+    let mut cancelled: Vec<Vec<u8>> = required.iter().map(|length| vec![0xCD; *length]).collect();
+    let mut cancelled_refs: Vec<&mut [u8]> = cancelled.iter_mut().map(Vec::as_mut_slice).collect();
+
+    assert!(matches!(
+        raw.decode_next_imcu_row(&mut cancelled_refs, &strides),
+        Err(DecodeErrors::Cancelled)
+    ));
+    assert!(polls.load(Ordering::SeqCst) > 1);
+    assert!(cancelled.iter().flatten().all(|byte| *byte == 0xCD));
+
+    cancel_after.store(usize::MAX, Ordering::SeqCst);
+    let mut retry: Vec<Vec<u8>> = required.iter().map(|length| vec![0; *length]).collect();
+    let mut retry_refs: Vec<&mut [u8]> = retry.iter_mut().map(Vec::as_mut_slice).collect();
+    let RawImcuRowStatus::RowReady { rows_written } =
+        raw.decode_next_imcu_row(&mut retry_refs, &strides).unwrap()
+    else {
+        panic!("retry did not produce the first stripe")
+    };
+    for index in 0..count {
+        assert_eq!(rows_written[index], rows[index]);
+        for row in 0..rows[index] {
+            assert_eq!(
+                &retry[index][row * strides[index]..row * strides[index] + layout[index].width],
+                &whole[index]
+                    [row * layout[index].stride..row * layout[index].stride + layout[index].width]
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/zune-jpeg/tests/scanlines.rs
+++ b/crates/zune-jpeg/tests/scanlines.rs
@@ -689,6 +689,36 @@ fn completed_scanline_sequence_can_replay() {
 }
 
 #[test]
+fn recreated_session_continues_from_the_next_scanline() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+
+    let row_bytes = {
+        let mut scanlines = decoder.scanline_output();
+        assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+        let row_bytes = scanlines.output_row_bytes().unwrap();
+        let mut first = vec![0; row_bytes];
+        assert_eq!(
+            scanlines.read_scanlines(&mut first, row_bytes).unwrap(),
+            ScanlineReadStatus::RowsProcessed { rows: 1 }
+        );
+        assert_eq!(&first, &expected[..row_bytes]);
+        row_bytes
+    };
+
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    assert_eq!(scanlines.output_scanline(), 1);
+    let mut second = vec![0; row_bytes];
+    assert_eq!(
+        scanlines.read_scanlines(&mut second, row_bytes).unwrap(),
+        ScanlineReadStatus::RowsProcessed { rows: 1 }
+    );
+    assert_eq!(&second, &expected[row_bytes..2 * row_bytes]);
+}
+
+#[test]
 fn incremental_scanline_parity() {
     assert_incremental_scanlines_match_decode(
         "baseline",

--- a/crates/zune-jpeg/tests/scanlines.rs
+++ b/crates/zune-jpeg/tests/scanlines.rs
@@ -430,7 +430,7 @@ fn short_scanline_buffers_are_rejected_without_progress() {
 fn cancellation_does_not_publish_scanlines_and_can_retry() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
-    let cancelled = Arc::new(AtomicBool::new(true));
+    let cancelled = Arc::new(AtomicBool::new(false));
     let check = Arc::clone(&cancelled);
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
     decoder.set_cancel(move || check.load(Ordering::SeqCst));
@@ -439,6 +439,7 @@ fn cancellation_does_not_publish_scanlines_and_can_retry() {
     assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
     let row_bytes = scanlines.output_row_bytes().unwrap();
     let mut row = vec![0xCD; row_bytes];
+    cancelled.store(true, Ordering::SeqCst);
 
     assert!(matches!(
         scanlines.read_scanlines(&mut row, row_bytes),
@@ -460,7 +461,7 @@ fn cancellation_after_a_committed_batch_is_reported_on_the_next_read() {
     let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
     let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
     let polls = Arc::new(AtomicUsize::new(0));
-    let cancel_at = Arc::new(AtomicUsize::new(2));
+    let cancel_at = Arc::new(AtomicUsize::new(usize::MAX));
     let check_polls = Arc::clone(&polls);
     let check_cancel_at = Arc::clone(&cancel_at);
     let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
@@ -472,6 +473,8 @@ fn cancellation_after_a_committed_batch_is_reported_on_the_next_read() {
     assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
     let row_bytes = scanlines.output_row_bytes().unwrap();
     let mut output = vec![0xCD; row_bytes * 100];
+    polls.store(0, Ordering::SeqCst);
+    cancel_at.store(2, Ordering::SeqCst);
 
     let ScanlineReadStatus::RowsProcessed { rows: first_rows } =
         scanlines.read_scanlines(&mut output, row_bytes).unwrap()
@@ -636,6 +639,7 @@ fn changing_output_options_rebuilds_derived_state_for_replay() {
                 );
             }
             OptionChangePrelude::PixelCheckpoint => {
+                decoder.set_incremental_mode(true);
                 decoder.decode_headers().unwrap();
                 let mut old_output = vec![0; decoder.output_buffer_size().unwrap()];
                 for _ in 0..2 {

--- a/crates/zune-jpeg/tests/scanlines.rs
+++ b/crates/zune-jpeg/tests/scanlines.rs
@@ -1,0 +1,738 @@
+use std::cell::Cell;
+use std::io::{BufRead, Read, Seek, SeekFrom};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use zune_core::bytestream::{ZByteReaderTrait, ZCursor};
+use zune_core::colorspace::ColorSpace;
+use zune_core::options::DecoderOptions;
+use zune_jpeg::errors::DecodeErrors;
+use zune_jpeg::{JpegDecoder, ScanlineReadStatus, ScanlineStatus};
+
+struct GrowableCursor<'a> {
+    data:     &'a [u8],
+    position: usize,
+    limit:    Rc<Cell<usize>>
+}
+
+impl<'a> GrowableCursor<'a> {
+    fn new(data: &'a [u8], limit: Rc<Cell<usize>>) -> Self {
+        Self {
+            data,
+            position: 0,
+            limit
+        }
+    }
+
+    fn visible(&self) -> usize {
+        self.limit.get().min(self.data.len())
+    }
+}
+
+impl Read for GrowableCursor<'_> {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        let visible = self.visible();
+        if self.position >= visible {
+            return Ok(0);
+        }
+        let count = output.len().min(visible - self.position);
+        output[..count].copy_from_slice(&self.data[self.position..self.position + count]);
+        self.position += count;
+        Ok(count)
+    }
+}
+
+impl BufRead for GrowableCursor<'_> {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        let visible = self.visible();
+        Ok(&self.data[self.position.min(visible)..visible])
+    }
+
+    fn consume(&mut self, amount: usize) {
+        self.position += amount;
+    }
+}
+
+impl Seek for GrowableCursor<'_> {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        let next = match position {
+            SeekFrom::Start(value) => value as i64,
+            SeekFrom::Current(value) => self.position as i64 + value,
+            SeekFrom::End(value) => self.visible() as i64 + value
+        };
+        if next < 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "seek before start"
+            ));
+        }
+        self.position = next as usize;
+        Ok(self.position as u64)
+    }
+}
+
+fn assert_incremental_scanlines_match_decode(name: &str, data: &[u8], step: usize) {
+    let expected = JpegDecoder::new(ZCursor::new(data)).decode().unwrap();
+    let limit = Rc::new(Cell::new(0));
+    let cursor = GrowableCursor::new(data, Rc::clone(&limit));
+    let mut decoder = JpegDecoder::new(cursor);
+    let mut available = 0;
+    let mut scanlines = decoder.scanline_output();
+    loop {
+        available = (available + step).min(data.len());
+        limit.set(available);
+        match scanlines.start().unwrap() {
+            ScanlineStatus::Ready => break,
+            ScanlineStatus::NeedMoreInput => continue,
+            ScanlineStatus::Complete => panic!("{name}: completed while starting"),
+            _ => panic!("{name}: unknown start status")
+        }
+    }
+
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let mut actual = vec![0; row_bytes * height];
+    let mut saw_suspension = false;
+    while scanlines.output_scanline() < height {
+        let row = scanlines.output_scanline();
+        let mut storage = vec![0xCD; row_bytes];
+        match scanlines.read_scanlines(&mut storage, row_bytes).unwrap() {
+            ScanlineReadStatus::RowsProcessed { rows: 1 } => {
+                actual[row * row_bytes..(row + 1) * row_bytes].copy_from_slice(&storage);
+            }
+            ScanlineReadStatus::NeedMoreInput => {
+                saw_suspension = true;
+                assert!(storage.iter().all(|byte| *byte == 0xCD));
+                assert_eq!(scanlines.output_scanline(), row);
+                if matches!(name, "progressive" | "multi_sos") {
+                    assert_eq!(
+                        row, 0,
+                        "{name}: buffered output exposed provisional preview rows"
+                    );
+                }
+                assert!(available < data.len(), "{name}: suspended with full input");
+                available = (available + step).min(data.len());
+                limit.set(available);
+            }
+            status => panic!("{name}: unexpected scanline status {status:?}")
+        }
+    }
+    assert!(
+        saw_suspension,
+        "{name}: test never suspended during row output"
+    );
+    assert_eq!(actual, expected, "{name}: incremental output mismatch");
+
+    loop {
+        match scanlines.finish().unwrap() {
+            ScanlineStatus::Complete => break,
+            ScanlineStatus::NeedMoreInput => {
+                assert!(
+                    available < data.len(),
+                    "{name}: finish suspended with full input"
+                );
+                available = (available + step).min(data.len());
+                limit.set(available);
+            }
+            ScanlineStatus::Ready => panic!("{name}: finish returned Ready"),
+            _ => panic!("{name}: unknown finish status")
+        }
+    }
+}
+
+fn assert_scanlines_match_decode(bytes: &[u8], colorspace: ColorSpace, rows_per_read: usize) {
+    let options = DecoderOptions::default().jpeg_set_out_colorspace(colorspace);
+    let expected = JpegDecoder::new_with_options(ZCursor::new(bytes), options)
+        .decode()
+        .unwrap();
+    let mut decoder = JpegDecoder::new_with_options(ZCursor::new(bytes), options);
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let stride = row_bytes + 5;
+    let mut actual = vec![0; row_bytes * height];
+
+    while scanlines.output_scanline() < height {
+        let row_start = scanlines.output_scanline();
+        let requested_rows = rows_per_read.min(height - row_start);
+        let mut storage = vec![0xCD; stride * requested_rows];
+        let status = scanlines.read_scanlines(&mut storage, stride).unwrap();
+        let ScanlineReadStatus::RowsProcessed { rows } = status else {
+            panic!(
+                "one-shot scanline input returned {status:?} at row {}",
+                scanlines.output_scanline()
+            )
+        };
+        assert!(rows > 0 && rows <= requested_rows);
+        for row in 0..rows {
+            actual[(row_start + row) * row_bytes..(row_start + row + 1) * row_bytes]
+                .copy_from_slice(&storage[row * stride..row * stride + row_bytes]);
+            assert!(storage[row * stride + row_bytes..(row + 1) * stride]
+                .iter()
+                .all(|byte| *byte == 0xCD));
+        }
+    }
+    assert_eq!(actual, expected);
+}
+
+fn decode_all_scanlines<T: ZByteReaderTrait>(decoder: &mut JpegDecoder<T>) -> Vec<u8> {
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let mut output = vec![0; row_bytes * height];
+    while scanlines.output_scanline() < height {
+        let row = scanlines.output_scanline();
+        assert!(matches!(
+            scanlines
+                .read_scanlines(&mut output[row * row_bytes..], row_bytes)
+                .unwrap(),
+            ScanlineReadStatus::RowsProcessed { rows } if rows > 0
+        ));
+    }
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+    output
+}
+
+#[test]
+fn baseline_420_one_row_reads_match_decode_with_custom_stride() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let stride = row_bytes + 7;
+    let mut actual = vec![0; row_bytes * height];
+
+    let mut empty = [];
+    assert_eq!(
+        scanlines.read_scanlines(&mut empty, 0).unwrap(),
+        ScanlineReadStatus::RowsProcessed { rows: 0 }
+    );
+    assert_eq!(scanlines.output_scanline(), 0);
+
+    for row in 0..height {
+        let mut storage = vec![0xCD; stride];
+        assert_eq!(
+            scanlines.read_scanlines(&mut storage, stride).unwrap(),
+            ScanlineReadStatus::RowsProcessed { rows: 1 }
+        );
+        actual[row * row_bytes..(row + 1) * row_bytes].copy_from_slice(&storage[..row_bytes]);
+        assert!(storage[row_bytes..].iter().all(|byte| *byte == 0xCD));
+        assert_eq!(scanlines.output_scanline(), row + 1);
+    }
+
+    assert_eq!(actual, expected);
+    let mut storage = vec![0xCD; stride];
+    assert_eq!(
+        scanlines.read_scanlines(&mut storage, stride).unwrap(),
+        ScanlineReadStatus::Complete
+    );
+    assert!(storage.iter().all(|byte| *byte == 0xCD));
+    assert_eq!(
+        scanlines.read_scanlines(&mut storage, stride).unwrap(),
+        ScanlineReadStatus::Complete
+    );
+}
+
+#[test]
+fn baseline_scanlines_match_supported_output_colorspaces() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    for colorspace in [
+        ColorSpace::RGB,
+        ColorSpace::RGBA,
+        ColorSpace::Luma,
+        ColorSpace::BGR,
+        ColorSpace::BGRA
+    ] {
+        assert_scanlines_match_decode(bytes, colorspace, 7);
+    }
+}
+
+#[test]
+fn batched_baseline_scanlines_match_decode() {
+    assert_scanlines_match_decode(
+        include_bytes!("../../../test-images/jpeg/2029.jpg"),
+        ColorSpace::RGB,
+        64
+    );
+}
+
+#[test]
+fn odd_dimension_scanlines_match_decode() {
+    assert_scanlines_match_decode(
+        include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg"),
+        ColorSpace::RGB,
+        3
+    );
+}
+
+#[test]
+fn oversized_final_read_does_not_write_past_logical_rows() {
+    let bytes = include_bytes!("../../../test-images/jpeg/non_interleaved_422_65x65.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    while scanlines.output_scanline() < height - 1 {
+        assert!(matches!(
+            scanlines.skip_scanlines(height - 1 - scanlines.output_scanline()).unwrap(),
+            ScanlineReadStatus::RowsProcessed { rows } if rows > 0
+        ));
+    }
+
+    let capacity = 80;
+    let mut storage = vec![0xCD; row_bytes * capacity];
+    assert_eq!(
+        scanlines.read_scanlines(&mut storage, row_bytes).unwrap(),
+        ScanlineReadStatus::RowsProcessed { rows: 1 }
+    );
+    assert!(storage[row_bytes..].iter().all(|byte| *byte == 0xCD));
+}
+
+#[test]
+fn progressive_scanlines_match_decode() {
+    assert_scanlines_match_decode(
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+        ColorSpace::RGB,
+        5
+    );
+}
+
+#[test]
+fn multi_sos_scanlines_match_decode() {
+    assert_scanlines_match_decode(
+        include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg"),
+        ColorSpace::RGB,
+        5
+    );
+}
+
+#[test]
+fn skip_scanlines_preserves_following_rows_and_end_behavior() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let skip = 19;
+
+    assert_eq!(
+        scanlines.skip_scanlines(0).unwrap(),
+        ScanlineReadStatus::RowsProcessed { rows: 0 }
+    );
+    let mut skipped = 0;
+    while skipped < skip {
+        let ScanlineReadStatus::RowsProcessed { rows } =
+            scanlines.skip_scanlines(skip - skipped).unwrap()
+        else {
+            panic!("skip did not make progress")
+        };
+        skipped += rows;
+    }
+    let mut row = vec![0; row_bytes];
+    assert_eq!(
+        scanlines.read_scanlines(&mut row, row_bytes).unwrap(),
+        ScanlineReadStatus::RowsProcessed { rows: 1 }
+    );
+    assert_eq!(&row, &expected[skip * row_bytes..(skip + 1) * row_bytes]);
+
+    let mut tail_skipped = 0;
+    while scanlines.output_scanline() < height {
+        let ScanlineReadStatus::RowsProcessed { rows } =
+            scanlines.skip_scanlines(usize::MAX).unwrap()
+        else {
+            panic!("tail skip did not make progress")
+        };
+        tail_skipped += rows;
+    }
+    assert_eq!(tail_skipped, height - skip - 1);
+    assert_eq!(
+        scanlines.skip_scanlines(1).unwrap(),
+        ScanlineReadStatus::Complete
+    );
+    assert_eq!(scanlines.output_scanline(), height);
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+}
+
+#[test]
+fn finish_discards_unread_rows_and_completes() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+    assert_eq!(
+        scanlines.output_scanline(),
+        scanlines.output_height().unwrap()
+    );
+}
+
+#[test]
+fn read_past_end_preserves_unfinished_sequence_until_finish() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let height = scanlines.output_height().unwrap();
+    let mut row = vec![0; row_bytes];
+    while scanlines.output_scanline() < height {
+        assert_eq!(
+            scanlines.read_scanlines(&mut row, row_bytes).unwrap(),
+            ScanlineReadStatus::RowsProcessed { rows: 1 }
+        );
+    }
+    assert_eq!(
+        scanlines.read_scanlines(&mut row, row_bytes).unwrap(),
+        ScanlineReadStatus::Complete
+    );
+    drop(scanlines);
+
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    assert_eq!(scanlines.output_scanline(), height);
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+}
+
+#[test]
+fn short_scanline_buffers_are_rejected_without_progress() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+
+    let mut row = vec![0xCD; row_bytes];
+    assert!(matches!(
+        scanlines.read_scanlines(&mut row, row_bytes - 1),
+        Err(DecodeErrors::Format(_))
+    ));
+    let mut short = vec![0xCD; row_bytes - 1];
+    assert!(matches!(
+        scanlines.read_scanlines(&mut short, row_bytes),
+        Err(DecodeErrors::TooSmallOutput(_, _))
+    ));
+    assert_eq!(scanlines.output_scanline(), 0);
+    assert!(row.iter().chain(short.iter()).all(|byte| *byte == 0xCD));
+}
+
+#[test]
+fn cancellation_does_not_publish_scanlines_and_can_retry() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+    let cancelled = Arc::new(AtomicBool::new(true));
+    let check = Arc::clone(&cancelled);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.set_cancel(move || check.load(Ordering::SeqCst));
+    decoder.set_cancel_interval(1);
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let mut row = vec![0xCD; row_bytes];
+
+    assert!(matches!(
+        scanlines.read_scanlines(&mut row, row_bytes),
+        Err(DecodeErrors::Cancelled)
+    ));
+    assert!(row.iter().all(|byte| *byte == 0xCD));
+    assert_eq!(scanlines.output_scanline(), 0);
+
+    cancelled.store(false, Ordering::SeqCst);
+    assert_eq!(
+        scanlines.read_scanlines(&mut row, row_bytes).unwrap(),
+        ScanlineReadStatus::RowsProcessed { rows: 1 }
+    );
+    assert_eq!(&row, &expected[..row_bytes]);
+}
+
+#[test]
+fn cancellation_after_a_committed_batch_is_reported_on_the_next_read() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+    let polls = Arc::new(AtomicUsize::new(0));
+    let cancel_at = Arc::new(AtomicUsize::new(2));
+    let check_polls = Arc::clone(&polls);
+    let check_cancel_at = Arc::clone(&cancel_at);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.set_cancel(move || {
+        check_polls.fetch_add(1, Ordering::SeqCst) >= check_cancel_at.load(Ordering::SeqCst)
+    });
+    decoder.set_cancel_interval(1);
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let mut output = vec![0xCD; row_bytes * 100];
+
+    let ScanlineReadStatus::RowsProcessed { rows: first_rows } =
+        scanlines.read_scanlines(&mut output, row_bytes).unwrap()
+    else {
+        panic!("first scanline batch did not complete")
+    };
+    assert!(first_rows > 0);
+    assert_eq!(scanlines.output_scanline(), first_rows);
+    assert_eq!(
+        &output[..first_rows * row_bytes],
+        &expected[..first_rows * row_bytes]
+    );
+
+    output.fill(0xCD);
+    assert!(matches!(
+        scanlines.read_scanlines(&mut output, row_bytes),
+        Err(DecodeErrors::Cancelled)
+    ));
+    assert!(output.iter().all(|byte| *byte == 0xCD));
+    assert_eq!(scanlines.output_scanline(), first_rows);
+
+    cancel_at.store(usize::MAX, Ordering::SeqCst);
+    let ScanlineReadStatus::RowsProcessed { rows } =
+        scanlines.read_scanlines(&mut output, row_bytes).unwrap()
+    else {
+        panic!("scanline retry did not complete")
+    };
+    assert_eq!(
+        &output[..rows * row_bytes],
+        &expected[first_rows * row_bytes..(first_rows + rows) * row_bytes]
+    );
+}
+
+#[test]
+fn buffered_cancellation_between_scanline_batches_is_atomic() {
+    let bytes = include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let check = Arc::clone(&cancelled);
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    decoder.set_cancel(move || check.load(Ordering::SeqCst));
+    decoder.set_cancel_interval(1);
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    let row_bytes = scanlines.output_row_bytes().unwrap();
+    let mut first = vec![0; row_bytes * 32];
+    let ScanlineReadStatus::RowsProcessed { rows: first_rows } =
+        scanlines.read_scanlines(&mut first, row_bytes).unwrap()
+    else {
+        panic!("first buffered batch did not produce rows")
+    };
+    assert!(first_rows > 0);
+
+    cancelled.store(true, Ordering::SeqCst);
+    let mut cancelled_rows = vec![0xCD; row_bytes * 32];
+    assert!(matches!(
+        scanlines.read_scanlines(&mut cancelled_rows, row_bytes),
+        Err(DecodeErrors::Cancelled)
+    ));
+    assert!(cancelled_rows.iter().all(|byte| *byte == 0xCD));
+    assert_eq!(scanlines.output_scanline(), first_rows);
+
+    cancelled.store(false, Ordering::SeqCst);
+    let ScanlineReadStatus::RowsProcessed { rows } = scanlines
+        .read_scanlines(&mut cancelled_rows, row_bytes)
+        .unwrap()
+    else {
+        panic!("buffered cancellation retry did not produce rows")
+    };
+    assert_eq!(
+        &cancelled_rows[..rows * row_bytes],
+        &expected[first_rows * row_bytes..(first_rows + rows) * row_bytes]
+    );
+}
+
+#[derive(Clone, Copy)]
+enum OptionChangePrelude {
+    Headers,
+    PixelCheckpoint,
+    Scanline
+}
+
+#[test]
+fn changing_output_options_rebuilds_derived_state_for_replay() {
+    let baseline = include_bytes!("../../../test-images/jpeg/2029.jpg").as_slice();
+    let progressive =
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg").as_slice();
+    for (name, bytes, initial, output, prelude) in [
+        (
+            "pixel checkpoint",
+            baseline,
+            ColorSpace::Luma,
+            ColorSpace::RGB,
+            OptionChangePrelude::PixelCheckpoint
+        ),
+        (
+            "baseline coeff",
+            baseline,
+            ColorSpace::Luma,
+            ColorSpace::RGB,
+            OptionChangePrelude::Scanline
+        ),
+        (
+            "progressive coeff",
+            progressive,
+            ColorSpace::Luma,
+            ColorSpace::RGB,
+            OptionChangePrelude::Scanline
+        ),
+        (
+            "RGB converter",
+            baseline,
+            ColorSpace::BGRA,
+            ColorSpace::RGB,
+            OptionChangePrelude::Headers
+        ),
+        (
+            "BGR converter",
+            baseline,
+            ColorSpace::RGB,
+            ColorSpace::BGR,
+            OptionChangePrelude::Headers
+        ),
+        (
+            "RGBA converter",
+            baseline,
+            ColorSpace::RGB,
+            ColorSpace::RGBA,
+            OptionChangePrelude::Headers
+        ),
+        (
+            "BGRA converter",
+            baseline,
+            ColorSpace::RGB,
+            ColorSpace::BGRA,
+            OptionChangePrelude::Headers
+        )
+    ] {
+        let initial_options = DecoderOptions::default().jpeg_set_out_colorspace(initial);
+        let output_options = DecoderOptions::default().jpeg_set_out_colorspace(output);
+        let expected = JpegDecoder::new_with_options(ZCursor::new(bytes), output_options)
+            .decode()
+            .unwrap();
+
+        let initial_limit = match prelude {
+            OptionChangePrelude::PixelCheckpoint => bytes.len() * 60 / 100,
+            OptionChangePrelude::Headers | OptionChangePrelude::Scanline => bytes.len()
+        };
+        let limit = Rc::new(Cell::new(initial_limit));
+        let cursor = GrowableCursor::new(bytes, Rc::clone(&limit));
+        let mut decoder = JpegDecoder::new_with_options(cursor, initial_options);
+        match prelude {
+            OptionChangePrelude::Headers => decoder.decode_headers().unwrap(),
+            OptionChangePrelude::Scanline => {
+                let mut scanlines = decoder.scanline_output();
+                assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+                let row_bytes = scanlines.output_row_bytes().unwrap();
+                let mut row = vec![0; row_bytes];
+                assert_eq!(
+                    scanlines.read_scanlines(&mut row, row_bytes).unwrap(),
+                    ScanlineReadStatus::RowsProcessed { rows: 1 }
+                );
+            }
+            OptionChangePrelude::PixelCheckpoint => {
+                decoder.decode_headers().unwrap();
+                let mut old_output = vec![0; decoder.output_buffer_size().unwrap()];
+                for _ in 0..2 {
+                    let error = decoder.decode_into(&mut old_output).unwrap_err();
+                    assert!(error.is_recoverable_eof());
+                }
+                assert!(decoder.decoded_scanlines().unwrap_or(0) > 0);
+                limit.set(bytes.len());
+            }
+        }
+        let committed_scans = decoder.decoded_scans();
+        decoder.set_options(output_options);
+        assert_eq!(decoder.decoded_output_bytes(), Some(0), "{name}");
+        assert_eq!(decoder.decoded_scanlines(), Some(0), "{name}");
+        if let Some(committed_scans) = committed_scans {
+            assert!(committed_scans > 0, "{name}");
+            assert_eq!(decoder.decoded_scans(), Some(committed_scans), "{name}");
+            assert_eq!(decoder.decoded_preview_output_bytes(), Some(0), "{name}");
+            assert_eq!(decoder.decoded_preview_scanlines(), Some(0), "{name}");
+        }
+
+        let actual = decode_all_scanlines(&mut decoder);
+        assert_eq!(actual, expected, "{name}: {initial:?} -> {output:?}");
+    }
+}
+
+#[test]
+fn completed_scanline_sequence_can_replay() {
+    let bytes = include_bytes!("../../../test-images/jpeg/2029.jpg");
+    let expected = JpegDecoder::new(ZCursor::new(bytes)).decode().unwrap();
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let mut scanlines = decoder.scanline_output();
+    assert_eq!(scanlines.start().unwrap(), ScanlineStatus::Ready);
+    assert_eq!(scanlines.finish().unwrap(), ScanlineStatus::Complete);
+    drop(scanlines);
+
+    let mut replay = decoder.scanline_output();
+    assert_eq!(replay.start().unwrap(), ScanlineStatus::Ready);
+    assert_eq!(replay.output_scanline(), 0);
+    let row_bytes = replay.output_row_bytes().unwrap();
+    let mut row = vec![0; row_bytes];
+    assert_eq!(
+        replay.read_scanlines(&mut row, row_bytes).unwrap(),
+        ScanlineReadStatus::RowsProcessed { rows: 1 }
+    );
+    assert_eq!(&row, &expected[..row_bytes]);
+}
+
+#[test]
+fn incremental_scanline_parity() {
+    assert_incremental_scanlines_match_decode(
+        "baseline",
+        include_bytes!("../../../test-images/jpeg/synthetic_image.jpg"),
+        37
+    );
+    assert_incremental_scanlines_match_decode(
+        "restart",
+        include_bytes!("../../../test-images/jpeg/four_components.jpg"),
+        97
+    );
+    assert_incremental_scanlines_match_decode(
+        "progressive",
+        include_bytes!("../../../test-images/jpeg/down_sampled_grayscale_prog.jpg"),
+        31
+    );
+    assert_incremental_scanlines_match_decode(
+        "multi_sos",
+        include_bytes!("../../../test-images/jpeg/non_interleaved_420_64x64.jpg"),
+        31
+    );
+}
+
+#[test]
+#[cfg(feature = "arith")]
+fn arithmetic_incremental_scanline_parity() {
+    assert_incremental_scanlines_match_decode(
+        "arithmetic_restart",
+        include_bytes!("../../../test-images/jpeg/arith/seq-restart.jpg"),
+        23
+    );
+    assert_incremental_scanlines_match_decode(
+        "arithmetic_progressive",
+        include_bytes!("../../../test-images/jpeg/arith/prog.jpg"),
+        23
+    );
+}
+
+#[test]
+fn dnl_scanlines_are_rejected_before_false_completion() {
+    let bytes = include_bytes!("images/dnl_image.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(bytes));
+    let mut scanlines = decoder.scanline_output();
+    assert!(matches!(
+        scanlines.start(),
+        Err(DecodeErrors::FormatStatic(
+            "converted scanline output does not support DNL images"
+        ))
+    ));
+    assert_eq!(scanlines.output_scanline(), 0);
+}


### PR DESCRIPTION
## Summary

This is the third PR in the JPEG raw and scanline output API work.

It is stacked on #440 , which is stacked on #386.

It adds pull-based converted scanline output through `ScanlineDecodeSession`. Rows are entropy-decoded, IDCT-processed, upsampled, and color-converted into caller-provided storage. The implementation does not decode a complete packed
image and expose rows by slicing that image.

The API supports sequential reads, skips, caller row strides, recoverable input suspension, replay, and recreated borrowing sessions. Progressive and multi-SOS images expose only stable final rows.

Normal `decode()`, `decode_into()`, and raw component output behavior remains unchanged.

## Public API

```rust
let mut scanlines = decoder.scanline_output();

match scanlines.start()? {
    ScanlineStatus::Ready => {}
    ScanlineStatus::NeedMoreInput | ScanlineStatus::Complete => return Ok(()),
}

match scanlines.read_scanlines(&mut output, row_stride)? {
    ScanlineReadStatus::RowsProcessed { rows } => consume(rows),
    ScanlineReadStatus::NeedMoreInput => provide_more_input(),
    ScanlineReadStatus::Complete => {}
}
```

The session also provides `skip_scanlines`, `output_scanline`, and `finish`.

Scaled-IDCT, horizontal crop, and DNL scanline output are outside this PR’s scope.

Part of #379