### PR TITLE
zune-jpeg: Add YCCK to CMYK color conversion

### DIFF
--- a/crates/zune-jpeg/src/worker.rs
+++ b/crates/zune-jpeg/src/worker.rs
@@ -81,6 +81,15 @@ pub(crate) fn color_convert(
                 output
             );
         }
+        (ColorSpace::YCCK, ColorSpace::CMYK) => {
+            color_convert_ycck_to_cmyk(
+                unprocessed,
+                width,
+                padded_width,
+                color_convert_16,
+                output
+            );
+        }
         (ColorSpace::CMYK, ColorSpace::RGB) => {
             color_convert_cymk_to_rgb::<3>(unprocessed, width, padded_width, output);
         }
@@ -250,6 +259,45 @@ fn color_convert_ycck_to_rgb<const NUM_COMPONENTS: usize>(
             pix[0] = blinn_8x8(255 - pix[0], m);
             pix[1] = blinn_8x8(255 - pix[1], m);
             pix[2] = blinn_8x8(255 - pix[2], m);
+        }
+    }
+}
+
+/// Convert a YCCK image to CMYK.
+///
+/// Adobe writes YCCK by inverting CMY and running it through the YCbCr transform, leaving K
+/// alone. Undoing that gives back CMYK: convert YCbCr to RGB, invert those three, and copy K.
+///
+/// Unlike the YCCK to RGB path this does not multiply by K. That step composites the image onto
+/// white, which a caller asking for CMYK wants to do itself.
+///
+/// The YCbCr conversion runs into a three component scratch buffer because `color_convert_16`
+/// only ever writes RGB-sized pixels; asking it for a four component stride would interleave
+/// the channels wrongly.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn color_convert_ycck_to_cmyk(
+    mcu_block: &[&[i16]; MAX_COMPONENTS], width: usize, padded_width: usize,
+    color_convert_16: ColorConvert16Ptr, output: &mut [u8]
+) {
+    let mut rgb = vec![0_u8; width * 3 * (output.len() / (width * 4))];
+    color_convert_ycbcr(
+        mcu_block,
+        width,
+        padded_width,
+        ColorSpace::RGB,
+        color_convert_16,
+        &mut rgb
+    );
+    for ((pix_w, rgb_w), k_w) in output
+        .chunks_exact_mut(width * 4)
+        .zip(rgb.chunks_exact(width * 3))
+        .zip(mcu_block[3].chunks_exact(padded_width))
+    {
+        for ((pix, src), k) in pix_w.chunks_exact_mut(4).zip(rgb_w.chunks_exact(3)).zip(k_w) {
+            pix[0] = 255 - src[0];
+            pix[1] = 255 - src[1];
+            pix[2] = 255 - src[2];
+            pix[3] = (*k) as u8;
         }
     }
 }

--- a/crates/zune-jpeg/tests/app14.rs
+++ b/crates/zune-jpeg/tests/app14.rs
@@ -216,6 +216,29 @@ fn four_component_transform_zero_remains_cmyk() {
 }
 
 #[test]
+fn ycck_decodes_to_cmyk_without_inverting() {
+    // Adobe stores YCCK with CMY inverted, so decoding to CMYK has to undo that. libjpeg reads
+    // this fixture as CMYK [240, 58, 21, 216]; before YCCK to CMYK existed the only way out was
+    // RGB, which returns the inverted tone.
+    let data = include_bytes!("../../../test-images/jpeg/four_components.jpg");
+    let mut decoder = JpegDecoder::new(ZCursor::new(data));
+    decoder.decode_headers().unwrap();
+    assert_eq!(decoder.input_colorspace(), Some(ColorSpace::YCCK));
+
+    let options = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::CMYK);
+    let mut decoder = JpegDecoder::new_with_options(ZCursor::new(data), options);
+    let output = decoder.decode().expect("YCCK to CMYK decode failed");
+
+    let pixels = output.len() / 4;
+    assert_eq!(pixels, 1318 * 611);
+    let mean = |channel: usize| {
+        output.chunks_exact(4).map(|p| u64::from(p[channel])).sum::<u64>() / pixels as u64
+    };
+    // A light image: little magenta or yellow, heavy cyan and black.
+    assert_eq!([mean(0), mean(1), mean(2), mean(3)], [240, 58, 21, 216]);
+}
+
+#[test]
 fn transform_one_is_ycbcr_and_transform_two_is_ycck() {
     let transform_one = with_adobe_transform(
         include_bytes!("../../../test-images/jpeg/app14/baseline_ycbcr.jpg"),


### PR DESCRIPTION
Fixes the YCCK side of #442.

Decoding a YCCK image to CMYK failed with `Unimplemented colorspace mapping from YCCK to CMYK`, leaving RGB as the only output. That path returns inverted colors for Adobe YCCK, so there was no way to get correct pixels out of these files.

Adobe writes YCCK by inverting CMY and running it through the YCbCr transform, leaving K alone. Undoing that gives back CMYK: convert YCbCr to RGB, invert those three, and copy K. Unlike the YCCK to RGB path this does not multiply by K, because that composites onto white, which a caller asking for CMYK wants to do itself.

The YCbCr conversion runs into a three component scratch buffer because `color_convert_16` only ever writes RGB-sized pixels; asking it for a four component stride interleaves the channels wrongly.

Checked against libjpeg: `test-images/jpeg/four_components.jpg` decodes to CMYK `[240, 58, 21, 216]` with both. The new test in `tests/app14.rs` asserts this.

This does not change the existing `(YCCK, RGB)` output, which is still inverted — that part of #442 needs a separate decision about whether changing it would break current callers.
